### PR TITLE
fix: Make prod as default environment name in sign workflow

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.ssl_com_password }}
           credential_id: ${{ secrets.ssl_com_credential_id }}
           totp_secret: ${{ secrets.ssl_com_totp_secret }}
-          environment_name: ${{ secrets.ssl_com_environment_name }}
+          environment_name: ${{ secrets.ssl_com_environment_name != 'TEST' && 'PROD' || 'TEST' }}
           dir_path: ./dist
           output_path: ./signed
 


### PR DESCRIPTION
## Overview
Fixed the sign workflow to use `PROD` environment name if the secret `ssl_com_environment_name` is not specified or not `TEST`.

## Result
Successful run is from here https://github.com/RewstApp/agent-smith-go/actions/runs/14245802033.