### PR TITLE
fix: Forbidden error on release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
   release:
     needs: sign
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Details
This PR aims to fix the permission error on release step. See [run](https://github.com/RewstApp/agent-smith-go/actions/runs/15269870893) for more details.