### PR TITLE
fix: [sc-86627] Orphaned Temp File on Updater Failure

### DIFF
--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -226,7 +226,11 @@ func (u *defaultUpdater) Download(asset Asset) (string, error) {
 		_ = file.Close()
 		if !success {
 			if removeErr := os.Remove(file.Name()); removeErr != nil {
-				u.logger.Error("Failed to remove temp installer file", "path", file.Name(), "error", removeErr)
+				u.logger.Error(
+					"Failed to remove temp installer file",
+					"path", file.Name(),
+					"error", removeErr,
+				)
 			}
 		}
 	}()

--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -99,6 +99,7 @@ type defaultUpdater struct {
 	runCommand       RunCommandFunc
 	checkClient      *http.Client
 	downloadClient   *http.Client
+	chmod            func(name string, mode os.FileMode) error
 }
 
 func NewUpdater(
@@ -116,6 +117,7 @@ func NewUpdater(
 		runCommand:       runCommand,
 		checkClient:      &http.Client{Timeout: checkTimeout},
 		downloadClient:   &http.Client{Timeout: downloadTimeout},
+		chmod:            os.Chmod,
 	}
 }
 
@@ -218,18 +220,26 @@ func (u *defaultUpdater) Download(asset Asset) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	success := false
 	defer func() {
 		_ = file.Close()
+		if !success {
+			if removeErr := os.Remove(file.Name()); removeErr != nil {
+				u.logger.Error("Failed to remove temp installer file", "path", file.Name(), "error", removeErr)
+			}
+		}
 	}()
 
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {
 		return "", err
 	}
-	if err = os.Chmod(file.Name(), 0o755); err != nil {
+	if err = u.chmod(file.Name(), 0o755); err != nil {
 		return "", fmt.Errorf("failed to set executable permission on installer: %w", err)
 	}
 
+	success = true
 	return file.Name(), nil
 }
 

--- a/internal/agent/updater_test.go
+++ b/internal/agent/updater_test.go
@@ -260,6 +260,43 @@ func TestDownload_HttpError(t *testing.T) {
 	}
 }
 
+func TestDownload_ChmodFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fake binary content"))
+	}))
+	defer server.Close()
+
+	logger := hclog.NewNullLogger()
+	device := newTestDevice()
+	u := NewUpdater(logger, device, "", "", nil).(*defaultUpdater)
+
+	var capturedTempPath string
+	u.chmod = func(name string, mode os.FileMode) error {
+		capturedTempPath = name
+		return fmt.Errorf("chmod not supported on this filesystem")
+	}
+
+	path, err := u.Download(Asset{Url: server.URL})
+
+	if err == nil {
+		t.Fatal("expected error from chmod failure, got nil")
+	}
+
+	if path != "" {
+		t.Errorf("expected empty path on error, got %s", path)
+	}
+
+	if capturedTempPath == "" {
+		t.Fatal("chmod mock was never called; test setup is broken")
+	}
+
+	// The temp file must not exist after the error — core assertion of the bug fix
+	if _, statErr := os.Stat(capturedTempPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected temp file %s to be removed after chmod failure, but it still exists", capturedTempPath)
+		_ = os.Remove(capturedTempPath)
+	}
+}
+
 func TestDownload_NonOkStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/agent/updater_test.go
+++ b/internal/agent/updater_test.go
@@ -292,7 +292,10 @@ func TestDownload_ChmodFailure(t *testing.T) {
 
 	// The temp file must not exist after the error — core assertion of the bug fix
 	if _, statErr := os.Stat(capturedTempPath); !os.IsNotExist(statErr) {
-		t.Errorf("expected temp file %s to be removed after chmod failure, but it still exists", capturedTempPath)
+		t.Errorf(
+			"expected temp file %s to be removed after chmod failure, but it still exists",
+			capturedTempPath,
+		)
 		_ = os.Remove(capturedTempPath)
 	}
 }


### PR DESCRIPTION
## Summary
Story details: https://app.shortcut.com/rewst/story/86627

**Root cause:** `internal/agent/updater.go` `Download` created a temp file via `os.CreateTemp` but had no cleanup on error paths. If `io.Copy` or `os.Chmod` failed after the file was created, the function returned an error and left the temp file on disk. On systems where chmod is unsupported (e.g. `noexec` mount on `/tmp`), every auto-update retry leaked a binary, silently accumulating files until disk exhaustion.

**Fix:** Added a `success` flag and expanded the deferred cleanup in `Download` to call `os.Remove` on the temp file whenever the function exits without setting `success = true`. Cleanup errors are logged via the updater's logger without masking the original error. A `chmod` function field was added to `defaultUpdater` (defaulting to `os.Chmod`) to allow error injection in tests without changing the `Updater` interface.

**Test:** Added `TestDownload_ChmodFailure` which injects a failing chmod stub, captures the temp file path from the stub, and asserts the file no longer exists on disk after `Download` returns the error.

## Changes
| File | Change |
|------|--------|
| `internal/agent/updater.go` | Added `chmod` field to `defaultUpdater`; replaced bare `file.Close()` defer with one that also removes the temp file on failure via `success` flag |
| `internal/agent/updater_test.go` | Added `TestDownload_ChmodFailure` covering the orphaned-file scenario; added `path/filepath`-free targeted assertion via captured temp path |

## Test plan
- [ ] `go test ./internal/agent/... -run TestDownload_ChmodFailure` passes
- [ ] `go test ./internal/agent/... -run TestDownload` passes
- [ ] `go test ./...` passes
