### PR TITLE
fix: [sc-86628] Duplicate Signal/Context Setup Across Darwin and Linux Service Files

### DIFF
--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -3,14 +3,11 @@
 package service
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
@@ -164,40 +161,4 @@ func NewServiceManager() ServiceManager {
 	return &defaultServiceManager{
 		system: &defaultLaunchCtl{},
 	}
-}
-
-func Run(runner Runner) (int, error) {
-	// Create a channel to listen for termination signals
-	signalReceived := make(chan os.Signal, 1)
-	signal.Notify(signalReceived, os.Interrupt, syscall.SIGTERM)
-
-	// Make go routines for the channels
-	stop := make(chan struct{})
-	ctxStop, cancelStop := context.WithCancel(context.Background())
-	defer cancelStop()
-
-	go func() {
-		select {
-		case <-signalReceived:
-			stop <- struct{}{}
-		case <-ctxStop.Done():
-		}
-	}()
-
-	// This channel is unused in darwin
-	running := make(chan struct{})
-	ctxRunning, cancelRunning := context.WithCancel(context.Background())
-	defer cancelRunning()
-
-	go func() {
-		select {
-		case <-running:
-		case <-ctxRunning.Done():
-		}
-	}()
-
-	// Execute the runner
-	exitCode := runner.Execute(stop, running)
-
-	return int(exitCode), nil
 }

--- a/internal/service/service_darwin_test.go
+++ b/internal/service/service_darwin_test.go
@@ -356,35 +356,3 @@ func TestDefaultServiceManager_Open_Error(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
-
-// Run tests
-
-type immediateRunner struct {
-	exitCode ServiceExitCode
-}
-
-func (r *immediateRunner) Name() string { return "test" }
-func (r *immediateRunner) Execute(stop <-chan struct{}, running chan<- struct{}) ServiceExitCode {
-	running <- struct{}{}
-	return r.exitCode
-}
-
-func TestRun_ReturnsZeroExitCode(t *testing.T) {
-	code, err := Run(&immediateRunner{exitCode: 0})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if code != 0 {
-		t.Errorf("expected exit code 0, got %d", code)
-	}
-}
-
-func TestRun_ReturnsNonZeroExitCode(t *testing.T) {
-	code, err := Run(&immediateRunner{exitCode: GenericError})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if code != int(GenericError) {
-		t.Errorf("expected exit code %d, got %d", GenericError, code)
-	}
-}

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -3,14 +3,11 @@
 package service
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
@@ -128,38 +125,3 @@ func NewServiceManager() ServiceManager {
 	}
 }
 
-func Run(runner Runner) (int, error) {
-	// Create a channel to listen for termination signals
-	signalReceived := make(chan os.Signal, 1)
-	signal.Notify(signalReceived, os.Interrupt, syscall.SIGTERM)
-
-	// Make go routines for the channels
-	stop := make(chan struct{})
-	ctxStop, cancelStop := context.WithCancel(context.Background())
-	defer cancelStop()
-
-	go func() {
-		select {
-		case <-signalReceived:
-			stop <- struct{}{}
-		case <-ctxStop.Done():
-		}
-	}()
-
-	// This channel is unused in linux
-	running := make(chan struct{})
-	ctxRunning, cancelRunning := context.WithCancel(context.Background())
-	defer cancelRunning()
-
-	go func() {
-		select {
-		case <-running:
-		case <-ctxRunning.Done():
-		}
-	}()
-
-	// Execute the runner
-	exitCode := runner.Execute(stop, running)
-
-	return int(exitCode), nil
-}

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -124,4 +124,3 @@ func NewServiceManager() ServiceManager {
 		system: &defaultSystemCtl{},
 	}
 }
-

--- a/internal/service/service_linux_test.go
+++ b/internal/service/service_linux_test.go
@@ -299,4 +299,3 @@ func TestDefaultServiceManager_Open_Error(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
-

--- a/internal/service/service_linux_test.go
+++ b/internal/service/service_linux_test.go
@@ -300,34 +300,3 @@ func TestDefaultServiceManager_Open_Error(t *testing.T) {
 	}
 }
 
-// Run tests
-
-type immediateRunner struct {
-	exitCode ServiceExitCode
-}
-
-func (r *immediateRunner) Name() string { return "test" }
-func (r *immediateRunner) Execute(stop <-chan struct{}, running chan<- struct{}) ServiceExitCode {
-	running <- struct{}{}
-	return r.exitCode
-}
-
-func TestRun_ReturnsZeroExitCode(t *testing.T) {
-	code, err := Run(&immediateRunner{exitCode: 0})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if code != 0 {
-		t.Errorf("expected exit code 0, got %d", code)
-	}
-}
-
-func TestRun_ReturnsNonZeroExitCode(t *testing.T) {
-	code, err := Run(&immediateRunner{exitCode: GenericError})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if code != int(GenericError) {
-		t.Errorf("expected exit code %d, got %d", GenericError, code)
-	}
-}

--- a/internal/service/service_unix.go
+++ b/internal/service/service_unix.go
@@ -1,0 +1,45 @@
+//go:build linux || darwin
+
+package service
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func Run(runner Runner) (int, error) {
+	// Create a channel to listen for termination signals
+	signalReceived := make(chan os.Signal, 1)
+	signal.Notify(signalReceived, os.Interrupt, syscall.SIGTERM)
+
+	// Make go routines for the channels
+	stop := make(chan struct{})
+	ctxStop, cancelStop := context.WithCancel(context.Background())
+	defer cancelStop()
+
+	go func() {
+		select {
+		case <-signalReceived:
+			stop <- struct{}{}
+		case <-ctxStop.Done():
+		}
+	}()
+
+	running := make(chan struct{})
+	ctxRunning, cancelRunning := context.WithCancel(context.Background())
+	defer cancelRunning()
+
+	go func() {
+		select {
+		case <-running:
+		case <-ctxRunning.Done():
+		}
+	}()
+
+	// Execute the runner
+	exitCode := runner.Execute(stop, running)
+
+	return int(exitCode), nil
+}

--- a/internal/service/service_unix_test.go
+++ b/internal/service/service_unix_test.go
@@ -1,0 +1,37 @@
+//go:build linux || darwin
+
+package service
+
+import (
+	"testing"
+)
+
+type immediateRunner struct {
+	exitCode ServiceExitCode
+}
+
+func (r *immediateRunner) Name() string { return "test" }
+func (r *immediateRunner) Execute(stop <-chan struct{}, running chan<- struct{}) ServiceExitCode {
+	running <- struct{}{}
+	return r.exitCode
+}
+
+func TestRun_ReturnsZeroExitCode(t *testing.T) {
+	code, err := Run(&immediateRunner{exitCode: 0})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestRun_ReturnsNonZeroExitCode(t *testing.T) {
+	code, err := Run(&immediateRunner{exitCode: GenericError})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if code != int(GenericError) {
+		t.Errorf("expected exit code %d, got %d", GenericError, code)
+	}
+}


### PR DESCRIPTION
## Summary
Story details: https://app.shortcut.com/rewst/story/86628

**Root cause:** `Run` was copy-pasted identically into `service_darwin.go` and `service_linux.go`, differing only in a comment (`// This channel is unused in darwin` vs `linux`). Any bug fix or improvement to signal handling required two coordinated edits, and a single-platform edit would silently introduce platform divergence.

**Fix:** Extracted the shared `Run` implementation into a new `service_unix.go` with `//go:build linux || darwin`. The per-platform files retain only their platform-specific service manager code. The Windows `Run` in `service_windows.go` is unchanged.

**Test:** Moved `immediateRunner`, `TestRun_ReturnsZeroExitCode`, and `TestRun_ReturnsNonZeroExitCode` into a new `service_unix_test.go` with the matching build tag. Both per-platform test files had the duplicated `Run` tests removed.

## Changes
| File | Change |
|------|--------|
| `internal/service/service_unix.go` | New file (`//go:build linux \|\| darwin`) with the single shared `Run` implementation |
| `internal/service/service_unix_test.go` | New file with matching build tag; contains `immediateRunner` and both `TestRun_*` tests |
| `internal/service/service_darwin.go` | Removed `Run` function and now-unused imports (`context`, `os/signal`, `syscall`) |
| `internal/service/service_linux.go` | Same removals as darwin |
| `internal/service/service_darwin_test.go` | Removed `immediateRunner` and duplicated `TestRun_*` tests |
| `internal/service/service_linux_test.go` | Same removals as darwin test file |

## Test plan
- [ ] `go test ./internal/service/...` passes on macOS
- [ ] `go test ./internal/service/...` passes on Linux
- [ ] `golangci-lint run ./internal/service/...` reports 0 issues
- [ ] `go test ./...` passes
