### PR TITLE
fix: [sc-86631] New `http.Client` Created Per Postback — Connection Pool Bypass

### DIFF
--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	workerCount      = 10
-	messageQueueSize = 100
+	workerCount          = 10
+	messageQueueSize     = 100
+	postbackHTTPTimeout  = 30 * time.Second
 )
 
 type errorResponse struct {
@@ -349,11 +350,7 @@ func (svc *serviceContext) processMessage(
 	}
 
 	logger.Info("Sending postback", "post_id", message.PostId, "url", postbackReq.URL)
-	httpClient := svc.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{}
-	}
-	res, err := httpClient.Do(postbackReq)
+	res, err := svc.HTTPClient.Do(postbackReq)
 	if err != nil {
 		logger.Error("Failed to send postback", "error", err)
 		return

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	workerCount          = 10
-	messageQueueSize     = 100
-	postbackHTTPTimeout  = 30 * time.Second
+	workerCount         = 10
+	messageQueueSize    = 100
+	postbackHTTPTimeout = 30 * time.Second
 )
 
 type errorResponse struct {

--- a/cmd/agent_smith/service_context.go
+++ b/cmd/agent_smith/service_context.go
@@ -19,7 +19,7 @@ type serviceContext struct {
 	Domain agent.DomainInfoProvider
 
 	Executor   interpreter.Executor
-	HTTPClient *http.Client // if nil, processMessage uses a default client
+	HTTPClient *http.Client
 }
 
 func newServiceContext(
@@ -56,6 +56,7 @@ func newServiceContext(
 	params.Sys = sys
 	params.Domain = domain
 	params.Executor = executor
+	params.HTTPClient = &http.Client{Timeout: postbackHTTPTimeout}
 
 	return &params, nil
 }


### PR DESCRIPTION
## Summary

Story details: https://app.shortcut.com/rewst/story/86631

- **[sc-86631]** A fresh `&http.Client{}` was created on every MQTT command postback, meaning every result sent to the Rewst engine required a new TCP+TLS connection. Under load this wasted file descriptors and could exhaust ephemeral ports.
- `newServiceContext` now initialises a single `*http.Client` (with a 30-second timeout) that is reused for all postbacks. Go's default `http.DefaultTransport` connection pool ensures TCP connections to the engine host are kept alive and reused across commands.
- The per-call nil-fallback `&http.Client{}` at `service.go:354` is removed; `processMessage` now calls `svc.HTTPClient.Do()` directly.

## Changed files

| File | Change |
|---|---|
| `cmd/agent_smith/service.go` | Added `postbackHTTPTimeout = 30 * time.Second` constant; removed per-call client creation |
| `cmd/agent_smith/service_context.go` | Initialise `HTTPClient` once in `newServiceContext` |

## Test plan

- [ ] `go test ./cmd/agent_smith/...` passes (all existing postback tests cover the shared-client path)
- [ ] Deploy agent, send 10 rapid commands, verify with `ss -tn` or `netstat` that the connection count to the engine host stays at 1–2 rather than growing to 10
- [ ] Verify all postbacks succeed and return correct results
