### PR TITLE
fix: [sc-87906] Temp File Leaked on Failed Command Execution

### DIFF
--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -124,6 +124,14 @@ func (e *baseExecutor) Execute(
 		return errorResultBytes(err)
 	}
 
+	// Remove temp file on both success and failure paths
+	defer func() {
+		err = os.Remove(tempfile.Name())
+		if err != nil {
+			logger.Error("Failed to remove temp file", "file", tempfile.Name(), "error", err)
+		}
+	}()
+
 	var stdoutBuf, stderrBuf bytes.Buffer
 
 	// #nosec G204
@@ -145,14 +153,6 @@ func (e *baseExecutor) Execute(
 		)
 		return resultBytes(stderrBuf.String(), stdoutBuf.String())
 	}
-
-	// Remove successfully executed temporary filename
-	defer func() {
-		err = os.Remove(tempfile.Name())
-		if err != nil {
-			logger.Error("Failed to remove temp file", "file", tempfile.Name(), "error", err)
-		}
-	}()
 
 	logger.Info(
 		"Command completed",

--- a/internal/interpreter/message_darwin_test.go
+++ b/internal/interpreter/message_darwin_test.go
@@ -4,6 +4,7 @@ package interpreter
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -56,6 +57,30 @@ func TestMessage_Execute_CommandError(t *testing.T) {
 
 	if !strings.Contains(out.Error, "fail") {
 		t.Errorf("expected stderr to contain 'fail', got %s", out.Error)
+	}
+}
+
+func TestExecute_TempFileRemovedOnCommandFailure(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	executor := NewExecutor()
+	orgId := "test-org-tempcleanup"
+	device := agent.Device{RewstOrgId: orgId}
+
+	scriptsDir := agent.GetScriptsDirectory(orgId)
+
+	msg := Message{
+		PostId:   "test:tempcleanup",
+		Commands: encodeCommand("exit 1"),
+	}
+
+	msg.Execute(executor, context.Background(), device, logger, nil, nil)
+
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("unexpected error reading scripts dir: %v", err)
+	}
+	for _, e := range entries {
+		t.Errorf("orphaned temp file found after failed execution: %s", e.Name())
 	}
 }
 

--- a/internal/interpreter/message_linux_test.go
+++ b/internal/interpreter/message_linux_test.go
@@ -4,6 +4,7 @@ package interpreter
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -56,6 +57,30 @@ func TestMessage_Execute_CommandError(t *testing.T) {
 
 	if !strings.Contains(out.Error, "fail") {
 		t.Errorf("expected stderr to contain 'fail', got %s", out.Error)
+	}
+}
+
+func TestExecute_TempFileRemovedOnCommandFailure(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	executor := NewExecutor()
+	orgId := "test-org-tempcleanup"
+	device := agent.Device{RewstOrgId: orgId}
+
+	scriptsDir := agent.GetScriptsDirectory(orgId)
+
+	msg := Message{
+		PostId:   "test:tempcleanup",
+		Commands: encodeCommand("exit 1"),
+	}
+
+	msg.Execute(executor, context.Background(), device, logger, nil, nil)
+
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("unexpected error reading scripts dir: %v", err)
+	}
+	for _, e := range entries {
+		t.Errorf("orphaned temp file found after failed execution: %s", e.Name())
 	}
 }
 


### PR DESCRIPTION
## Summary

- **[sc-87906]** `defer os.Remove(tempfile.Name())` was placed *after* `cmd.Run()` in `base_executor.go`. Because `defer` is only registered when the statement is reached, any early return on execution failure (line 146) left the temporary script file on disk indefinitely. Over time — especially in retry-heavy workflows — these files accumulate in the system temp directory, consuming disk space and potentially leaking sensitive script content.
- Moved the `defer os.Remove(...)` to immediately after `tempfile.Close()` succeeds, before `cmd.Run()` is called. The cleanup now fires on every exit path: execution failure, success, and context cancellation.

## Changed files

| File | Change |
|---|---|
| `internal/interpreter/base_executor.go` | Moved `defer os.Remove(tempfile.Name())` from after `cmd.Run()` to after `tempfile.Close()` so cleanup is guaranteed on both success and failure paths |
| `internal/interpreter/message_darwin_test.go` | Added `os` import and `TestExecute_TempFileRemovedOnCommandFailure` regression test |
| `internal/interpreter/message_linux_test.go` | Added `os` import and `TestExecute_TempFileRemovedOnCommandFailure` regression test |

## Tests added

**`TestExecute_TempFileRemovedOnCommandFailure`** — the regression test. Runs a command that exits with code 1, then reads the scripts directory and fails if any orphaned temp files remain. With the old bug, the `defer` was never registered on the failure path and the file would persist. With the fix, the deferred cleanup fires before `Execute` returns.

## Test plan

- [ ] `go test -race ./internal/interpreter/...` passes
- [ ] `TestExecute_TempFileRemovedOnCommandFailure` passes on both Darwin and Linux
- [ ] Trigger a command that exits non-zero; confirm no residual `exec-*.ps1` files remain in the system temp scripts directory
- [ ] Trigger a command that succeeds; confirm the temp file is also cleaned up
- [ ] Run `go test -race ./internal/interpreter/...` and confirm all tests pass
