### PR TITLE
fix: [sc-87907] Out-of-Bounds Panic in `extractMessage` — syslog.go

### DIFF
--- a/internal/syslog/syslog.go
+++ b/internal/syslog/syslog.go
@@ -8,6 +8,9 @@ type Syslog interface {
 }
 
 func extractMessage(line string) string {
-	start := strings.Index(line, "]") + 2
-	return line[start:]
+	idx := strings.Index(line, "]")
+	if idx < 0 || idx+2 > len(line) {
+		return line
+	}
+	return line[idx+2:]
 }

--- a/internal/syslog/syslog_test.go
+++ b/internal/syslog/syslog_test.go
@@ -35,8 +35,18 @@ func TestExtractMessage(t *testing.T) {
 		},
 		{
 			name:     "no bracket in line",
-			input:    "xno bracket here",
+			input:    "no bracket here",
 			expected: "no bracket here",
+		},
+		{
+			name:     "bracket is last character",
+			input:    "2024-01-01 [ERROR]",
+			expected: "2024-01-01 [ERROR]",
+		},
+		{
+			name:     "bracket followed by exactly one character",
+			input:    "[INFO]x",
+			expected: "",
 		},
 	}
 


### PR DESCRIPTION
## Summary

[sc-87907] `extractMessage` in `syslog.go` computed the slice start as `strings.Index(line, "]") + 2` without bounds-checking. When `]` is absent `strings.Index` returns `-1`, making `start = 1` — no panic, but the first character is silently dropped. When `]` is the last character, `start = len(line) + 1`, causing `line[start:]` to panic. A single malformed or truncated log line in the syslog `Write` path could crash the agent service or silently kill the logging goroutine, producing no further log output on any platform (macOS, Linux, Windows).

Added a bounds check so that when `]` is absent or is the last character, the full original line is returned unchanged instead of panicking.

## Changed files

| File | Change |
|------|--------|
| `internal/syslog/syslog.go` | Added bounds check to `extractMessage`: guards against absent `]` (`idx < 0`) and `]` as the last character (`idx+2 > len(line)`), returning the full original line in both cases |
| `internal/syslog/syslog_test.go` | Fixed stale "no bracket in line" case that was documenting the off-by-one bug; added `bracket_is_last_character` and `bracket_followed_by_exactly_one_character` edge-case entries |

## Tests added

`bracket_is_last_character` — passes `"2024-01-01 [ERROR]"` where `]` is the final character. With the old code this panicked. With the fix the full original line is returned unchanged.

`bracket_followed_by_exactly_one_character` — passes `"[INFO]x"` where only one character follows `]`. Confirms no panic and that the resulting slice is an empty string.

## Test plan

- [ ] `go test -race ./internal/syslog/...` passes
- [ ] `bracket_is_last_character` and `bracket_followed_by_exactly_one_character` pass
- [ ] Enable syslog on a test machine and emit a log line with no `]`; confirm the agent does not panic and the line appears in the system log
- [ ] Emit a log line where `]` is the final character; confirm no panic and the full line is forwarded
