### PR TITLE
fix: [sc-87865] Hardcoded MQTT QoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ rewst_agent_config.win.exe --org-id YOUR_ORG_ID --config-url CONFIG_URL --config
 - `--syslog`: Write logs to system log instead of file (Linux/macOS)
 - `--disable-agent-postback`: Disable agent postback
 - `--no-auto-updates`: Disable auto updates
+- `--mqtt-qos`: MQTT subscription QoS level (`0` = at-most-once, `1` = at-least-once, `2` = exactly-once). Defaults to `1` when omitted.
 
 Example with optional parameters:
 ```bash
-./rewst_agent_config --org-id YOUR_ORG_ID --config-url CONFIG_URL --config-secret CONFIG_SECRET --logging-level info --syslog --disable-agent-postback --no-auto-updates
+./rewst_agent_config --org-id YOUR_ORG_ID --config-url CONFIG_URL --config-secret CONFIG_SECRET --logging-level info --syslog --disable-agent-postback --no-auto-updates --mqtt-qos 1
 ```
 
 ## Update
@@ -51,7 +52,7 @@ Example with optional parameters:
 Once installed, the agent can be updated and configured using the config executable. The optional parameters are also available.
 
 ```bash
-./rewst_agent_config --org-id YOUR_ORG_ID --update --logging-level info --syslog --disable-agent-postback --no-auto-updates
+./rewst_agent_config --org-id YOUR_ORG_ID --update --logging-level info --syslog --disable-agent-postback --no-auto-updates --mqtt-qos 1
 ```
 
 ## Service Mode
@@ -131,6 +132,7 @@ Once launched, the menu guides you through the following checks:
       Log Level:    info
       Syslog:       false
       Auto-Updates: true
+      MQTT QoS:     1
 
   ── MQTT/WebSocket Connectivity ──
 

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -112,6 +112,11 @@ func runConfig(params *configContext) error {
 	response.Configuration.DisableAutoUpdates = params.NoAutoUpdates
 	response.Configuration.GithubToken = params.GithubToken
 
+	if params.MqttQos != -1 {
+		qos := byte(params.MqttQos)
+		response.Configuration.MqttQos = &qos
+	}
+
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)
 	err = params.FS.MkdirAll(dataDir)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -23,6 +23,7 @@ type configContext struct {
 	DisableAgentPostback bool
 	NoAutoUpdates        bool
 	GithubToken          string
+	MqttQos              int
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -60,6 +61,7 @@ func newConfigContext(
 	)
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
+	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)
@@ -81,6 +83,10 @@ func newConfigContext(
 
 	if !allowedLoggingLevels[params.LoggingLevel] {
 		return nil, fmt.Errorf("invalid logging-level")
+	}
+
+	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
+		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
 	}
 
 	params.Sys = sys

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -38,6 +38,23 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf("expected nil, got %v", result.Domain)
 	}
 
+	if result.MqttQos != -1 {
+		t.Errorf("expected MqttQos -1 (unset), got %v", result.MqttQos)
+	}
+
+	resultWithQos, _ := newConfigContext(
+		[]string{
+			"--org-id", orgId,
+			"--config-url", configUrl,
+			"--config-secret", configSecret,
+			"--mqtt-qos", "2",
+		},
+		nil, nil, nil, nil,
+	)
+	if resultWithQos.MqttQos != 2 {
+		t.Errorf("expected MqttQos 2, got %v", resultWithQos.MqttQos)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -58,6 +75,19 @@ func TestNewConfigContext(t *testing.T) {
 				"invalid",
 			},
 			"invalid logging-level",
+		},
+		{
+			[]string{
+				"--org-id",
+				orgId,
+				"--config-url",
+				configUrl,
+				"--config-secret",
+				configSecret,
+				"--mqtt-qos",
+				"3",
+			},
+			"invalid mqtt-qos",
 		},
 	}
 

--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -267,6 +267,9 @@ func runCheckAgents(params *diagnosticContext, agents []agentInfo) {
 			fmt.Printf("      Log Level:    %s\n", a.Device.LoggingLevel)
 			fmt.Printf("      Syslog:       %v\n", a.Device.UseSyslog)
 			fmt.Printf("      Auto-Updates: %v\n", !a.Device.DisableAutoUpdates)
+			if a.Device.MqttQos != nil {
+				fmt.Printf("      MQTT QoS:     %d\n", *a.Device.MqttQos)
+			}
 		}
 	}
 }

--- a/cmd/agent_smith/main.go
+++ b/cmd/agent_smith/main.go
@@ -83,7 +83,7 @@ func main() {
 	// Show usage
 	loggingLevelsList := getAllowedConfigLevelsString("|")
 	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates]",
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2]",
 		loggingLevelsList,
 	)
 	usages := []string{

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -48,6 +48,10 @@ func (svc *serviceContext) loadConfig() (agent.Device, error) {
 		return device, err
 	}
 
+	if device.MqttQos != nil && *device.MqttQos > 2 {
+		return device, fmt.Errorf("mqtt_qos must be 0, 1, or 2; got %d", *device.MqttQos)
+	}
+
 	return device, nil
 }
 
@@ -262,7 +266,11 @@ func (svc *serviceContext) Execute(
 
 		// Subscribe to the topic
 		topic := fmt.Sprintf("devices/%s/messages/devicebound/#", device.DeviceId)
-		token = client.Subscribe(topic, 1, func(client mqtt.Client, msg mqtt.Message) {
+		qos := byte(1)
+		if device.MqttQos != nil {
+			qos = *device.MqttQos
+		}
+		token = client.Subscribe(topic, qos, func(client mqtt.Client, msg mqtt.Message) {
 			payload := msg.Payload()
 			select {
 			case msgQueue <- payload:

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -96,6 +96,64 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+// TestLoadConfig_MqttQos tests QoS validation in loadConfig
+func TestLoadConfig_MqttQos(t *testing.T) {
+	qos := func(v byte) *byte { return &v }
+
+	tests := []struct {
+		name        string
+		mqttQos     *byte
+		expectError bool
+	}{
+		{name: "qos_absent_defaults_to_1", mqttQos: nil, expectError: false},
+		{name: "qos_0_accepted", mqttQos: qos(0), expectError: false},
+		{name: "qos_1_accepted", mqttQos: qos(1), expectError: false},
+		{name: "qos_2_accepted", mqttQos: qos(2), expectError: false},
+		{name: "qos_3_rejected", mqttQos: qos(3), expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.json")
+
+			device := agent.Device{DeviceId: "test-device", MqttQos: tt.mqttQos}
+			configBytes, err := json.Marshal(device)
+			if err != nil {
+				t.Fatalf("failed to marshal config: %v", err)
+			}
+
+			if err = os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			svc := &serviceContext{ConfigFile: configPath}
+			got, err := svc.loadConfig()
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.mqttQos == nil {
+				if got.MqttQos != nil {
+					t.Errorf("expected MqttQos nil, got %d", *got.MqttQos)
+				}
+			} else {
+				if got.MqttQos == nil || *got.MqttQos != *tt.mqttQos {
+					t.Errorf("expected MqttQos %d, got %v", *tt.mqttQos, got.MqttQos)
+				}
+			}
+		})
+	}
+}
+
 // TestLoadConfig_FileNotFound tests loadConfig with missing file
 func TestLoadConfig_FileNotFound(t *testing.T) {
 	svc := &serviceContext{

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -81,6 +81,13 @@ func runUpdate(params *updateContext) {
 	device.DisableAutoUpdates = params.NoAutoUpdates
 	device.GithubToken = params.GithubToken
 
+	if params.MqttQos != -1 {
+		qos := byte(params.MqttQos)
+		device.MqttQos = &qos
+	} else {
+		device.MqttQos = nil
+	}
+
 	// Save the updated configuration file
 	configBytes, err := json.MarshalIndent(device, "", "  ")
 	if err != nil {

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -18,6 +18,7 @@ type updateContext struct {
 	DisableAgentPostback bool
 	NoAutoUpdates        bool
 	GithubToken          string
+	MqttQos              int
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -53,6 +54,7 @@ func newUpdateContext(
 	)
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
+	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)
@@ -70,6 +72,10 @@ func newUpdateContext(
 
 	if !allowedLoggingLevels[params.LoggingLevel] {
 		return nil, fmt.Errorf("invalid logging-level")
+	}
+
+	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
+		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
 	}
 
 	params.Sys = sys

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -26,6 +26,18 @@ func TestNewUpdateContext(t *testing.T) {
 		t.Errorf("expected nil, got %v", result.Domain)
 	}
 
+	if result.MqttQos != -1 {
+		t.Errorf("expected MqttQos -1 (unset), got %v", result.MqttQos)
+	}
+
+	resultWithQos, _ := newUpdateContext(
+		[]string{"--org-id", orgId, "--update", "--mqtt-qos", "0"},
+		nil, nil, nil, nil,
+	)
+	if resultWithQos.MqttQos != 0 {
+		t.Errorf("expected MqttQos 0, got %v", resultWithQos.MqttQos)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -36,6 +48,10 @@ func TestNewUpdateContext(t *testing.T) {
 		{
 			[]string{"--org-id", orgId, "--update", "--logging-level", "invalid"},
 			"invalid logging-level",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--mqtt-qos", "3"},
+			"invalid mqtt-qos",
 		},
 	}
 

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -15,6 +15,7 @@ type Device struct {
 	DisableAgentPostback bool               `json:"disable_agent_postback"`
 	DisableAutoUpdates   bool               `json:"disable_auto_updates"`
 	GithubToken          string             `json:"github_token,omitempty"`
+	MqttQos              *byte              `json:"mqtt_qos,omitempty"`
 }
 
 type Plugin struct {


### PR DESCRIPTION
## Summary
[sc-87865] The MQTT subscription QoS level was hardcoded to `1` (at-least-once) in `service.go` with no way to override it. Operators who need at-most-once delivery (QoS 0) for high-throughput scenarios, or exactly-once delivery (QoS 2) for critical command channels, had no recourse without a code change. A new optional `mqtt_qos` field is added to the device configuration with a default of `1`, preserving existing behaviour for all current deployments. Values outside `[0, 2]` are rejected at config-load time with a descriptive error.

## Changed files

| File | Change |
|------|--------|
| `internal/agent/device.go` | Added `MqttQos *byte` field (`json:"mqtt_qos,omitempty"`) to `Device`; pointer type distinguishes "not set" (nil → runtime default of 1) from an explicit `0` |
| `cmd/agent_smith/service.go` | `loadConfig()` rejects `mqtt_qos` values outside `[0, 2]`; `client.Subscribe` reads the configured value, falling back to `1` when the field is absent |
| `cmd/agent_smith/config_context.go` | Added `MqttQos int` field and `--mqtt-qos` flag (default `-1` = unset); validates that any supplied value is `0`, `1`, or `2` |
| `cmd/agent_smith/update_context.go` | Same additions as `config_context.go` |
| `cmd/agent_smith/config.go` | Applies `params.MqttQos` to the fetched device configuration before saving; leaves the field nil when the flag is absent |
| `cmd/agent_smith/update.go` | Applies `params.MqttQos` when updating config; explicitly clears it to nil when the flag is absent, consistent with how other optional fields behave |
| `cmd/agent_smith/diagnostic.go` | Prints `MQTT QoS: <n>` in the agent scan output when the field is present in the config file |
| `cmd/agent_smith/main.go` | Usage string updated to include `[--mqtt-qos 0\|1\|2]` for both config and update modes |
| `README.md` | Documents `--mqtt-qos` in Configuration Options; updates example commands and diagnostic output sample |

## Tests added

`TestLoadConfig_MqttQos` (in `service_test.go`) — table-driven test covering all five cases: absent field (nil preserved), QoS 0/1/2 accepted, QoS 3 rejected with an error.

`TestNewConfigContext` error case `invalid mqtt-qos` — verifies that `--mqtt-qos 3` is rejected by `newConfigContext`; happy-path assertion confirms `--mqtt-qos 2` sets `MqttQos` to `2`.

`TestNewUpdateContext` error case `invalid mqtt-qos` — same coverage for `newUpdateContext`; happy-path assertion confirms `--mqtt-qos 0` sets `MqttQos` to `0`.

## Test plan

- [ ] `go test -race ./...` passes
- [ ] `TestLoadConfig_MqttQos` subtests all pass (absent, 0, 1, 2 accepted; 3 rejected)
- [ ] Start agent with `mqtt_qos` omitted from config; confirm QoS 1 behaviour is unchanged from the previous release
- [ ] Set `mqtt_qos: 0` in the config file, start the agent, and confirm commands are received (at-most-once, no duplicate protection)
- [ ] Set `mqtt_qos: 2` and confirm the agent subscribes successfully with exactly-once semantics
- [ ] Set `mqtt_qos: 3` and confirm the agent fails to start with `mqtt_qos must be 0, 1, or 2; got 3`
- [ ] Run `--config-url ... --mqtt-qos 2` and confirm the saved config file contains `"mqtt_qos": 2`
- [ ] Run `--update --mqtt-qos 0` and confirm the saved config file reflects the new value
- [ ] Run `--update` without `--mqtt-qos` and confirm `mqtt_qos` is absent from the saved config (runtime defaults to 1)
- [ ] Run `--diagnostic` on an agent with `mqtt_qos: 2`; confirm `MQTT QoS: 2` appears in the scan output
- [ ] Run `--diagnostic` on an agent without `mqtt_qos`; confirm the line is omitted
