### PR TITLE
fix: [sc-87866] Error Context Lost in Host Info

### DIFF
--- a/internal/agent/host.go
+++ b/internal/agent/host.go
@@ -2,12 +2,17 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/RewstApp/agent-smith-go/internal/version"
 	"github.com/hashicorp/go-hclog"
 )
+
+// ErrNoMACAddress is returned by MACAddress when no network interface
+// with a hardware address is found.
+var ErrNoMACAddress = errors.New("no MAC address found")
 
 type HostInfo struct {
 	AgentVersion          string  `json:"agent_version"`

--- a/internal/agent/host_darwin.go
+++ b/internal/agent/host_darwin.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -13,6 +12,8 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/mem"
 )
+
+var netInterfaces = net.Interfaces
 
 type darwinDefaultSystemInfoProvider struct{}
 
@@ -48,7 +49,7 @@ func (*darwinDefaultSystemInfoProvider) TotalMemoryBytes() (uint64, error) {
 }
 
 func (*darwinDefaultSystemInfoProvider) MACAddress() (*string, error) {
-	ifas, err := net.Interfaces()
+	ifas, err := netInterfaces()
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (*darwinDefaultSystemInfoProvider) MACAddress() (*string, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("%s", "No mac address found")
+	return nil, ErrNoMACAddress
 }
 
 func NewSystemInfoProvider() SystemInfoProvider {

--- a/internal/agent/host_darwin_test.go
+++ b/internal/agent/host_darwin_test.go
@@ -4,9 +4,23 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"net"
 	"os"
 	"testing"
 )
+
+func TestDarwinDefaultSystemInfoProvider_MACAddress_NoInterface(t *testing.T) {
+	orig := netInterfaces
+	netInterfaces = func() ([]net.Interface, error) { return nil, nil }
+	defer func() { netInterfaces = orig }()
+
+	sys := &darwinDefaultSystemInfoProvider{}
+	_, err := sys.MACAddress()
+	if !errors.Is(err, ErrNoMACAddress) {
+		t.Errorf("expected ErrNoMACAddress, got %v", err)
+	}
+}
 
 func TestDarwinDefaultSystemInfoProvider_MACAddress(t *testing.T) {
 	sys := &darwinDefaultSystemInfoProvider{}

--- a/internal/agent/host_linux.go
+++ b/internal/agent/host_linux.go
@@ -4,7 +4,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -13,6 +12,8 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/mem"
 )
+
+var netInterfaces = net.Interfaces
 
 type linuxDefaultSystemInfoProvider struct{}
 
@@ -48,7 +49,7 @@ func (*linuxDefaultSystemInfoProvider) TotalMemoryBytes() (uint64, error) {
 }
 
 func (*linuxDefaultSystemInfoProvider) MACAddress() (*string, error) {
-	ifas, err := net.Interfaces()
+	ifas, err := netInterfaces()
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (*linuxDefaultSystemInfoProvider) MACAddress() (*string, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("%s", "No mac address found")
+	return nil, ErrNoMACAddress
 }
 
 func NewSystemInfoProvider() SystemInfoProvider {

--- a/internal/agent/host_linux_test.go
+++ b/internal/agent/host_linux_test.go
@@ -4,9 +4,23 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"net"
 	"os"
 	"testing"
 )
+
+func TestLinuxDefaultSystemInfoProvider_MACAddress_NoInterface(t *testing.T) {
+	orig := netInterfaces
+	netInterfaces = func() ([]net.Interface, error) { return nil, nil }
+	defer func() { netInterfaces = orig }()
+
+	sys := &linuxDefaultSystemInfoProvider{}
+	_, err := sys.MACAddress()
+	if !errors.Is(err, ErrNoMACAddress) {
+		t.Errorf("expected ErrNoMACAddress, got %v", err)
+	}
+}
 
 func TestLinuxDefaultSystemInfoProvider_MACAddress(t *testing.T) {
 	sys := &linuxDefaultSystemInfoProvider{}

--- a/internal/agent/host_windows.go
+++ b/internal/agent/host_windows.go
@@ -5,7 +5,6 @@ package agent
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -15,6 +14,8 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/mem"
 )
+
+var netInterfaces = net.Interfaces
 
 type windowsDefaultSystemInfoProvider struct{}
 
@@ -50,7 +51,7 @@ func (*windowsDefaultSystemInfoProvider) TotalMemoryBytes() (uint64, error) {
 }
 
 func (*windowsDefaultSystemInfoProvider) MACAddress() (*string, error) {
-	ifas, err := net.Interfaces()
+	ifas, err := netInterfaces()
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func (*windowsDefaultSystemInfoProvider) MACAddress() (*string, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("%s", "No mac address found")
+	return nil, ErrNoMACAddress
 }
 
 func NewSystemInfoProvider() SystemInfoProvider {

--- a/internal/agent/host_windows_test.go
+++ b/internal/agent/host_windows_test.go
@@ -4,10 +4,24 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"net"
 	"os"
 	"strings"
 	"testing"
 )
+
+func TestWindowsDefaultSystemInfoProvider_MACAddress_NoInterface(t *testing.T) {
+	orig := netInterfaces
+	netInterfaces = func() ([]net.Interface, error) { return nil, nil }
+	defer func() { netInterfaces = orig }()
+
+	sys := &windowsDefaultSystemInfoProvider{}
+	_, err := sys.MACAddress()
+	if !errors.Is(err, ErrNoMACAddress) {
+		t.Errorf("expected ErrNoMACAddress, got %v", err)
+	}
+}
 
 func TestWindowsDefaultSystemInfoProvider_MACAddress(t *testing.T) {
 	sys := &windowsDefaultSystemInfoProvider{}


### PR DESCRIPTION
## Summary
[sc-87866] `MACAddress()` in `host_darwin.go`, `host_linux.go`, and `host_windows.go` returned a bare `fmt.Errorf("%s", "No mac address found")` — a static string with no wrapped error — breaking Go error chains and making root-cause diagnosis impossible when MAC address enumeration fails. A sentinel error `ErrNoMACAddress` is introduced so callers can reliably detect and handle this condition via `errors.Is`, and the misleading `fmt.Errorf` pattern is replaced throughout.

## Changed files

| File | Change |
|------|--------|
| `internal/agent/host.go` | Added `ErrNoMACAddress = errors.New("no MAC address found")` exported sentinel |
| `internal/agent/host_darwin.go` | Removed `"fmt"` import; added `var netInterfaces = net.Interfaces` for test injection; `MACAddress()` now calls `netInterfaces()` and returns `ErrNoMACAddress` instead of the bare string error |
| `internal/agent/host_linux.go` | Same changes as `host_darwin.go` |
| `internal/agent/host_windows.go` | Same changes as `host_darwin.go` |

## Tests added

`TestDarwinDefaultSystemInfoProvider_MACAddress_NoInterface` — mocks `netInterfaces` to return an empty slice; asserts `errors.Is(err, ErrNoMACAddress)`.

`TestLinuxDefaultSystemInfoProvider_MACAddress_NoInterface` — same coverage for Linux.

`TestWindowsDefaultSystemInfoProvider_MACAddress_NoInterface` — same coverage for Windows.

## Test plan

- [ ] `go test -race ./internal/agent/...` passes on the current platform
- [ ] `TestDarwinDefaultSystemInfoProvider_MACAddress_NoInterface` / Linux / Windows variants all pass
- [ ] Simulate a missing MAC address (mock returns empty list); confirm `errors.Is(err, ErrNoMACAddress)` is true
- [ ] Confirm existing `MACAddress` happy-path tests are unaffected
- [ ] Run `go vet ./...`; confirm no `printf`-style linter warnings remain for these lines
