### PR TITLE
fix: [sc-89003] PowerShell Profile Output Contaminates Host Info Fields

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -337,12 +337,37 @@ jobs:
           name: it-windows-latest
           path: ./dist
 
+      - name: Inject PowerShell profile noise
+        id: inject_profile_noise
+        shell: powershell
+        run: |
+          $noise = "PROFILE_NOISE_$(New-Guid)"
+          $profilePath = $PROFILE.AllUsersAllHosts
+          New-Item -ItemType Directory -Force -Path (Split-Path $profilePath) | Out-Null
+          Add-Content -Path $profilePath -Value "Write-Output '$noise'"
+          Write-Output "Profile noise '$noise' injected to: $profilePath"
+          "noise=$noise" >> $env:GITHUB_OUTPUT
+
       - name: Install agent
         id: install_agent
         shell: pwsh
         run: |
-          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
+          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }} 2>&1 | Tee-Object -FilePath install_output.txt
           Write-Output "service=RewstRemoteAgent_${{ vars.IT_ORG_ID }}" >> $env:GITHUB_OUTPUT
+
+      - name: Check install output for profile noise
+        shell: pwsh
+        run: |
+          $noise = "${{ steps.inject_profile_noise.outputs.noise }}"
+          $installOutput = Get-Content install_output.txt -Raw
+          Write-Output "=== Install output ==="
+          Write-Output $installOutput
+          Write-Output "======================"
+          if ($installOutput -match [regex]::Escape($noise)) {
+            Write-Error "FAIL: Profile noise '$noise' found in install output — PowerShell profile output contaminated agent data"
+            exit 1
+          }
+          Write-Output "PASS: Profile noise not found in install output — -NoProfile flag correctly suppresses profile output"
 
       - name: Check service
         shell: pwsh

--- a/internal/agent/host_windows.go
+++ b/internal/agent/host_windows.go
@@ -75,7 +75,9 @@ func NewSystemInfoProvider() SystemInfoProvider {
 type psRunnerFunc func(ctx context.Context, script string) (string, error)
 
 func defaultPSRunner(ctx context.Context, script string) (string, error) {
-	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	cmd := exec.CommandContext(
+		ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script,
+	)
 	var outb bytes.Buffer
 	cmd.Stdout = &outb
 	if err := cmd.Run(); err != nil {

--- a/internal/agent/host_windows.go
+++ b/internal/agent/host_windows.go
@@ -72,62 +72,52 @@ func NewSystemInfoProvider() SystemInfoProvider {
 	return &windowsDefaultSystemInfoProvider{}
 }
 
-type windowsDefaultDomainInfoProvider struct{}
+type psRunnerFunc func(ctx context.Context, script string) (string, error)
 
-func (*windowsDefaultDomainInfoProvider) ADDomain(ctx context.Context) (*string, error) {
-	cmd := exec.CommandContext(
-		ctx,
-		"powershell",
-		"-Command",
-		`$domainInfo = (Get-WmiObject Win32_ComputerSystem).Domain
+func defaultPSRunner(ctx context.Context, script string) (string, error) {
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(outb.String()), nil
+}
+
+type windowsDefaultDomainInfoProvider struct {
+	psRunner psRunnerFunc
+}
+
+func (p *windowsDefaultDomainInfoProvider) ADDomain(ctx context.Context) (*string, error) {
+	output, err := p.psRunner(ctx, `$domainInfo = (Get-WmiObject Win32_ComputerSystem).Domain
     if ($domainInfo -and $domainInfo -ne 'WORKGROUP') {
         return $domainInfo
     } else {
         return $null
-    }`,
-	)
-
-	var outb bytes.Buffer
-	cmd.Stdout = &outb
-
-	err := cmd.Run()
+    }`)
 	if err != nil {
 		return nil, err
 	}
-
-	domain := strings.TrimSpace(outb.String())
-	if len(domain) == 0 {
+	if len(output) == 0 {
 		return nil, nil
 	}
-
-	return &domain, nil
+	return &output, nil
 }
 
-func (*windowsDefaultDomainInfoProvider) IsADDomainController(ctx context.Context) (bool, error) {
-	cmd := exec.CommandContext(
-		ctx,
-		"powershell",
-		"-Command",
-		`$domainStatus = (Get-WmiObject Win32_ComputerSystem).DomainRole
+func (p *windowsDefaultDomainInfoProvider) IsADDomainController(ctx context.Context) (bool, error) {
+	output, err := p.psRunner(ctx, `$domainStatus = (Get-WmiObject Win32_ComputerSystem).DomainRole
     if ($domainStatus -eq 4 -or $domainStatus -eq 5) {
         return $true
     } else {
         return $false
-    }`,
-	)
-
-	var outb bytes.Buffer
-	cmd.Stdout = &outb
-
-	err := cmd.Run()
+    }`)
 	if err != nil {
 		return false, err
 	}
-
-	return strings.TrimSpace(outb.String()) == "True", nil
+	return output == "True", nil
 }
 
-func (*windowsDefaultDomainInfoProvider) IsEntraConnectServer() (bool, error) {
+func (p *windowsDefaultDomainInfoProvider) IsEntraConnectServer() (bool, error) {
 	entraServiceNames := []string{"ADSync", "Azure AD Sync", "EntraConnectSync", "OtherFutureName"}
 
 	for _, name := range entraServiceNames {
@@ -140,7 +130,7 @@ func (*windowsDefaultDomainInfoProvider) IsEntraConnectServer() (bool, error) {
 	return false, nil
 }
 
-func (*windowsDefaultDomainInfoProvider) EntraDomain(ctx context.Context) (*string, error) {
+func (p *windowsDefaultDomainInfoProvider) EntraDomain(ctx context.Context) (*string, error) {
 	cmd := exec.CommandContext(ctx, "dsregcmd", "/status")
 	var outb bytes.Buffer
 	cmd.Stdout = &outb
@@ -173,5 +163,5 @@ func (*windowsDefaultDomainInfoProvider) EntraDomain(ctx context.Context) (*stri
 }
 
 func NewDomainInfoProvider() DomainInfoProvider {
-	return &windowsDefaultDomainInfoProvider{}
+	return &windowsDefaultDomainInfoProvider{psRunner: defaultPSRunner}
 }

--- a/internal/agent/host_windows_test.go
+++ b/internal/agent/host_windows_test.go
@@ -153,7 +153,9 @@ func TestWindowsDefaultDomainInfoProvider_ADDomain_ProfileNoise(t *testing.T) {
 	}
 	// Without -NoProfile the full contaminated string is returned, not just the domain.
 	if *result == "example.com" {
-		t.Error("expected contamination to corrupt the domain value; -NoProfile suppresses this in production")
+		t.Error(
+			"profile noise corrupts domain value; -NoProfile suppresses this in production",
+		)
 	}
 }
 
@@ -211,7 +213,9 @@ func TestWindowsDefaultDomainInfoProvider_IsADDomainController_ProfileNoise(t *t
 	}
 	// Without -NoProfile the comparison fails and a DC is reported as non-DC.
 	if result {
-		t.Error("expected contamination to suppress true result; -NoProfile suppresses this in production")
+		t.Error(
+			"profile noise suppresses DC true result; -NoProfile suppresses this in production",
+		)
 	}
 }
 

--- a/internal/agent/host_windows_test.go
+++ b/internal/agent/host_windows_test.go
@@ -97,23 +97,126 @@ func TestNewSystemInfoProvider(t *testing.T) {
 }
 
 func TestWindowsDefaultDomainInfoProvider_ADDomain(t *testing.T) {
-	domain := &windowsDefaultDomainInfoProvider{}
+	domain := &windowsDefaultDomainInfoProvider{psRunner: defaultPSRunner}
 	_, err := domain.ADDomain(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
 }
 
+func TestWindowsDefaultDomainInfoProvider_ADDomain_CleanOutput(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			return "example.com", nil
+		},
+	}
+	result, err := provider.ADDomain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || *result != "example.com" {
+		t.Errorf("expected example.com, got %v", result)
+	}
+}
+
+func TestWindowsDefaultDomainInfoProvider_ADDomain_EmptyOutput(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			return "", nil
+		},
+	}
+	result, err := provider.ADDomain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil for workgroup machine, got %v", *result)
+	}
+}
+
+// TestWindowsDefaultDomainInfoProvider_ADDomain_ProfileNoise documents the contamination
+// bug: without -NoProfile, profile stdout prepends noise to the domain, so the returned
+// value is the full noisy string instead of just the domain name.
+func TestWindowsDefaultDomainInfoProvider_ADDomain_ProfileNoise(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			// Simulate profile output prepended before the actual domain (no -NoProfile).
+			return "Welcome to PowerShell!\nexample.com", nil
+		},
+	}
+	result, err := provider.ADDomain(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a result, got nil")
+	}
+	// Without -NoProfile the full contaminated string is returned, not just the domain.
+	if *result == "example.com" {
+		t.Error("expected contamination to corrupt the domain value; -NoProfile suppresses this in production")
+	}
+}
+
 func TestWindowsDefaultDomainInfoProvider_IsADDomainController(t *testing.T) {
-	domain := &windowsDefaultDomainInfoProvider{}
+	domain := &windowsDefaultDomainInfoProvider{psRunner: defaultPSRunner}
 	_, err := domain.IsADDomainController(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
 }
 
+func TestWindowsDefaultDomainInfoProvider_IsADDomainController_True(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			return "True", nil
+		},
+	}
+	result, err := provider.IsADDomainController(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result {
+		t.Error("expected true, got false")
+	}
+}
+
+func TestWindowsDefaultDomainInfoProvider_IsADDomainController_False(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			return "False", nil
+		},
+	}
+	result, err := provider.IsADDomainController(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result {
+		t.Error("expected false, got true")
+	}
+}
+
+// TestWindowsDefaultDomainInfoProvider_IsADDomainController_ProfileNoise documents that
+// without -NoProfile, profile stdout causes the "True"/"False" comparison to fail, always
+// returning false even for actual domain controllers.
+func TestWindowsDefaultDomainInfoProvider_IsADDomainController_ProfileNoise(t *testing.T) {
+	provider := &windowsDefaultDomainInfoProvider{
+		psRunner: func(_ context.Context, _ string) (string, error) {
+			// Simulate profile noise before "True" (no -NoProfile).
+			return "Welcome to PowerShell!\nTrue", nil
+		},
+	}
+	result, err := provider.IsADDomainController(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Without -NoProfile the comparison fails and a DC is reported as non-DC.
+	if result {
+		t.Error("expected contamination to suppress true result; -NoProfile suppresses this in production")
+	}
+}
+
 func TestWindowsDefaultDomainInfoProvider_IsEntraConnectServer(t *testing.T) {
-	domain := &windowsDefaultDomainInfoProvider{}
+	domain := &windowsDefaultDomainInfoProvider{psRunner: defaultPSRunner}
 	_, err := domain.IsEntraConnectServer()
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
@@ -121,7 +224,7 @@ func TestWindowsDefaultDomainInfoProvider_IsEntraConnectServer(t *testing.T) {
 }
 
 func TestWindowsDefaultDomainInfoProvider_EntraDomain(t *testing.T) {
-	domain := &windowsDefaultDomainInfoProvider{}
+	domain := &windowsDefaultDomainInfoProvider{psRunner: defaultPSRunner}
 	_, err := domain.EntraDomain(context.Background())
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)


### PR DESCRIPTION
## Summary

`ADDomain()` and `IsADDomainController()` in `internal/agent/host_windows.go` invoked PowerShell without `-NoProfile`, allowing the user or machine profile to write arbitrary text to stdout before the script's own output. On Windows devices where the PowerShell profile prints output (e.g. welcome banners, `Write-Output` statements), `ad_domain` would contain the profile banner text instead of the real domain name, and `is_ad_domain_controller` would always return `false` because the string comparison `== "True"` failed against the contaminated multiline output. Any Rewst workflow that branches on `ad_domain` or `is_ad_domain_controller` from a `get_installation` response would receive incorrect values on affected devices. A `defaultPSRunner` function is introduced that invokes `powershell -NoProfile -NonInteractive`, and `windowsDefaultDomainInfoProvider` is refactored to accept the runner as an injected field so tests can substitute a fake without global state.

## Changed files

| File | Change |
|---|---|
| `internal/agent/host_windows.go` | Added `psRunnerFunc` type and `defaultPSRunner` that calls `powershell -NoProfile -NonInteractive`; added `psRunner psRunnerFunc` field to `windowsDefaultDomainInfoProvider`; refactored `ADDomain` and `IsADDomainController` to delegate to `p.psRunner`; `NewDomainInfoProvider` injects `defaultPSRunner` |
| `internal/agent/host_windows_test.go` | Added unit tests for clean output, empty output (workgroup), and profile-noise contamination for both `ADDomain` and `IsADDomainController`; added Windows integration test that dot-sources a temp noisy profile |
| `.github/workflows/integration-test.yml` | Added **Inject PowerShell profile noise** step (before install) that writes `PROFILE_NOISE_<guid>` to `$PROFILE.AllUsersAllHosts` using `shell: powershell` (PS5, matching the agent's internal calls); added **Check install output for profile noise** step (after install) that reads captured stdout and fails if the noise string is present |
| `cmd/agent_smith/diagnostic.go` | Added option `[7] Show host data` to the interactive diagnostic menu; implemented `runHostDataCheck` which calls `agent.NewHostInfo` and prints all host fields with aligned labels; included in option `[6] Run all checks` |
| `cmd/agent_smith/diagnostic_test.go` | Added `TestRunDiagnosticWith_Option7_HostData` menu dispatch test and four `TestRunHostDataCheck_*` unit tests covering success, nil pointer fields, provider error, and org ID fallback; updated option-6 and `runAllChecksWith` tests to supply `Sys`/`Domain` mocks |

## Tests added

- `TestWindowsDefaultDomainInfoProvider_ADDomain_CleanOutput` — injects a runner returning `"example.com"`; asserts `ADDomain` returns that value.
- `TestWindowsDefaultDomainInfoProvider_ADDomain_EmptyOutput` — injects a runner returning `""`; asserts `ADDomain` returns `nil` for workgroup machines.
- `TestWindowsDefaultDomainInfoProvider_ADDomain_ProfileNoise` — injects a runner returning `"Welcome to PowerShell!\nexample.com"`; asserts the contaminated string is returned (documents the bug that `-NoProfile` prevents in production).
- `TestWindowsDefaultDomainInfoProvider_IsADDomainController_True` — injects `"True"`; asserts `true` is returned.
- `TestWindowsDefaultDomainInfoProvider_IsADDomainController_False` — injects `"False"`; asserts `false` is returned.
- `TestWindowsDefaultDomainInfoProvider_IsADDomainController_ProfileNoise` — injects `"Welcome to PowerShell!\nTrue"`; asserts `false` is returned (documents the contamination bug).
- `TestWindowsDefaultDomainInfoProvider_Integration_ProfileNoise` — Windows-only; creates a temp profile that emits `INTEGRATION_PROFILE_NOISE`, runs both a noisy subtest (dot-sources the profile, shows contamination) and a clean subtest (uses `defaultPSRunner` with `-NoProfile`, asserts noise is absent).
- `TestRunHostDataCheck_Success` — calls `runHostDataCheck` with a fully populated mock `Sys`/`Domain`; asserts no panic or error.
- `TestRunHostDataCheck_NilPointerFields` — nil `MacAddress`, `AdDomain`, `EntraDomain`; asserts defaults (`<none>`, `<workgroup>`, `<not joined>`) are rendered without panic.
- `TestRunHostDataCheck_SysProviderError` — `HostPlatform` returns an error; asserts `[FAIL]` path is reached.
- `TestRunHostDataCheck_FallsBackToParamsOrgId` — `target.OrgId` is empty; asserts `params.OrgId` is used instead.
- `TestRunDiagnosticWith_Option7_HostData` — sends `"7\n0\n"` to the menu; asserts no panic.

## Test plan

- [ ] `go test -race ./internal/agent/...` passes (on Windows; `host_windows_test.go` is build-constrained)
- [ ] `go test -race ./cmd/agent_smith/...` passes on all platforms
- [ ] `TestWindowsDefaultDomainInfoProvider_ADDomain_ProfileNoise` and `_IsADDomainController_ProfileNoise` confirm the bug path: contaminated input produces a wrong result
- [ ] `TestWindowsDefaultDomainInfoProvider_ADDomain_CleanOutput` and `_IsADDomainController_True/False` confirm the fix path: clean input (as `-NoProfile` guarantees) produces correct values
- [ ] On a Windows device with `Write-Output "PROFILE_NOISE"` in `$PROFILE.AllUsersCurrentHost`, trigger `get_installation` and confirm `ad_domain` equals the actual domain (or `null`) and `is_ad_domain_controller` is correct
- [ ] CI `test-windows-latest` workflow: **Check install output for profile noise** step passes — noise string absent from install stdout
- [ ] Diagnostic mode: running `--diagnostic` and selecting `[7]` prints correct host fields; `[6]` includes host data output
