### PR TITLE
fix: [sc-87908] JSON Marshal Errors Silently Swallowed in result.go

### DIFF
--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -42,14 +42,14 @@ func (e *baseExecutor) Execute(
 	// Parse the commands
 	commandBytes, err := base64.StdEncoding.DecodeString(message.Commands)
 	if err != nil {
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	// Decode using UTF16LE
 	decoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder()
 	commands, _, err := transform.String(decoder, string(commandBytes))
 	if err != nil {
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	// Run the command in the system using powershell
@@ -93,26 +93,26 @@ func (e *baseExecutor) Execute(
 	scriptsDir := agent.GetScriptsDirectory(device.RewstOrgId)
 	err = e.FS.MkdirAll(scriptsDir)
 	if err != nil {
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	tempfile, err := os.CreateTemp(scriptsDir, "exec-*.ps1")
 	if err != nil {
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	if e.WriteUtf8BOM {
 		_, err = tempfile.Write(utf8BOM)
 		if err != nil {
 			logger.Error("Failed to write BOM", "error", err)
-			return errorResultBytes(err)
+			return errorResultBytes(logger, err)
 		}
 	}
 
 	_, err = tempfile.WriteString(commands)
 	if err != nil {
 		logger.Error("Failed to write command file", "error", err)
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	logger.Info("Command saved to", "message_id", message.PostId, "path", tempfile.Name())
@@ -121,7 +121,7 @@ func (e *baseExecutor) Execute(
 	err = tempfile.Close()
 	if err != nil {
 		logger.Error("Failed to close temp file handle", "error", err)
-		return errorResultBytes(err)
+		return errorResultBytes(logger, err)
 	}
 
 	// Remove temp file on both success and failure paths
@@ -151,7 +151,7 @@ func (e *baseExecutor) Execute(
 			"info",
 			stdoutBuf.String(),
 		)
-		return resultBytes(stderrBuf.String(), stdoutBuf.String())
+		return resultBytes(logger, stderrBuf.String(), stdoutBuf.String())
 	}
 
 	logger.Info(
@@ -169,7 +169,7 @@ func (e *baseExecutor) Execute(
 		stdoutBuf.String(),
 	)
 
-	return resultBytes(stderrBuf.String(), stdoutBuf.String())
+	return resultBytes(logger, stderrBuf.String(), stdoutBuf.String())
 }
 
 func (e *baseExecutor) AlwaysPostback() bool {

--- a/internal/interpreter/message.go
+++ b/internal/interpreter/message.go
@@ -47,20 +47,20 @@ func (msg *Message) Execute(
 		// Load the paths data
 		paths, err := agent.NewPathsData(ctx, device.RewstOrgId, logger, sys, domain)
 		if err != nil {
-			return errorResultBytes(err)
+			return errorResultBytes(logger, err)
 		}
 
 		// Convert to bytes in json
 		pathsBytes, err := json.MarshalIndent(&paths, "", "  ")
 		if err != nil {
-			return errorResultBytes(err)
+			return errorResultBytes(logger, err)
 		}
 
 		return pathsBytes
 	}
 
 	// No command
-	return errorResultBytes(fmt.Errorf("noop"))
+	return errorResultBytes(logger, fmt.Errorf("noop"))
 }
 
 func (msg *Message) CreatePostbackRequest(

--- a/internal/interpreter/result.go
+++ b/internal/interpreter/result.go
@@ -1,6 +1,10 @@
 package interpreter
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-hclog"
+)
 
 type errorResult struct {
 	Error string `json:"error"`
@@ -11,19 +15,27 @@ type result struct {
 	Output string `json:"output"`
 }
 
-func errorResultBytes(err error) []byte {
-	result := &errorResult{
+func errorResultBytes(logger hclog.Logger, err error) []byte {
+	r := &errorResult{
 		Error: err.Error(),
 	}
-	bytes, _ := json.MarshalIndent(result, "", "  ")
-	return bytes
+	b, marshalErr := json.MarshalIndent(r, "", "  ")
+	if marshalErr != nil {
+		logger.Error("Failed to marshal error result", "error", marshalErr)
+		return []byte(`{"error":"failed to marshal error result"}`)
+	}
+	return b
 }
 
-func resultBytes(err string, out string) []byte {
-	result := &result{
+func resultBytes(logger hclog.Logger, err string, out string) []byte {
+	r := &result{
 		Error:  err,
 		Output: out,
 	}
-	bytes, _ := json.MarshalIndent(result, "", "  ")
-	return bytes
+	b, marshalErr := json.MarshalIndent(r, "", "  ")
+	if marshalErr != nil {
+		logger.Error("Failed to marshal result", "error", marshalErr)
+		return []byte(`{"error":"failed to marshal result","output":""}`)
+	}
+	return b
 }

--- a/internal/interpreter/result_test.go
+++ b/internal/interpreter/result_test.go
@@ -4,16 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestErrorResultBytes(t *testing.T) {
+	logger := hclog.NewNullLogger()
 	err := errors.New("test error")
-	result := errorResultBytes(err)
+	b := errorResultBytes(logger, err)
+
+	if b == nil {
+		t.Fatal("expected non-nil bytes")
+	}
 
 	var out errorResult
-
-	err = json.Unmarshal(result, &out)
-	if err != nil {
+	if err = json.Unmarshal(b, &out); err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
 
@@ -23,7 +28,12 @@ func TestErrorResultBytes(t *testing.T) {
 }
 
 func TestResultBytes(t *testing.T) {
-	b := resultBytes("some error", "some output")
+	logger := hclog.NewNullLogger()
+	b := resultBytes(logger, "some error", "some output")
+
+	if b == nil {
+		t.Fatal("expected non-nil bytes")
+	}
 
 	var out result
 	err := json.Unmarshal(b, &out)
@@ -37,5 +47,27 @@ func TestResultBytes(t *testing.T) {
 
 	if out.Output != "some output" {
 		t.Errorf("expected 'some output', got %s", out.Output)
+	}
+}
+
+func TestErrorResultBytesNeverNil(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	b := errorResultBytes(logger, errors.New("any error"))
+	if len(b) == 0 {
+		t.Fatal("expected non-empty bytes")
+	}
+	if !json.Valid(b) {
+		t.Errorf("expected valid JSON, got %s", b)
+	}
+}
+
+func TestResultBytesNeverNil(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	b := resultBytes(logger, "", "")
+	if len(b) == 0 {
+		t.Fatal("expected non-empty bytes")
+	}
+	if !json.Valid(b) {
+		t.Errorf("expected valid JSON, got %s", b)
 	}
 }


### PR DESCRIPTION
## Summary

- `errorResultBytes` and `resultBytes` in `internal/interpreter/result.go` were discarding `json.MarshalIndent` errors with `_`, returning `nil` bytes on failure with no log entry and no signal to the caller
- Both functions now accept an `hclog.Logger`, check the marshal error, log it via `logger.Error`, and return a hardcoded valid JSON fallback so neither function can ever return `nil` or empty bytes
- All call sites in `base_executor.go` and `message.go` updated to pass the already-available logger; tests updated accordingly with new assertions that returned bytes are always non-nil and valid JSON

## Test plan

- [ ] Run `go test ./internal/interpreter/...` — all tests pass
- [ ] Run `go vet ./internal/interpreter/...` — no new warnings
- [ ] Confirm `TestErrorResultBytesNeverNil` and `TestResultBytesNeverNil` assert non-empty, valid JSON output from both functions
- [ ] Confirm existing `TestErrorResultBytes` and `TestResultBytes` still validate correct field values

