### PR TITLE
chore: [sc-88692] Add QoS Data to Subscribed Messages Info Log and Integration Test Verification

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -132,6 +132,28 @@ jobs:
           if [ "$failed" = true ]; then exit 1; fi
           echo "All config.json fields validated"
 
+      - name: Check subscribed messages log for topic and QoS
+        shell: bash
+        run: |
+          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
+          logContent=$(cat "$logFile")
+          echo "$logContent"
+
+          subscribedLine=$(echo "$logContent" | grep "Subscribed to messages" | head -1)
+          if [ -z "$subscribedLine" ]; then
+            echo "ERROR: Expected 'Subscribed to messages' not found in logs"
+            exit 1
+          fi
+          if ! echo "$subscribedLine" | grep -qF "topic="; then
+            echo "ERROR: Expected 'topic=' not found in 'Subscribed to messages' log line"
+            exit 1
+          fi
+          if ! echo "$subscribedLine" | grep -qF "qos="; then
+            echo "ERROR: Expected 'qos=' not found in 'Subscribed to messages' log line"
+            exit 1
+          fi
+          echo "Subscribed messages log includes topic and QoS: $subscribedLine"
+
       - name: Send test command
         shell: bash
         run: |
@@ -410,6 +432,28 @@ jobs:
 
           if ($failed) { exit 1 }
           Write-Output "All config.json fields validated"
+
+      - name: Check subscribed messages log for topic and QoS
+        shell: pwsh
+        run: |
+          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
+          $logContent = Get-Content $logFile -Raw
+          Write-Output $logContent
+
+          $subscribedLine = ($logContent -split "`n" | Where-Object { $_ -match "Subscribed to messages" } | Select-Object -First 1)
+          if (-not $subscribedLine) {
+            Write-Error "Expected 'Subscribed to messages' not found in logs"
+            exit 1
+          }
+          if ($subscribedLine -notmatch [regex]::Escape("topic=")) {
+            Write-Error "Expected 'topic=' not found in 'Subscribed to messages' log line"
+            exit 1
+          }
+          if ($subscribedLine -notmatch [regex]::Escape("qos=")) {
+            Write-Error "Expected 'qos=' not found in 'Subscribed to messages' log line"
+            exit 1
+          }
+          Write-Output "Subscribed messages log includes topic and QoS: $subscribedLine"
 
       - name: Send test command
         shell: pwsh
@@ -741,6 +785,28 @@ jobs:
 
           if [ "$failed" = true ]; then exit 1; fi
           echo "All config.json fields validated"
+
+      - name: Check subscribed messages log for topic and QoS
+        shell: bash
+        run: |
+          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
+          logContent=$(cat "$logFile")
+          echo "$logContent"
+
+          subscribedLine=$(echo "$logContent" | grep "Subscribed to messages" | head -1)
+          if [ -z "$subscribedLine" ]; then
+            echo "ERROR: Expected 'Subscribed to messages' not found in logs"
+            exit 1
+          fi
+          if ! echo "$subscribedLine" | grep -qF "topic="; then
+            echo "ERROR: Expected 'topic=' not found in 'Subscribed to messages' log line"
+            exit 1
+          fi
+          if ! echo "$subscribedLine" | grep -qF "qos="; then
+            echo "ERROR: Expected 'qos=' not found in 'Subscribed to messages' log line"
+            exit 1
+          fi
+          echo "Subscribed messages log includes topic and QoS: $subscribedLine"
 
       - name: Send test command
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Check subscribed messages log for topic and QoS
         shell: bash
         run: |
+          sleep 10
           logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
           logContent=$(cat "$logFile")
           echo "$logContent"
@@ -436,6 +437,7 @@ jobs:
       - name: Check subscribed messages log for topic and QoS
         shell: pwsh
         run: |
+          Start-Sleep -Seconds 10
           $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
           $logContent = Get-Content $logFile -Raw
           Write-Output $logContent
@@ -789,6 +791,7 @@ jobs:
       - name: Check subscribed messages log for topic and QoS
         shell: bash
         run: |
+          sleep 10
           logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
           logContent=$(cat "$logFile")
           echo "$logContent"

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -290,7 +290,7 @@ func (svc *serviceContext) Execute(
 		}
 
 		// Complete initialization
-		logger.Info("Subscribed to messages")
+		logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
 		_ = notifier.Notify("AgentStatus:Online") // Best effort notification
 
 		// Reset the timeout

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -843,3 +843,103 @@ func TestExecute_DisconnectCalledOnSubscribeFailure(t *testing.T) {
 		t.Fatal("Execute did not exit within timeout")
 	}
 }
+
+// TestExecute_SubscribedMessagesLogIncludesQoS verifies that the "Subscribed
+// to messages" log entry includes the topic and QoS level being used.
+func TestExecute_SubscribedMessagesLogIncludesQoS(t *testing.T) {
+	tests := []struct {
+		name        string
+		mqttQos     *byte
+		expectedQoS string
+	}{
+		{
+			name:        "default_qos_1",
+			mqttQos:     nil,
+			expectedQoS: "qos=1",
+		},
+		{
+			name:        "explicit_qos_0",
+			mqttQos:     func() *byte { b := byte(0); return &b }(),
+			expectedQoS: "qos=0",
+		},
+		{
+			name:        "explicit_qos_2",
+			mqttQos:     func() *byte { b := byte(2); return &b }(),
+			expectedQoS: "qos=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.json")
+			logPath := filepath.Join(tmpDir, "test.log")
+
+			device := agent.Device{
+				DeviceId:             "test-device",
+				SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+				AzureIotHubHost:      "test.azure-devices.net",
+				LoggingLevel:         "info",
+				DisableAutoUpdates:   true,
+				DisableAgentPostback: true,
+				MqttQos:              tt.mqttQos,
+			}
+			configBytes, _ := json.Marshal(device)
+			if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			origNewClient := inmqtt.NewClient
+			inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client {
+				return &mockMQTTClient{}
+			}
+			defer func() { inmqtt.NewClient = origNewClient }()
+
+			svc := &serviceContext{
+				ConfigFile: configPath,
+				LogFile:    logPath,
+				OrgId:      "test-org",
+				Executor:   &mockExecutor{},
+			}
+
+			stop := make(chan struct{})
+			running := make(chan struct{}, 1)
+			done := make(chan service.ServiceExitCode, 1)
+			go func() { done <- svc.Execute(stop, running) }()
+
+			select {
+			case <-running:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Execute did not signal running within timeout")
+			}
+
+			close(stop)
+
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("Execute did not exit within timeout")
+			}
+
+			logBytes, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("failed to read log: %v", err)
+			}
+			logContent := string(logBytes)
+
+			if !strings.Contains(logContent, "Subscribed to messages") {
+				t.Error("expected log to contain 'Subscribed to messages'")
+			}
+			if !strings.Contains(logContent, tt.expectedQoS) {
+				t.Errorf(
+					"expected log to contain %q, but log was:\n%s",
+					tt.expectedQoS,
+					logContent,
+				)
+			}
+			if !strings.Contains(logContent, "topic=") {
+				t.Errorf("expected log to contain 'topic=', but log was:\n%s", logContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Added `topic` and `qos` fields to the `Subscribed to messages` info log entry in `service.go`, making the MQTT subscription QoS level visible in agent logs
- Added unit tests (`TestExecute_SubscribedMessagesLogIncludesQoS`) covering default QoS 1 and explicit QoS 0 and 2
- Added a `Check subscribed messages log for topic and QoS` integration test step to all three OS jobs (ubuntu, windows, macos) in the integration test workflow, with a 10-second wait to allow the agent time to connect and subscribe before checking

## Changes

### `cmd/agent_smith/service.go`
Updated the subscription success log to include structured fields:
```
logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
```

### `cmd/agent_smith/service_test.go`
Added `TestExecute_SubscribedMessagesLogIncludesQoS` with three subtests verifying the log line includes both `topic=` and `qos=` for each valid QoS level (0, 1, 2).

### `.github/workflows/integration-test.yml`
Added a new workflow step in each OS job that:
1. Waits 10 seconds for the agent to connect and subscribe
2. Reads the agent log and finds the `Subscribed to messages` line
3. Fails if `topic=` or `qos=` are absent from that line

## Testing

- All existing unit tests pass: `go test ./...`
- New unit tests pass for QoS 0, 1 (default), and 2
- Integration test steps verified against the log format produced by the updated `service.go`
