### PR TITLE
chore: [sc-89214] Improve Release Notes Readability in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,16 @@ jobs:
           pipx install commitizen
           pipx upgrade commitizen
 
-      - name: Bump version and push
+      - name: Bump version, generate changelog, and push
         run: |
           git config --local user.email "automated_builds@rewst.io"
           git config --local user.name "Rewst GitHub Actions"
-          git tag "v$(cz bump --yes --get-next)"
+          NEXT_VERSION=$(cz bump --yes --get-next)
+          cz changelog --incremental --unreleased-version "v$NEXT_VERSION" --file-name CHANGELOG.md
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "docs: update changelog for v$NEXT_VERSION"
+          git tag "v$NEXT_VERSION"
+          git push origin HEAD:main
           git push --tags
 
   build:
@@ -80,6 +85,11 @@ jobs:
         id: extract_version
         run: echo "version=v$(cz version -p)" >> $GITHUB_OUTPUT
 
+      - name: Generate release notes
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          awk -v ver="## $VERSION" 'p && /^## /{ exit } $0 ~ ver{ p=1 } p' CHANGELOG.md > release_notes.md
+
       - name: Download windows signed assets
         uses: actions/download-artifact@v8
         with:
@@ -101,6 +111,6 @@ jobs:
       - name: Create release and upload files
         shell: pwsh
         run: |
-          gh release create ${{ steps.extract_version.outputs.version }} --generate-notes (Get-Item ./signed/*)
+          gh release create ${{ steps.extract_version.outputs.version }} --notes-file release_notes.md (Get-Item ./signed/*)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `--generate-notes` in the release job with commitizen-generated changelog content grouped by conventional commit type (feat, fix, refactor, etc.)
- In the `bump` job, run `cz changelog --incremental` after computing the next version to append a structured section to `CHANGELOG.md`, commit it, then tag that commit
- In the `release` job, extract only the current version's section from `CHANGELOG.md` into `release_notes.md` and pass it to `gh release create` via `--notes-file`

## Motivation

`--generate-notes` produces a flat, ungrouped list of PR titles with no semantic structure. Commitizen's changelog output groups changes by type and scope, matching the conventional commit convention already enforced in this repo.

## Changes

**`bump` job** (`Bump version, generate changelog, and push`)
- Captures `NEXT_VERSION` from `cz bump --yes --get-next`
- Runs `cz changelog --incremental --unreleased-version "v$NEXT_VERSION" --file-name CHANGELOG.md` to append only new commits since the previous tag
- Commits `CHANGELOG.md` and tags the resulting commit as `v$NEXT_VERSION`
- Pushes the branch commit and tags separately so the tag always points to the changelog commit

**`release` job** (`Generate release notes`)
- Uses `awk` to slice out the current version's section from `CHANGELOG.md` and writes it to `release_notes.md`

**`release` job** (`Create release and upload files`)
- Swaps `--generate-notes` for `--notes-file release_notes.md`

## Testing

1. Trigger the **Release** workflow manually via `workflow_dispatch` on `main`
2. Confirm the `bump` job commits an updated `CHANGELOG.md` and pushes a tag
3. Open the newly created GitHub release and verify notes are grouped by change type (Features, Bug Fixes, etc.) and cover only commits since the previous tag
