### PR TITLE
fix: [sc-89690] Missing Release Title in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,6 @@ jobs:
       - name: Create release and upload files
         shell: pwsh
         run: |
-          gh release create ${{ steps.extract_version.outputs.version }} --notes-file release_notes.md (Get-Item ./signed/*)
+          gh release create ${{ steps.extract_version.outputs.version }} --title "${{ steps.extract_version.outputs.version }}" --notes-file release_notes.md (Get-Item ./signed/*)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Added `--title` flag to `gh release create` in `.github/workflows/release.yml` so GitHub releases display the version (e.g. `v1.2.3`) as the release title instead of the bare tag name.

## Changes

- `.github/workflows/release.yml` line 114: added `--title "${{ steps.extract_version.outputs.version }}"` to the `gh release create` command.

## Test plan

- [ ] Trigger the release workflow and verify the GitHub Releases page shows the version as the release title.
- [ ] Confirm release notes and signed artifacts are still attached correctly.
- [ ] Check that previous releases are unaffected.
