### PR TITLE
fix: [sc-89434] Close msgQueue per reconnect cycle to prevent goroutine leak

### DIFF
--- a/cmd/agent_smith/message_queue_test.go
+++ b/cmd/agent_smith/message_queue_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -324,6 +325,66 @@ func TestMessageQueue_ConcurrencyBoundedByWorkerCount(t *testing.T) {
 	}
 	if peak == 0 {
 		t.Error("no messages were processed")
+	}
+}
+
+// TestWorkerPool_NoLeakAcrossReconnectCycles verifies that closing msgQueue at
+// the end of each connection cycle allows all worker goroutines to exit, so
+// goroutine count stays stable across multiple reconnect cycles.
+func TestWorkerPool_NoLeakAcrossReconnectCycles(t *testing.T) {
+	exec := &countingExecutor{}
+	svc := newTestSvc(exec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := agent.Device{}
+
+	baseline := runtime.NumGoroutine()
+
+	const cycles = 5
+	for range cycles {
+		msgQueue := make(chan []byte, messageQueueSize)
+		var wg sync.WaitGroup
+		for range workerCount {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case payload, ok := <-msgQueue:
+						if !ok {
+							return
+						}
+						svc.processMessage(payload, ctx, device, logger, notifier)
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
+
+		// Enqueue a message to exercise the drain path.
+		msgQueue <- validPayload("echo hi")
+
+		// Simulate what Execute does on disconnect: close the queue and wait.
+		close(msgQueue)
+		wg.Wait()
+	}
+
+	// Allow the runtime to collect any transient goroutines.
+	runtime.GC()
+	time.Sleep(10 * time.Millisecond)
+
+	after := runtime.NumGoroutine()
+	const maxDelta = 3
+	if after > baseline+maxDelta {
+		t.Errorf(
+			"goroutine count grew after %d reconnect cycles: baseline=%d after=%d (leaked ~%d)",
+			cycles, baseline, after, after-baseline,
+		)
 	}
 }
 

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
@@ -184,31 +185,6 @@ func (svc *serviceContext) Execute(
 	_ = notifier.Notify("AgentStarted") // Best effort notification
 	rg := utils.ReconnectTimeoutGenerator{}
 
-	msgQueue := make(chan []byte, messageQueueSize)
-	for i := range workerCount {
-		go func() {
-			logger.Debug("Message worker started", "worker", i)
-			for {
-				select {
-				case payload, ok := <-msgQueue:
-					if !ok {
-						logger.Debug("Message worker stopped: queue closed", "worker", i)
-						return
-					}
-					logger.Debug(
-						"Message worker processing",
-						"worker", i,
-						"queue_length", len(msgQueue),
-					)
-					svc.processMessage(payload, ctx, device, logger, notifier)
-				case <-ctx.Done():
-					logger.Debug("Message worker stopped: context cancelled", "worker", i)
-					return
-				}
-			}
-		}()
-	}
-
 	for {
 		// Wait for the timeout
 		if rg.Timeout() > 0 {
@@ -225,6 +201,41 @@ func (svc *serviceContext) Execute(
 		// Move to the next timeout
 		rg.Next()
 
+		// Create a fresh message queue and worker pool for this connection attempt.
+		// Workers are closed and drained at every exit point so goroutines do not
+		// accumulate across reconnection cycles.
+		msgQueue := make(chan []byte, messageQueueSize)
+		var wg sync.WaitGroup
+		for i := range workerCount {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				logger.Debug("Message worker started", "worker", i)
+				for {
+					select {
+					case payload, ok := <-msgQueue:
+						if !ok {
+							logger.Debug("Message worker stopped: queue closed", "worker", i)
+							return
+						}
+						logger.Debug(
+							"Message worker processing",
+							"worker", i,
+							"queue_length", len(msgQueue),
+						)
+						svc.processMessage(payload, ctx, device, logger, notifier)
+					case <-ctx.Done():
+						logger.Debug("Message worker stopped: context cancelled", "worker", i)
+						return
+					}
+				}
+			}()
+		}
+		drainWorkers := func() {
+			close(msgQueue)
+			wg.Wait()
+		}
+
 		// Create a channel to wait for lost connection
 		lost := make(chan struct{})
 
@@ -232,6 +243,7 @@ func (svc *serviceContext) Execute(
 		opts, err := mqtt.NewClientOptions(device)
 		if err != nil {
 			logger.Error("Failed to create client options", "error", err)
+			drainWorkers()
 			return service.GenericError
 		}
 
@@ -250,6 +262,7 @@ func (svc *serviceContext) Execute(
 
 		if token.Wait() && token.Error() != nil {
 			logger.Error("Failed to connect", "error", token.Error())
+			drainWorkers()
 			continue
 		}
 		disconnectQuiesce := (uint)(mqtt.DefaultDisconnectQuiesce / time.Millisecond)
@@ -286,6 +299,7 @@ func (svc *serviceContext) Execute(
 		if token.Wait() && token.Error() != nil {
 			logger.Error("Failed to subscribe", "error", token.Error())
 			client.Disconnect(disconnectQuiesce)
+			drainWorkers()
 			continue
 		}
 
@@ -302,10 +316,12 @@ func (svc *serviceContext) Execute(
 		case <-stopped:
 			_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
 			client.Disconnect(disconnectQuiesce)
+			drainWorkers()
 			return 0
 		case <-lost:
 			_ = notifier.Notify("AgentStatus:Offline") // Best effort notification
 			client.Disconnect(disconnectQuiesce)
+			drainWorkers()
 			continue
 		}
 	}


### PR DESCRIPTION
## Summary

- Worker goroutines leaked on every MQTT reconnect cycle because `msgQueue` was created once before the reconnection loop and never closed, so workers had no signal to exit between cycles.
- `msgQueue` creation and the worker pool are now moved inside the reconnection loop so each connection attempt gets a fresh queue and a fresh `sync.WaitGroup`.
- A `drainWorkers()` closure (`close(msgQueue)` + `wg.Wait()`) is called at every exit point before the loop resets: connection lost, subscribe failure, connect failure, stop signal, and MQTT options error. Workers drain any buffered messages and exit cleanly before the next cycle begins.

## Changes

- `cmd/agent_smith/service.go`: removed pre-loop worker/queue setup; added per-iteration worker pool with `sync.WaitGroup` and `drainWorkers()` calls at all five exit/continue paths; added `"sync"` import.
- `cmd/agent_smith/message_queue_test.go`: added `TestWorkerPool_NoLeakAcrossReconnectCycles` — runs 5 simulated connection cycles, each creating workers, enqueuing a message, closing the queue, and waiting; asserts goroutine count does not grow beyond baseline + 3.

## Test plan

- [ ] Run `go test ./cmd/agent_smith/...` — all tests pass including `TestWorkerPool_NoLeakAcrossReconnectCycles`
- [ ] Deploy to a machine with intermittent network connectivity, simulate 5+ MQTT disconnection/reconnection cycles, and confirm goroutine count remains stable via `go tool pprof` or `/debug/pprof/goroutine`
- [ ] Send a command after reconnection and confirm the result is posted back correctly