### PR TITLE
fix: [sc-89438] Guarantee MQTT client cleanup on all reconnect cycle exit paths

### DIFF
--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -201,129 +201,131 @@ func (svc *serviceContext) Execute(
 		// Move to the next timeout
 		rg.Next()
 
-		// Create a fresh message queue and worker pool for this connection attempt.
-		// Workers are closed and drained at every exit point so goroutines do not
-		// accumulate across reconnection cycles.
-		msgQueue := make(chan []byte, messageQueueSize)
-		var wg sync.WaitGroup
-		for i := range workerCount {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				logger.Debug("Message worker started", "worker", i)
-				for {
-					select {
-					case payload, ok := <-msgQueue:
-						if !ok {
-							logger.Debug("Message worker stopped: queue closed", "worker", i)
-							return
-						}
-						logger.Debug(
-							"Message worker processing",
-							"worker", i,
-							"queue_length", len(msgQueue),
-						)
-						svc.processMessage(payload, ctx, device, logger, notifier)
-					case <-ctx.Done():
-						logger.Debug("Message worker stopped: context cancelled", "worker", i)
+		shouldReturn, clearBackoff, exitCode := svc.runCycle(ctx, device, logger, notifier, stopped)
+		if clearBackoff {
+			rg.Clear()
+			rg.Next()
+		}
+		if shouldReturn {
+			return exitCode
+		}
+	}
+}
+
+// runCycle runs one MQTT connection attempt through to disconnect. It returns
+// (shouldReturn, clearBackoff, exitCode): shouldReturn signals Execute to exit
+// with exitCode; clearBackoff signals that a successful connection was
+// established and the reconnect backoff should be reset.
+//
+// Cleanup is guaranteed on all exit paths: drainWorkers is deferred first, then
+// client.Disconnect is deferred after the client is created (LIFO order means
+// Disconnect runs before drainWorkers).
+func (svc *serviceContext) runCycle(
+	ctx context.Context,
+	device agent.Device,
+	logger hclog.Logger,
+	notifier plugins.NotifierWrapper,
+	stopped <-chan struct{},
+) (bool, bool, service.ServiceExitCode) {
+	msgQueue := make(chan []byte, messageQueueSize)
+	var wg sync.WaitGroup
+	for i := range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logger.Debug("Message worker started", "worker", i)
+			for {
+				select {
+				case payload, ok := <-msgQueue:
+					if !ok {
+						logger.Debug("Message worker stopped: queue closed", "worker", i)
 						return
 					}
+					logger.Debug(
+						"Message worker processing",
+						"worker", i,
+						"queue_length", len(msgQueue),
+					)
+					svc.processMessage(payload, ctx, device, logger, notifier)
+				case <-ctx.Done():
+					logger.Debug("Message worker stopped: context cancelled", "worker", i)
+					return
 				}
-			}()
-		}
-		drainWorkers := func() {
-			close(msgQueue)
-			wg.Wait()
-		}
-
-		// Create a channel to wait for lost connection
-		lost := make(chan struct{}, 1)
-
-		// Create MQTT options
-		opts, err := mqtt.NewClientOptions(device)
-		if err != nil {
-			logger.Error("Failed to create client options", "error", err)
-			drainWorkers()
-			return service.GenericError
-		}
-
-		// Manually handle auto reconnection
-		opts.SetAutoReconnect(false)
-
-		// Add event handlers
-		opts.OnConnectionLost = func(client mqtt.Client, err error) {
-			logger.Error("Connection lost", "error", err)
-			lost <- struct{}{}
-		}
-
-		// Connect to the broker
-		client := mqtt.NewClient(opts)
-		token := client.Connect()
-
-		if token.Wait() && token.Error() != nil {
-			logger.Error("Failed to connect", "error", token.Error())
-			drainWorkers()
-			continue
-		}
-		disconnectQuiesce := (uint)(mqtt.DefaultDisconnectQuiesce / time.Millisecond)
-
-		// Update device twin reported properties before subscribing
-		err = mqtt.UpdateReportedProperties(client, mqtt.ReportedProperties{
-			AgentVersion: version.Version,
-		})
-		if err != nil {
-			logger.Warn("Failed to update device twin reported properties", "error", err)
-		} else {
-			logger.Info("Device twin reported properties updated", "agent_version", version.Version)
-		}
-
-		// Subscribe to the topic
-		topic := fmt.Sprintf("devices/%s/messages/devicebound/#", device.DeviceId)
-		qos := byte(1)
-		if device.MqttQos != nil {
-			qos = *device.MqttQos
-		}
-		token = client.Subscribe(topic, qos, func(client mqtt.Client, msg mqtt.Message) {
-			payload := msg.Payload()
-			select {
-			case msgQueue <- payload:
-			default:
-				logger.Warn(
-					"Message dropped: queue full",
-					"queue_size",
-					messageQueueSize,
-				)
 			}
-		})
+		}()
+	}
+	defer func() {
+		close(msgQueue)
+		wg.Wait()
+	}()
 
-		if token.Wait() && token.Error() != nil {
-			logger.Error("Failed to subscribe", "error", token.Error())
-			client.Disconnect(disconnectQuiesce)
-			drainWorkers()
-			continue
-		}
+	// Create a channel to wait for lost connection
+	lost := make(chan struct{}, 1)
 
-		// Complete initialization
-		logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
-		_ = notifier.Notify("AgentStatus:Online") // Best effort notification
+	opts, err := mqtt.NewClientOptions(device)
+	if err != nil {
+		logger.Error("Failed to create client options", "error", err)
+		return true, false, service.GenericError
+	}
 
-		// Reset the timeout
-		rg.Clear()
-		rg.Next()
+	opts.SetAutoReconnect(false)
+	opts.OnConnectionLost = func(client mqtt.Client, err error) {
+		logger.Error("Connection lost", "error", err)
+		lost <- struct{}{}
+	}
 
-		// Wait for the stop/shutdown command or lost connection
+	disconnectQuiesce := (uint)(mqtt.DefaultDisconnectQuiesce / time.Millisecond)
+	client := mqtt.NewClient(opts)
+	defer client.Disconnect(disconnectQuiesce)
+
+	token := client.Connect()
+	if token.Wait() && token.Error() != nil {
+		logger.Error("Failed to connect", "error", token.Error())
+		return false, false, 0
+	}
+
+	err = mqtt.UpdateReportedProperties(client, mqtt.ReportedProperties{
+		AgentVersion: version.Version,
+	})
+	if err != nil {
+		logger.Warn("Failed to update device twin reported properties", "error", err)
+	} else {
+		logger.Info("Device twin reported properties updated", "agent_version", version.Version)
+	}
+
+	topic := fmt.Sprintf("devices/%s/messages/devicebound/#", device.DeviceId)
+	qos := byte(1)
+	if device.MqttQos != nil {
+		qos = *device.MqttQos
+	}
+	token = client.Subscribe(topic, qos, func(client mqtt.Client, msg mqtt.Message) {
+		payload := msg.Payload()
 		select {
-		case <-stopped:
-			_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
-			client.Disconnect(disconnectQuiesce)
-			drainWorkers()
-			return 0
-		case <-lost:
-			_ = notifier.Notify("AgentStatus:Offline") // Best effort notification
-			client.Disconnect(disconnectQuiesce)
-			drainWorkers()
-			continue
+		case msgQueue <- payload:
+		default:
+			logger.Warn(
+				"Message dropped: queue full",
+				"queue_size",
+				messageQueueSize,
+			)
 		}
+	})
+
+	if token.Wait() && token.Error() != nil {
+		logger.Error("Failed to subscribe", "error", token.Error())
+		return false, false, 0
+	}
+
+	logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
+	_ = notifier.Notify("AgentStatus:Online") // Best effort notification
+
+	select {
+	case <-stopped:
+		_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
+		return true, true, 0
+	case <-lost:
+		_ = notifier.Notify("AgentStatus:Offline") // Best effort notification
+		return false, true, 0
 	}
 }
 

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -584,8 +584,9 @@ func (t *mockMQTTToken) Done() <-chan struct{} {
 func (t *mockMQTTToken) Error() error { return t.err }
 
 // mockMQTTClient implements pahomqtt.Client for testing.
-// Connect and Publish succeed; Subscribe returns subscribeErr.
+// Connect returns connectErr (nil = success); Subscribe returns subscribeErr.
 type mockMQTTClient struct {
+	connectErr   error
 	subscribeErr error
 }
 
@@ -606,7 +607,7 @@ func (m *disconnectTrackingClient) Disconnect(_ uint) {
 func (m *mockMQTTClient) IsConnected() bool      { return true }
 func (m *mockMQTTClient) IsConnectionOpen() bool { return true }
 func (m *mockMQTTClient) Connect() pahomqtt.Token {
-	return &mockMQTTToken{}
+	return &mockMQTTToken{err: m.connectErr}
 }
 func (m *mockMQTTClient) Disconnect(_ uint) {}
 func (m *mockMQTTClient) Publish(_ string, _ byte, _ bool, _ interface{}) pahomqtt.Token {
@@ -869,6 +870,77 @@ func TestExecute_DisconnectCalledOnSubscribeFailure(t *testing.T) {
 	}
 
 	// Now let Execute exit cleanly via the reconnect-wait select.
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+}
+
+// TestExecute_DisconnectCalledOnConnectFailure verifies that client.Disconnect
+// is called even when Connect() itself fails. This exercises the deferred
+// cleanup path added to fix sc-89438: the old explicit-call approach had no
+// Disconnect call on the connect-failure path, leaking TCP resources.
+func TestExecute_DisconnectCalledOnConnectFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	device := agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		LoggingLevel:         "error",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+	configBytes, _ := json.Marshal(device)
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// disconnected is sent to by the client's Disconnect method. The test
+	// receives from it *before* closing stop, proving that Disconnect fired
+	// even when Connect() returned an error (deferred cleanup).
+	disconnected := make(chan struct{}, 1)
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &disconnectTrackingClient{
+			mockMQTTClient: mockMQTTClient{connectErr: errors.New("connection refused")},
+			onDisconnect:   func() { disconnected <- struct{}{} },
+		}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	// Wait for Disconnect to be called on the failed-connect cycle before
+	// closing stop. With the old code (no Disconnect on connect failure)
+	// this would block indefinitely.
+	select {
+	case <-disconnected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client.Disconnect was not called after connect failure")
+	}
+
 	close(stop)
 
 	select {


### PR DESCRIPTION
## Summary
- Extracted the per-cycle MQTT connection body from `Execute` into a new `runCycle` method so `defer client.Disconnect()` and `defer drainWorkers()` guarantee cleanup on **every** exit path (connect failure, subscribe failure, stop signal, connection lost, and panics)
- The previous code had no `client.Disconnect()` call on the connect-failure path, leaving Paho's internal TCP/TLS resources abandoned on every failed cycle
- Added `TestExecute_DisconnectCalledOnConnectFailure` as a regression test — it receives from a `disconnected` channel *before* closing `stop`, proving `Disconnect` fires during the failed cycle via deferred cleanup

## Test plan
- [x] `TestExecute_DisconnectCalledOnConnectFailure` — new regression test; would block indefinitely against the old code
- [x] `TestExecute_DisconnectCalledOnStop` — existing test, still passes
- [x] `TestExecute_DisconnectCalledOnSubscribeFailure` — existing sc-86631 regression test, still passes
- [x] `go test ./...` — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)