### PR TITLE
feat: [sc-89424] Run service as a specific user account (--service-username / --service-password)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -612,7 +612,7 @@ jobs:
       - name: Grant Log on as a service right
         shell: pwsh
         run: |
-          $sidStr = ([System.Security.Principal.NTAccount]".\rewst_agent_it").Translate([System.Security.Principal.SecurityIdentifier]).Value
+          $sidStr = (Get-LocalUser -Name "rewst_agent_it").SID.Value
           $tmpInf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.inf'
           secedit /export /cfg $tmpInf /quiet
           $policy = Get-Content $tmpInf -Raw -Encoding Unicode

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -663,7 +663,7 @@ jobs:
         shell: pwsh
         run: |
           Start-Sleep -Seconds 15
-          $result = (Get-Content -Path "C:\RewstTest\rewst_whoami_result.txt" -Raw -ErrorAction SilentlyContinue).Trim()
+          $result = ((Get-Content -Path "C:\RewstTest\rewst_whoami_result.txt" -Raw -ErrorAction SilentlyContinue) ?? "").Trim()
           Write-Output "whoami returned: '$result'"
           if ($result -notmatch "rewst_agent_it") {
             Write-Error "Expected whoami to contain 'rewst_agent_it', got '$result'"
@@ -700,7 +700,7 @@ jobs:
         shell: pwsh
         run: |
           Start-Sleep -Seconds 15
-          $result = (Get-Content -Path "C:\RewstTest\rewst_whoami_result2.txt" -Raw -ErrorAction SilentlyContinue).Trim()
+          $result = ((Get-Content -Path "C:\RewstTest\rewst_whoami_result2.txt" -Raw -ErrorAction SilentlyContinue) ?? "").Trim()
           Write-Output "whoami returned: '$result'"
           if ($result -notmatch "rewst_agent_it") {
             Write-Error "Expected whoami to contain 'rewst_agent_it', got '$result'"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -198,6 +198,82 @@ jobs:
           fi
           echo "Error handling verified: failing command error was captured"
 
+      - name: Create service account
+        shell: bash
+        run: |
+          sudo useradd -r -s /bin/false rewst_agent_it
+          echo "Created local service account: rewst_agent_it"
+
+      - name: Update service with service account credentials
+        shell: bash
+        run: |
+          sudo ./dist/rewst_agent_config.linux.bin \
+            --update \
+            --org-id ${{ vars.IT_ORG_ID }} \
+            --service-username rewst_agent_it \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify User= directive in systemd unit file
+        shell: bash
+        run: |
+          unitFile="/etc/systemd/system/${{ steps.install_agent.outputs.service }}.service"
+          content=$(cat "$unitFile")
+          echo "$content"
+          if ! echo "$content" | grep -qF "User=rewst_agent_it"; then
+            echo "ERROR: Expected 'User=rewst_agent_it' not found in unit file"
+            exit 1
+          fi
+          echo "PASS: User=rewst_agent_it confirmed in systemd unit file"
+
+      - name: Send whoami command (service account)
+        shell: bash
+        run: |
+          sleep 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
+          --form 'commands="whoami > /tmp/rewst_whoami_result.txt"'
+
+      - name: Validate whoami output matches service account
+        shell: bash
+        run: |
+          sleep 15
+          result=$(cat /tmp/rewst_whoami_result.txt 2>/dev/null | tr -d '[:space:]')
+          echo "whoami returned: '$result'"
+          if [ "$result" != "rewst_agent_it" ]; then
+            echo "ERROR: Expected whoami to return 'rewst_agent_it', got '$result'"
+            exit 1
+          fi
+          echo "PASS: Command executed as service account 'rewst_agent_it'"
+
+      - name: Re-install agent (default system account)
+        shell: bash
+        run: |
+          sudo ./dist/rewst_agent_config.linux.bin \
+            --config-url ${{ vars.IT_CONFIG_URL }} \
+            --config-secret ${{ secrets.IT_CONFIG_SECRET }} \
+            --org-id ${{ vars.IT_ORG_ID }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send whoami command (system account)
+        shell: bash
+        run: |
+          sleep 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
+          --form 'commands="whoami > /tmp/rewst_whoami_result2.txt"'
+
+      - name: Validate whoami output matches system account
+        shell: bash
+        run: |
+          sleep 15
+          result=$(cat /tmp/rewst_whoami_result2.txt 2>/dev/null | tr -d '[:space:]')
+          echo "whoami returned: '$result'"
+          if [ "$result" != "root" ]; then
+            echo "ERROR: Expected whoami to return 'root', got '$result'"
+            exit 1
+          fi
+          echo "PASS: Command executed as default system account 'root'"
+
       - name: Install integration test binary (old version)
         shell: bash
         run: |
@@ -524,6 +600,112 @@ jobs:
             exit 1
           }
           Write-Output "Error handling verified: failing command error was captured"
+
+      - name: Create service account
+        shell: pwsh
+        run: |
+          $password = ConvertTo-SecureString "TestP@ss123!" -AsPlainText -Force
+          New-LocalUser -Name "rewst_agent_it" -Password $password -Description "Rewst IT integration test service account" -PasswordNeverExpires
+          Write-Output "Created local service account: rewst_agent_it"
+
+      - name: Grant Log on as a service right
+        shell: pwsh
+        run: |
+          $sidStr = ([System.Security.Principal.NTAccount]".\rewst_agent_it").Translate([System.Security.Principal.SecurityIdentifier]).Value
+          $tmpInf = [System.IO.Path]::GetTempFileName() -replace '\.tmp$', '.inf'
+          secedit /export /cfg $tmpInf /quiet
+          $policy = Get-Content $tmpInf -Raw -Encoding Unicode
+          if ($policy -match 'SeServiceLogonRight') {
+            $policy = $policy -replace '(SeServiceLogonRight\s*=\s*)([^\r\n]+)', "`$1`$2,*$sidStr"
+          } elseif ($policy -match '\[Privilege Rights\]') {
+            $policy = $policy -replace '(\[Privilege Rights\])', "`$1`r`nSeServiceLogonRight = *$sidStr"
+          } else {
+            $policy += "`r`n[Privilege Rights]`r`nSeServiceLogonRight = *$sidStr`r`n"
+          }
+          [System.IO.File]::WriteAllText($tmpInf, $policy, [System.Text.Encoding]::Unicode)
+          secedit /configure /db "$env:TEMP\secedit.sdb" /cfg $tmpInf /areas USER_RIGHTS /quiet
+          Remove-Item $tmpInf -Force -ErrorAction SilentlyContinue
+          Write-Output "Granted SeServiceLogonRight to rewst_agent_it ($sidStr)"
+
+      - name: Create test output directory
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force "C:\RewstTest" | Out-Null
+          icacls "C:\RewstTest" /grant "Everyone:(OI)(CI)F" | Out-Null
+          Write-Output "Created C:\RewstTest with world-writable permissions"
+
+      - name: Update service with service account credentials
+        shell: pwsh
+        run: |
+          ./dist/rewst_agent_config.win.exe --update --org-id ${{ vars.IT_ORG_ID }} --service-username ".\rewst_agent_it" --service-password "TestP@ss123!" --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify service logon account
+        shell: pwsh
+        run: |
+          $output = (sc.exe qc ${{ steps.install_agent.outputs.service }}) -join "`n"
+          Write-Output $output
+          if ($output -notmatch "rewst_agent_it") {
+            Write-Error "Expected 'rewst_agent_it' not found in sc.exe qc output"
+            exit 1
+          }
+          Write-Output "PASS: Service logon account set to rewst_agent_it"
+
+      - name: Send whoami command (service account)
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
+          --form 'commands="(whoami) | Out-File -FilePath C:\RewstTest\rewst_whoami_result.txt -Encoding utf8"'
+
+      - name: Validate whoami output matches service account
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 15
+          $result = (Get-Content -Path "C:\RewstTest\rewst_whoami_result.txt" -Raw -ErrorAction SilentlyContinue).Trim()
+          Write-Output "whoami returned: '$result'"
+          if ($result -notmatch "rewst_agent_it") {
+            Write-Error "Expected whoami to contain 'rewst_agent_it', got '$result'"
+            exit 1
+          }
+          Write-Output "PASS: Command executed as service account 'rewst_agent_it'"
+
+      - name: Re-install agent (default system account)
+        shell: pwsh
+        run: |
+          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }} 2>&1 | Tee-Object -FilePath reinstall_output.txt
+          Write-Output "Agent re-installed with default system account"
+
+      - name: Verify service logon account reverted to LocalSystem
+        shell: pwsh
+        run: |
+          $output = (sc.exe qc ${{ steps.install_agent.outputs.service }}) -join "`n"
+          Write-Output $output
+          if ($output -notmatch "LocalSystem") {
+            Write-Error "Expected 'LocalSystem' not found in sc.exe qc output after re-install"
+            exit 1
+          }
+          Write-Output "PASS: Service logon account reverted to LocalSystem"
+
+      - name: Send whoami command (system account)
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
+          --form 'commands="(whoami) | Out-File -FilePath C:\RewstTest\rewst_whoami_result2.txt -Encoding utf8"'
+
+      - name: Validate whoami output matches system account
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 15
+          $result = (Get-Content -Path "C:\RewstTest\rewst_whoami_result2.txt" -Raw -ErrorAction SilentlyContinue).Trim()
+          Write-Output "whoami returned: '$result'"
+          if ($result -notmatch "nt authority\\system") {
+            Write-Error "Expected whoami to contain 'nt authority\system', got '$result'"
+            exit 1
+          }
+          Write-Output "PASS: Command executed as default system account 'nt authority\system'"
 
       - name: Install integration test binary (old version)
         shell: pwsh
@@ -853,6 +1035,92 @@ jobs:
             exit 1
           fi
           echo "Error handling verified: failing command error was captured"
+
+      - name: Create service account
+        shell: bash
+        run: |
+          NEXT_UID=$(dscl . -list /Users UniqueID | awk '{print $2}' | sort -n | tail -1 | xargs -I{} expr {} + 1)
+          sudo dscl . -create /Users/rewst_agent_it
+          sudo dscl . -create /Users/rewst_agent_it UserShell /bin/false
+          sudo dscl . -create /Users/rewst_agent_it RealName "Rewst IT Test Account"
+          sudo dscl . -create /Users/rewst_agent_it UniqueID "$NEXT_UID"
+          sudo dscl . -create /Users/rewst_agent_it PrimaryGroupID 20
+          sudo dscl . -create /Users/rewst_agent_it NFSHomeDirectory /var/empty
+          echo "Created local service account: rewst_agent_it (UID=$NEXT_UID)"
+
+      - name: Update service with service account credentials
+        shell: bash
+        run: |
+          sudo ./dist/rewst_agent_config.mac-os.bin \
+            --update \
+            --org-id ${{ vars.IT_ORG_ID }} \
+            --service-username rewst_agent_it \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify UserName key in launchd plist
+        shell: bash
+        run: |
+          plistFile="/Library/LaunchDaemons/${{ steps.install_agent.outputs.service }}.plist"
+          content=$(cat "$plistFile")
+          echo "$content"
+          if ! echo "$content" | grep -qF "<key>UserName</key>"; then
+            echo "ERROR: Expected '<key>UserName</key>' not found in plist"
+            exit 1
+          fi
+          if ! echo "$content" | grep -qF "<string>rewst_agent_it</string>"; then
+            echo "ERROR: Expected '<string>rewst_agent_it</string>' not found in plist"
+            exit 1
+          fi
+          echo "PASS: UserName=rewst_agent_it confirmed in launchd plist"
+
+      - name: Send whoami command (service account)
+        shell: bash
+        run: |
+          sleep 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
+          --form 'commands="whoami > /tmp/rewst_whoami_result.txt"'
+
+      - name: Validate whoami output matches service account
+        shell: bash
+        run: |
+          sleep 15
+          result=$(cat /tmp/rewst_whoami_result.txt 2>/dev/null | tr -d '[:space:]')
+          echo "whoami returned: '$result'"
+          if [ "$result" != "rewst_agent_it" ]; then
+            echo "ERROR: Expected whoami to return 'rewst_agent_it', got '$result'"
+            exit 1
+          fi
+          echo "PASS: Command executed as service account 'rewst_agent_it'"
+
+      - name: Re-install agent (default system account)
+        shell: bash
+        run: |
+          sudo ./dist/rewst_agent_config.mac-os.bin \
+            --config-url ${{ vars.IT_CONFIG_URL }} \
+            --config-secret ${{ secrets.IT_CONFIG_SECRET }} \
+            --org-id ${{ vars.IT_ORG_ID }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send whoami command (system account)
+        shell: bash
+        run: |
+          sleep 10
+          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
+          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
+          --form 'commands="whoami > /tmp/rewst_whoami_result2.txt"'
+
+      - name: Validate whoami output matches system account
+        shell: bash
+        run: |
+          sleep 15
+          result=$(cat /tmp/rewst_whoami_result2.txt 2>/dev/null | tr -d '[:space:]')
+          echo "whoami returned: '$result'"
+          if [ "$result" != "root" ]; then
+            echo "ERROR: Expected whoami to return 'root', got '$result'"
+            exit 1
+          fi
+          echo "PASS: Command executed as default system account 'root'"
 
       - name: Install integration test binary (old version)
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -560,12 +560,6 @@ jobs:
           Write-Output $logContent
           Write-Output "=== End agent log ==="
 
-          Write-Output "=== Windows Application Event Log (last 30 entries) ==="
-          Get-WinEvent -LogName Application -MaxEvents 30 -ErrorAction SilentlyContinue |
-            Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message |
-            Format-List
-          Write-Output "=== End Windows Application Event Log ==="
-
           $expectedPatterns = @(
             "Command completed",
             "Sending postback",
@@ -599,7 +593,6 @@ jobs:
       - name: Check logs for error handling
         shell: pwsh
         run: |
-          Start-Sleep -Seconds 15
           $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
           $logContent = Get-Content $logFile -Raw
           Write-Output $logContent

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -663,6 +663,7 @@ jobs:
 
           try {
             $whoamiResult = whoami
+            New-Item -ItemType Directory -Force -Path \"C:\RewstTest\" | Out-Null
             $whoamiResult | Out-File -FilePath C:\RewstTest\rewst_whoami_result.txt -Encoding utf8
             $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value $whoamiResult
             $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
@@ -715,6 +716,7 @@ jobs:
 
           try {
             $whoamiResult = whoami
+            New-Item -ItemType Directory -Force -Path \"C:\RewstTest\" | Out-Null
             $whoamiResult | Out-File -FilePath C:\RewstTest\rewst_whoami_result2.txt -Encoding utf8
             $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value $whoamiResult
             $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -679,6 +679,10 @@ jobs:
         shell: pwsh
         run: |
           Start-Sleep -Seconds 15
+          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
+          Write-Output "=== Agent log ==="
+          Get-Content $logFile -ErrorAction SilentlyContinue
+          Write-Output "=== End agent log ==="
           $result = ((Get-Content -Path "C:\RewstTest\rewst_whoami_result.txt" -Raw -ErrorAction SilentlyContinue) ?? "").Trim()
           Write-Output "whoami returned: '$result'"
           if ($result -notmatch "rewst_agent_it") {
@@ -732,6 +736,10 @@ jobs:
         shell: pwsh
         run: |
           Start-Sleep -Seconds 15
+          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
+          Write-Output "=== Agent log ==="
+          Get-Content $logFile -ErrorAction SilentlyContinue
+          Write-Output "=== End agent log ==="
           $result = ((Get-Content -Path "C:\RewstTest\rewst_whoami_result2.txt" -Raw -ErrorAction SilentlyContinue) ?? "").Trim()
           Write-Output "whoami returned: '$result'"
           if ($result -notmatch "rewst_agent_it") {

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -245,16 +245,17 @@ jobs:
           fi
           echo "PASS: Command executed as service account 'rewst_agent_it'"
 
-      - name: Re-install agent (default system account)
+      - name: Re-install agent (with service account)
         shell: bash
         run: |
           sudo ./dist/rewst_agent_config.linux.bin \
             --config-url ${{ vars.IT_CONFIG_URL }} \
             --config-secret ${{ secrets.IT_CONFIG_SECRET }} \
             --org-id ${{ vars.IT_ORG_ID }} \
-            --github-token ${{ secrets.GITHUB_TOKEN }}
+            --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --service-username rewst_agent_it
 
-      - name: Send whoami command (system account)
+      - name: Send whoami command (service account after re-install)
         shell: bash
         run: |
           sleep 10
@@ -262,17 +263,17 @@ jobs:
           --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
           --form 'commands="whoami > /tmp/rewst_whoami_result2.txt"'
 
-      - name: Validate whoami output matches system account
+      - name: Validate whoami output matches service account after re-install
         shell: bash
         run: |
           sleep 15
           result=$(cat /tmp/rewst_whoami_result2.txt 2>/dev/null | tr -d '[:space:]')
           echo "whoami returned: '$result'"
-          if [ "$result" != "root" ]; then
-            echo "ERROR: Expected whoami to return 'root', got '$result'"
+          if [ "$result" != "rewst_agent_it" ]; then
+            echo "ERROR: Expected whoami to return 'rewst_agent_it', got '$result'"
             exit 1
           fi
-          echo "PASS: Command executed as default system account 'root'"
+          echo "PASS: Command executed as service account 'rewst_agent_it' after re-install"
 
       - name: Install integration test binary (old version)
         shell: bash
@@ -670,24 +671,24 @@ jobs:
           }
           Write-Output "PASS: Command executed as service account 'rewst_agent_it'"
 
-      - name: Re-install agent (default system account)
+      - name: Re-install agent (with service account)
         shell: pwsh
         run: |
-          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }} 2>&1 | Tee-Object -FilePath reinstall_output.txt
-          Write-Output "Agent re-installed with default system account"
+          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }} --service-username ".\rewst_agent_it" --service-password "TestP@ss123!" 2>&1 | Tee-Object -FilePath reinstall_output.txt
+          Write-Output "Agent re-installed with service account"
 
-      - name: Verify service logon account reverted to LocalSystem
+      - name: Verify service logon account after re-install
         shell: pwsh
         run: |
           $output = (sc.exe qc ${{ steps.install_agent.outputs.service }}) -join "`n"
           Write-Output $output
-          if ($output -notmatch "LocalSystem") {
-            Write-Error "Expected 'LocalSystem' not found in sc.exe qc output after re-install"
+          if ($output -notmatch "rewst_agent_it") {
+            Write-Error "Expected 'rewst_agent_it' not found in sc.exe qc output after re-install"
             exit 1
           }
-          Write-Output "PASS: Service logon account reverted to LocalSystem"
+          Write-Output "PASS: Service logon account is 'rewst_agent_it' after re-install"
 
-      - name: Send whoami command (system account)
+      - name: Send whoami command (service account after re-install)
         shell: pwsh
         run: |
           Start-Sleep -Seconds 10
@@ -695,17 +696,17 @@ jobs:
           --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
           --form 'commands="(whoami) | Out-File -FilePath C:\RewstTest\rewst_whoami_result2.txt -Encoding utf8"'
 
-      - name: Validate whoami output matches system account
+      - name: Validate whoami output matches service account after re-install
         shell: pwsh
         run: |
           Start-Sleep -Seconds 15
           $result = (Get-Content -Path "C:\RewstTest\rewst_whoami_result2.txt" -Raw -ErrorAction SilentlyContinue).Trim()
           Write-Output "whoami returned: '$result'"
-          if ($result -notmatch "nt authority\\system") {
-            Write-Error "Expected whoami to contain 'nt authority\system', got '$result'"
+          if ($result -notmatch "rewst_agent_it") {
+            Write-Error "Expected whoami to contain 'rewst_agent_it', got '$result'"
             exit 1
           }
-          Write-Output "PASS: Command executed as default system account 'nt authority\system'"
+          Write-Output "PASS: Command executed as service account 'rewst_agent_it' after re-install"
 
       - name: Install integration test binary (old version)
         shell: pwsh
@@ -1093,16 +1094,17 @@ jobs:
           fi
           echo "PASS: Command executed as service account 'rewst_agent_it'"
 
-      - name: Re-install agent (default system account)
+      - name: Re-install agent (with service account)
         shell: bash
         run: |
           sudo ./dist/rewst_agent_config.mac-os.bin \
             --config-url ${{ vars.IT_CONFIG_URL }} \
             --config-secret ${{ secrets.IT_CONFIG_SECRET }} \
             --org-id ${{ vars.IT_ORG_ID }} \
-            --github-token ${{ secrets.GITHUB_TOKEN }}
+            --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --service-username rewst_agent_it
 
-      - name: Send whoami command (system account)
+      - name: Send whoami command (service account after re-install)
         shell: bash
         run: |
           sleep 10
@@ -1110,17 +1112,17 @@ jobs:
           --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
           --form 'commands="whoami > /tmp/rewst_whoami_result2.txt"'
 
-      - name: Validate whoami output matches system account
+      - name: Validate whoami output matches service account after re-install
         shell: bash
         run: |
           sleep 15
           result=$(cat /tmp/rewst_whoami_result2.txt 2>/dev/null | tr -d '[:space:]')
           echo "whoami returned: '$result'"
-          if [ "$result" != "root" ]; then
-            echo "ERROR: Expected whoami to return 'root', got '$result'"
+          if [ "$result" != "rewst_agent_it" ]; then
+            echo "ERROR: Expected whoami to return 'rewst_agent_it', got '$result'"
             exit 1
           fi
-          echo "PASS: Command executed as default system account 'root'"
+          echo "PASS: Command executed as service account 'rewst_agent_it' after re-install"
 
       - name: Install integration test binary (old version)
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -657,7 +657,22 @@ jobs:
           Start-Sleep -Seconds 10
           curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
           --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="(whoami) | Out-File -FilePath C:\RewstTest\rewst_whoami_result.txt -Encoding utf8"'
+          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          $PS_Results = New-Object -TypeName psobject
+
+          try {
+            $whoamiResult = whoami
+            $whoamiResult | Out-File -FilePath C:\RewstTest\rewst_whoami_result.txt -Encoding utf8
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value $whoamiResult
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
+          } catch {
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value \"\"
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value $_.Exception.Message
+          }
+
+          $postData = $PS_Results | ConvertTo-Json
+          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
 
       - name: Validate whoami output matches service account
         shell: pwsh
@@ -694,7 +709,22 @@ jobs:
           Start-Sleep -Seconds 10
           curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
           --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="(whoami) | Out-File -FilePath C:\RewstTest\rewst_whoami_result2.txt -Encoding utf8"'
+          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          $PS_Results = New-Object -TypeName psobject
+
+          try {
+            $whoamiResult = whoami
+            $whoamiResult | Out-File -FilePath C:\RewstTest\rewst_whoami_result2.txt -Encoding utf8
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value $whoamiResult
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
+          } catch {
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value \"\"
+            $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value $_.Exception.Message
+          }
+
+          $postData = $PS_Results | ConvertTo-Json
+          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
 
       - name: Validate whoami output matches service account after re-install
         shell: pwsh

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -556,7 +556,15 @@ jobs:
         run: |
           $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
           $logContent = Get-Content $logFile -Raw
+          Write-Output "=== Agent log ==="
           Write-Output $logContent
+          Write-Output "=== End agent log ==="
+
+          Write-Output "=== Windows Application Event Log (last 30 entries) ==="
+          Get-WinEvent -LogName Application -MaxEvents 30 -ErrorAction SilentlyContinue |
+            Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message |
+            Format-List
+          Write-Output "=== End Windows Application Event Log ==="
 
           $expectedPatterns = @(
             "Command completed",
@@ -918,6 +926,11 @@ jobs:
       - name: Check Windows Event Log for command completed
         shell: pwsh
         run: |
+          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
+          Write-Output "=== Agent log ==="
+          Get-Content $logFile -ErrorAction SilentlyContinue
+          Write-Output "=== End agent log ==="
+
           $events = Get-WinEvent -LogName Application -FilterXPath "*[System[Provider[@Name='RewstRemoteAgent_${{ vars.IT_ORG_ID }}']]]"
           Write-Output "Found $($events.Count) event(s)"
           $events | ForEach-Object { Write-Output $_.Message }

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
+	"github.com/RewstApp/agent-smith-go/internal/syslog"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 )
@@ -174,6 +175,14 @@ func runConfig(params *configContext) error {
 
 	logger.Info("Configuration saved to", "path", configFilePath)
 	logger.Info("Logs will be saved to", "path", agent.GetLogFilePath(params.OrgId))
+
+	// Pre-register the Windows Event Log source while running as admin so the
+	// service can open it without needing HKLM write access (no-op on Linux/macOS).
+	if params.UseSyslog {
+		if err := syslog.EnsureSource(name); err != nil {
+			logger.Warn("Failed to pre-register event log source", "error", err)
+		}
+	}
 
 	// Create the program directory
 	programDir := agent.GetProgramDirectory(params.OrgId)

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -215,6 +215,8 @@ func runConfig(params *configContext) error {
 		OrgId:               params.OrgId,
 		ConfigFilePath:      configFilePath,
 		LogFilePath:         agent.GetLogFilePath(params.OrgId),
+		ServiceUsername:     params.ServiceUsername,
+		ServicePassword:     params.ServicePassword,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create service: %w", err)

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -215,6 +215,7 @@ func runConfig(params *configContext) error {
 		OrgId:               params.OrgId,
 		ConfigFilePath:      configFilePath,
 		LogFilePath:         agent.GetLogFilePath(params.OrgId),
+		ScriptsDirectory:    agent.GetScriptsDirectory(params.OrgId),
 		ServiceUsername:     params.ServiceUsername,
 		ServicePassword:     params.ServicePassword,
 	})

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -64,8 +64,18 @@ func newConfigContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
-	fs.StringVar(&params.ServiceUsername, "service-username", "", "User account the service runs as")
-	fs.StringVar(&params.ServicePassword, "service-password", "", "Password for the service user account (Windows only)")
+	fs.StringVar(
+		&params.ServiceUsername,
+		"service-username",
+		"",
+		"User account the service runs as",
+	)
+	fs.StringVar(
+		&params.ServicePassword,
+		"service-password",
+		"",
+		"Password for the service user account (Windows only)",
+	)
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -24,6 +24,8 @@ type configContext struct {
 	NoAutoUpdates        bool
 	GithubToken          string
 	MqttQos              int
+	ServiceUsername      string
+	ServicePassword      string
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -62,6 +64,8 @@ func newConfigContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.StringVar(&params.ServiceUsername, "service-username", "", "User account the service runs as")
+	fs.StringVar(&params.ServicePassword, "service-password", "", "Password for the service user account (Windows only)")
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -99,3 +99,41 @@ func TestNewConfigContext(t *testing.T) {
 		}
 	}
 }
+
+func TestNewConfigContext_ServiceCredentials(t *testing.T) {
+	result, err := newConfigContext(
+		[]string{
+			"--org-id", "test123",
+			"--config-url", "https://config.url/",
+			"--config-secret", "secret123",
+			"--service-username", `DOMAIN\svc_rewst`,
+			"--service-password", "p@ssw0rd",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ServiceUsername != `DOMAIN\svc_rewst` {
+		t.Errorf("expected ServiceUsername 'DOMAIN\\svc_rewst', got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "p@ssw0rd" {
+		t.Errorf("expected ServicePassword 'p@ssw0rd', got %q", result.ServicePassword)
+	}
+}
+
+func TestNewConfigContext_ServiceCredentialsDefaultEmpty(t *testing.T) {
+	result, err := newConfigContext(
+		[]string{"--org-id", "test123", "--config-url", "https://config.url/", "--config-secret", "secret123"},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ServiceUsername != "" {
+		t.Errorf("expected empty ServiceUsername by default, got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "" {
+		t.Errorf("expected empty ServicePassword by default, got %q", result.ServicePassword)
+	}
+}

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -124,8 +124,18 @@ func TestNewConfigContext_ServiceCredentials(t *testing.T) {
 
 func TestNewConfigContext_ServiceCredentialsDefaultEmpty(t *testing.T) {
 	result, err := newConfigContext(
-		[]string{"--org-id", "test123", "--config-url", "https://config.url/", "--config-secret", "secret123"},
-		nil, nil, nil, nil,
+		[]string{
+			"--org-id",
+			"test123",
+			"--config-url",
+			"https://config.url/",
+			"--config-secret",
+			"secret123",
+		},
+		nil,
+		nil,
+		nil,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -394,6 +394,54 @@ func TestRunConfig_ServiceCreateFails(t *testing.T) {
 	}
 }
 
+func TestRunConfig_ServiceCredentialsPassedToCreate(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	sm := &mockServiceManager{
+		openErr:       errors.New("no existing service"),
+		createService: &mockService{},
+	}
+	params := newBaseConfigParams(srv.URL)
+	params.ServiceUsername = `DOMAIN\svc_rewst`
+	params.ServicePassword = "p@ssw0rd"
+	params.ServiceManager = sm
+
+	err := runConfig(params)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if sm.capturedCreateParams.ServiceUsername != `DOMAIN\svc_rewst` {
+		t.Errorf("expected ServiceUsername to be passed to Create, got %q", sm.capturedCreateParams.ServiceUsername)
+	}
+	if sm.capturedCreateParams.ServicePassword != "p@ssw0rd" {
+		t.Errorf("expected ServicePassword to be passed to Create, got %q", sm.capturedCreateParams.ServicePassword)
+	}
+}
+
+func TestRunConfig_NoServiceCredentials_EmptyInCreate(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	sm := &mockServiceManager{
+		openErr:       errors.New("no existing service"),
+		createService: &mockService{},
+	}
+	params := newBaseConfigParams(srv.URL)
+	params.ServiceManager = sm
+
+	err := runConfig(params)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if sm.capturedCreateParams.ServiceUsername != "" {
+		t.Errorf("expected empty ServiceUsername when not provided, got %q", sm.capturedCreateParams.ServiceUsername)
+	}
+	if sm.capturedCreateParams.ServicePassword != "" {
+		t.Errorf("expected empty ServicePassword when not provided, got %q", sm.capturedCreateParams.ServicePassword)
+	}
+}
+
 func TestRunConfig_ServiceStartFails(t *testing.T) {
 	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
 	defer srv.Close()

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -412,10 +412,16 @@ func TestRunConfig_ServiceCredentialsPassedToCreate(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if sm.capturedCreateParams.ServiceUsername != `DOMAIN\svc_rewst` {
-		t.Errorf("expected ServiceUsername to be passed to Create, got %q", sm.capturedCreateParams.ServiceUsername)
+		t.Errorf(
+			"expected ServiceUsername to be passed to Create, got %q",
+			sm.capturedCreateParams.ServiceUsername,
+		)
 	}
 	if sm.capturedCreateParams.ServicePassword != "p@ssw0rd" {
-		t.Errorf("expected ServicePassword to be passed to Create, got %q", sm.capturedCreateParams.ServicePassword)
+		t.Errorf(
+			"expected ServicePassword to be passed to Create, got %q",
+			sm.capturedCreateParams.ServicePassword,
+		)
 	}
 }
 
@@ -435,10 +441,16 @@ func TestRunConfig_NoServiceCredentials_EmptyInCreate(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if sm.capturedCreateParams.ServiceUsername != "" {
-		t.Errorf("expected empty ServiceUsername when not provided, got %q", sm.capturedCreateParams.ServiceUsername)
+		t.Errorf(
+			"expected empty ServiceUsername when not provided, got %q",
+			sm.capturedCreateParams.ServiceUsername,
+		)
 	}
 	if sm.capturedCreateParams.ServicePassword != "" {
-		t.Errorf("expected empty ServicePassword when not provided, got %q", sm.capturedCreateParams.ServicePassword)
+		t.Errorf(
+			"expected empty ServicePassword when not provided, got %q",
+			sm.capturedCreateParams.ServicePassword,
+		)
 	}
 }
 

--- a/cmd/agent_smith/main_test.go
+++ b/cmd/agent_smith/main_test.go
@@ -109,10 +109,10 @@ func (m *mockService) Start() error   { return m.startErr }
 func (m *mockService) Close() error   { return nil }
 
 type mockServiceManager struct {
-	openErr             error
-	openService         service.Service
-	createErr           error
-	createService       service.Service
+	openErr              error
+	openService          service.Service
+	createErr            error
+	createService        service.Service
 	capturedCreateParams service.AgentParams
 }
 

--- a/cmd/agent_smith/main_test.go
+++ b/cmd/agent_smith/main_test.go
@@ -109,10 +109,11 @@ func (m *mockService) Start() error   { return m.startErr }
 func (m *mockService) Close() error   { return nil }
 
 type mockServiceManager struct {
-	openErr       error
-	openService   service.Service
-	createErr     error
-	createService service.Service
+	openErr             error
+	openService         service.Service
+	createErr           error
+	createService       service.Service
+	capturedCreateParams service.AgentParams
 }
 
 func (m *mockServiceManager) Open(name string) (service.Service, error) {
@@ -120,5 +121,6 @@ func (m *mockServiceManager) Open(name string) (service.Service, error) {
 }
 
 func (m *mockServiceManager) Create(params service.AgentParams) (service.Service, error) {
+	m.capturedCreateParams = params
 	return m.createService, m.createErr
 }

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -135,7 +135,11 @@ func runUpdate(params *updateContext) {
 	const writeRetryInterval = 3 * time.Second
 	var writeErr error
 	for attempt := range maxWriteAttempts {
-		writeErr = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
+		writeErr = params.FS.WriteFile(
+			agentExecutablePath,
+			execFileBytes,
+			utils.DefaultExecutableFileMod,
+		)
 		if writeErr == nil {
 			break
 		}
@@ -159,7 +163,13 @@ func runUpdate(params *updateContext) {
 		logger.Info("Re-registering service with new account", "username", params.ServiceUsername)
 
 		if err = svc.Delete(); err != nil {
-			logger.Error("Failed to delete service for re-registration", "service", name, "error", err)
+			logger.Error(
+				"Failed to delete service for re-registration",
+				"service",
+				name,
+				"error",
+				err,
+			)
 			_ = svc.Close()
 			return
 		}

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -119,10 +119,25 @@ func runUpdate(params *updateContext) {
 		return
 	}
 
+	// Retry the executable write: on Windows the old process holds an exe lock
+	// until it fully exits, which can happen just after the SCM reports Stopped.
 	agentExecutablePath := pathsData.AgentExecutablePath
-	err = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
-	if err != nil {
-		logger.Error("Failed to create agent executable", "error", err)
+	const maxWriteAttempts = 10
+	const writeRetryInterval = 3 * time.Second
+	var writeErr error
+	for attempt := range maxWriteAttempts {
+		writeErr = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
+		if writeErr == nil {
+			break
+		}
+		if attempt < maxWriteAttempts-1 {
+			logger.Info("Agent executable in use, retrying",
+				"attempt", attempt+1, "of", maxWriteAttempts, "error", writeErr)
+			time.Sleep(writeRetryInterval)
+		}
+	}
+	if writeErr != nil {
+		logger.Error("Failed to create agent executable", "error", writeErr)
 		_ = svc.Close()
 		return
 	}

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
+	"github.com/RewstApp/agent-smith-go/internal/syslog"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 )
@@ -103,6 +104,14 @@ func runUpdate(params *updateContext) {
 	}
 
 	logger.Info("Configuration successfully updated", "path", configFilePath)
+
+	// Pre-register the Windows Event Log source while running as admin so the
+	// service can open it without needing HKLM write access (no-op on Linux/macOS).
+	if params.UseSyslog {
+		if err := syslog.EnsureSource(name); err != nil {
+			logger.Warn("Failed to pre-register event log source", "error", err)
+		}
+	}
 
 	// Copy the agent executable
 	execFilePath, err := params.FS.Executable()

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -153,6 +153,7 @@ func runUpdate(params *updateContext) {
 			OrgId:               params.OrgId,
 			ConfigFilePath:      configFilePath,
 			LogFilePath:         agent.GetLogFilePath(params.OrgId),
+			ScriptsDirectory:    agent.GetScriptsDirectory(params.OrgId),
 			ServiceUsername:     params.ServiceUsername,
 			ServicePassword:     params.ServicePassword,
 		})

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/service"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 )
@@ -25,12 +26,6 @@ func runUpdate(params *updateContext) {
 		logger.Error("Failed to open service", "name", name, "error", err)
 		return
 	}
-	defer func() {
-		err = svc.Close()
-		if err != nil {
-			logger.Error("Failed to close service handle", "error", err)
-		}
-	}()
 
 	// Stop the service if its running
 	if svc.IsActive() {
@@ -38,6 +33,7 @@ func runUpdate(params *updateContext) {
 		err = svc.Stop()
 		if err != nil {
 			logger.Error("Failed to stop service", "service", name, "error", err)
+			_ = svc.Close()
 			return
 		}
 
@@ -56,6 +52,7 @@ func runUpdate(params *updateContext) {
 	)
 	if err != nil {
 		logger.Error("Failed to read paths", "error", err)
+		_ = svc.Close()
 		return
 	}
 
@@ -64,6 +61,7 @@ func runUpdate(params *updateContext) {
 	configFileBytes, err := params.FS.ReadFile(configFilePath)
 	if err != nil {
 		logger.Error("Failed to load config", "error", err)
+		_ = svc.Close()
 		return
 	}
 
@@ -72,6 +70,7 @@ func runUpdate(params *updateContext) {
 	err = json.Unmarshal(configFileBytes, &device)
 	if err != nil {
 		logger.Error("Failed to decode config", "error", err)
+		_ = svc.Close()
 		return
 	}
 
@@ -92,12 +91,14 @@ func runUpdate(params *updateContext) {
 	configBytes, err := json.MarshalIndent(device, "", "  ")
 	if err != nil {
 		logger.Error("Failed to print config file", "error", err)
+		_ = svc.Close()
 		return
 	}
 
 	err = params.FS.WriteFile(configFilePath, configBytes, utils.DefaultFileMod)
 	if err != nil {
 		logger.Error("Failed to save config", "error", err)
+		_ = svc.Close()
 		return
 	}
 
@@ -107,12 +108,14 @@ func runUpdate(params *updateContext) {
 	execFilePath, err := params.FS.Executable()
 	if err != nil {
 		logger.Error("Failed to get executable", "error", err)
+		_ = svc.Close()
 		return
 	}
 
 	execFileBytes, err := params.FS.ReadFile(execFilePath)
 	if err != nil {
 		logger.Error("Failed to read executable file", "error", err)
+		_ = svc.Close()
 		return
 	}
 
@@ -120,15 +123,61 @@ func runUpdate(params *updateContext) {
 	err = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
 	if err != nil {
 		logger.Error("Failed to create agent executable", "error", err)
+		_ = svc.Close()
 		return
 	}
 
 	logger.Info("Agent installed to", "path", agentExecutablePath)
 
+	// When a new service username is requested, re-register the service under the
+	// new account instead of starting the existing registration.
+	if params.ServiceUsername != "" {
+		logger.Info("Re-registering service with new account", "username", params.ServiceUsername)
+
+		if err = svc.Delete(); err != nil {
+			logger.Error("Failed to delete service for re-registration", "service", name, "error", err)
+			_ = svc.Close()
+			return
+		}
+		if err = svc.Close(); err != nil {
+			logger.Error("Failed to close service handle", "error", err)
+			return
+		}
+
+		logger.Info("Waiting for service executable to stop")
+		time.Sleep(serviceExecutableTimeout)
+
+		svc, err = params.ServiceManager.Create(service.AgentParams{
+			Name:                name,
+			AgentExecutablePath: agentExecutablePath,
+			OrgId:               params.OrgId,
+			ConfigFilePath:      configFilePath,
+			LogFilePath:         agent.GetLogFilePath(params.OrgId),
+			ServiceUsername:     params.ServiceUsername,
+			ServicePassword:     params.ServicePassword,
+		})
+		if err != nil {
+			logger.Error("Failed to re-create service", "service", name, "error", err)
+			return
+		}
+		defer func() {
+			if err := svc.Close(); err != nil {
+				logger.Error("Failed to close service handle", "error", err)
+			}
+		}()
+
+		logger.Info("Service re-registered", "service", name)
+	} else {
+		defer func() {
+			if err := svc.Close(); err != nil {
+				logger.Error("Failed to close service handle", "error", err)
+			}
+		}()
+	}
+
 	// Starting the service
 	logger.Info("Starting service", "service", name)
-	err = svc.Start()
-	if err != nil {
+	if err = svc.Start(); err != nil {
 		logger.Error("Failed to start service", "service", name, "error", err)
 		return
 	}

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -57,8 +57,18 @@ func newUpdateContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
-	fs.StringVar(&params.ServiceUsername, "service-username", "", "User account the service runs as")
-	fs.StringVar(&params.ServicePassword, "service-password", "", "Password for the service user account (Windows only)")
+	fs.StringVar(
+		&params.ServiceUsername,
+		"service-username",
+		"",
+		"User account the service runs as",
+	)
+	fs.StringVar(
+		&params.ServicePassword,
+		"service-password",
+		"",
+		"Password for the service user account (Windows only)",
+	)
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -19,6 +19,8 @@ type updateContext struct {
 	NoAutoUpdates        bool
 	GithubToken          string
 	MqttQos              int
+	ServiceUsername      string
+	ServicePassword      string
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -55,6 +57,8 @@ func newUpdateContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.StringVar(&params.ServiceUsername, "service-username", "", "User account the service runs as")
+	fs.StringVar(&params.ServicePassword, "service-password", "", "Password for the service user account (Windows only)")
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -63,3 +63,40 @@ func TestNewUpdateContext(t *testing.T) {
 		}
 	}
 }
+
+func TestNewUpdateContext_ServiceCredentials(t *testing.T) {
+	result, err := newUpdateContext(
+		[]string{
+			"--org-id", "test123",
+			"--update",
+			"--service-username", `DOMAIN\svc_rewst`,
+			"--service-password", "p@ssw0rd",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ServiceUsername != `DOMAIN\svc_rewst` {
+		t.Errorf("expected ServiceUsername 'DOMAIN\\svc_rewst', got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "p@ssw0rd" {
+		t.Errorf("expected ServicePassword 'p@ssw0rd', got %q", result.ServicePassword)
+	}
+}
+
+func TestNewUpdateContext_ServiceCredentialsDefaultEmpty(t *testing.T) {
+	result, err := newUpdateContext(
+		[]string{"--org-id", "test123", "--update"},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.ServiceUsername != "" {
+		t.Errorf("expected empty ServiceUsername by default, got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "" {
+		t.Errorf("expected empty ServicePassword by default, got %q", result.ServicePassword)
+	}
+}

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -201,10 +201,16 @@ func TestRunUpdate_ServiceUsername_ReRegistersService(t *testing.T) {
 	runUpdate(params)
 
 	if sm.capturedCreateParams.ServiceUsername != `DOMAIN\svc_rewst` {
-		t.Errorf("expected ServiceUsername to be re-registered, got %q", sm.capturedCreateParams.ServiceUsername)
+		t.Errorf(
+			"expected ServiceUsername to be re-registered, got %q",
+			sm.capturedCreateParams.ServiceUsername,
+		)
 	}
 	if sm.capturedCreateParams.ServicePassword != "p@ssw0rd" {
-		t.Errorf("expected ServicePassword to be re-registered, got %q", sm.capturedCreateParams.ServicePassword)
+		t.Errorf(
+			"expected ServicePassword to be re-registered, got %q",
+			sm.capturedCreateParams.ServicePassword,
+		)
 	}
 }
 

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -183,3 +183,78 @@ func TestRunUpdate_StartFails(t *testing.T) {
 
 	runUpdate(params)
 }
+
+// ── service re-registration tests (t.Parallel because they hit serviceExecutableTimeout) ──
+
+func TestRunUpdate_ServiceUsername_ReRegistersService(t *testing.T) {
+	t.Parallel()
+
+	sm := &mockServiceManager{
+		openService:   &mockService{isActive: false},
+		createService: &mockService{},
+	}
+	params := newBaseUpdateParams()
+	params.ServiceUsername = `DOMAIN\svc_rewst`
+	params.ServicePassword = "p@ssw0rd"
+	params.ServiceManager = sm
+
+	runUpdate(params)
+
+	if sm.capturedCreateParams.ServiceUsername != `DOMAIN\svc_rewst` {
+		t.Errorf("expected ServiceUsername to be re-registered, got %q", sm.capturedCreateParams.ServiceUsername)
+	}
+	if sm.capturedCreateParams.ServicePassword != "p@ssw0rd" {
+		t.Errorf("expected ServicePassword to be re-registered, got %q", sm.capturedCreateParams.ServicePassword)
+	}
+}
+
+func TestRunUpdate_ServiceUsername_DeleteFails(t *testing.T) {
+	params := newBaseUpdateParams()
+	params.ServiceUsername = `DOMAIN\svc_rewst`
+	params.ServiceManager = &mockServiceManager{
+		openService: &mockService{isActive: false, deleteErr: errors.New("delete failed")},
+	}
+
+	runUpdate(params) // returns early before the sleep
+}
+
+func TestRunUpdate_ServiceUsername_CreateFails(t *testing.T) {
+	t.Parallel()
+
+	params := newBaseUpdateParams()
+	params.ServiceUsername = `DOMAIN\svc_rewst`
+	params.ServiceManager = &mockServiceManager{
+		openService: &mockService{isActive: false},
+		createErr:   errors.New("create failed"),
+	}
+
+	runUpdate(params)
+}
+
+func TestRunUpdate_ServiceUsername_StartFails(t *testing.T) {
+	t.Parallel()
+
+	params := newBaseUpdateParams()
+	params.ServiceUsername = `DOMAIN\svc_rewst`
+	params.ServiceManager = &mockServiceManager{
+		openService:   &mockService{isActive: false},
+		createService: &mockService{startErr: errors.New("start failed")},
+	}
+
+	runUpdate(params)
+}
+
+func TestRunUpdate_NoServiceUsername_DoesNotCallCreate(t *testing.T) {
+	sm := &mockServiceManager{
+		openService:   &mockService{isActive: false},
+		createService: &mockService{},
+	}
+	params := newBaseUpdateParams()
+	params.ServiceManager = sm
+
+	runUpdate(params)
+
+	if sm.capturedCreateParams.ServiceUsername != "" || sm.capturedCreateParams.Name != "" {
+		t.Error("expected Create not to be called when ServiceUsername is empty")
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,6 +6,7 @@ type AgentParams struct {
 	OrgId               string
 	ConfigFilePath      string
 	LogFilePath         string
+	ScriptsDirectory    string
 	ServiceUsername     string
 	ServicePassword     string
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,6 +6,8 @@ type AgentParams struct {
 	OrgId               string
 	ConfigFilePath      string
 	LogFilePath         string
+	ServiceUsername     string
+	ServicePassword     string
 }
 
 type Service interface {

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -173,6 +173,14 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
 			return nil, err
 		}
+		if params.ScriptsDirectory != "" {
+			if err := os.MkdirAll(params.ScriptsDirectory, 0o755); err != nil {
+				return nil, err
+			}
+			if err := s.chownDir(params.ScriptsDirectory, params.ServiceUsername); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return svc, nil

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -150,7 +150,11 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.LogFilePath,
 	)
 	if params.ServiceUsername != "" {
-		fmt.Fprintf(&serviceConfig, "<key>UserName</key>\n<string>%s</string>\n", params.ServiceUsername)
+		fmt.Fprintf(
+			&serviceConfig,
+			"<key>UserName</key>\n<string>%s</string>\n",
+			params.ServiceUsername,
+		)
 	}
 	fmt.Fprintf(&serviceConfig, "<key>RunAtLoad</key>\n<false/>\n")
 	fmt.Fprintf(
@@ -170,7 +174,10 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	}
 
 	if params.ServiceUsername != "" && s.chownDir != nil {
-		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+		if err := s.chownDir(
+			filepath.Dir(params.ConfigFilePath),
+			params.ServiceUsername,
+		); err != nil {
 			return nil, err
 		}
 		if params.ScriptsDirectory != "" {

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -6,11 +6,34 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
+
+func chownR(dir, username string) error {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("user %q not found: %w", username, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return err
+	}
+	return filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(path, uid, gid)
+	})
+}
 
 type launchCtl interface {
 	Run(args ...string) ([]byte, error)
@@ -105,7 +128,8 @@ func (svc *darwinService) IsActive() bool {
 }
 
 type defaultServiceManager struct {
-	system launchCtl
+	system   launchCtl
+	chownDir func(dir, username string) error
 }
 
 func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
@@ -145,6 +169,12 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		return nil, err
 	}
 
+	if params.ServiceUsername != "" && s.chownDir != nil {
+		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+			return nil, err
+		}
+	}
+
 	return svc, nil
 }
 
@@ -162,6 +192,7 @@ func (s *defaultServiceManager) Open(name string) (Service, error) {
 
 func NewServiceManager() ServiceManager {
 	return &defaultServiceManager{
-		system: &defaultLaunchCtl{},
+		system:   &defaultLaunchCtl{},
+		chownDir: chownR,
 	}
 }

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -125,6 +125,9 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.ConfigFilePath,
 		params.LogFilePath,
 	)
+	if params.ServiceUsername != "" {
+		fmt.Fprintf(&serviceConfig, "<key>UserName</key>\n<string>%s</string>\n", params.ServiceUsername)
+	}
 	fmt.Fprintf(&serviceConfig, "<key>RunAtLoad</key>\n<false/>\n")
 	fmt.Fprintf(
 		&serviceConfig,

--- a/internal/service/service_darwin_test.go
+++ b/internal/service/service_darwin_test.go
@@ -356,3 +356,61 @@ func TestDefaultServiceManager_Open_Error(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
+
+func TestDefaultServiceManager_Create_WithServiceUsername(t *testing.T) {
+	tmpFile := newTempPlistPath(t)
+	mock := &mockLaunchCtl{plistPath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+	params := AgentParams{
+		Name:                "my-service",
+		AgentExecutablePath: "/usr/bin/agent",
+		OrgId:               "org-abc",
+		ConfigFilePath:      "/etc/agent.json",
+		LogFilePath:         "/var/log/agent.log",
+		ServiceUsername:     "rewst",
+	}
+
+	if _, err := sm.Create(params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read plist file: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "<key>UserName</key>") {
+		t.Errorf("expected plist to contain '<key>UserName</key>', got:\n%s", content)
+	}
+	if !strings.Contains(content, "<string>rewst</string>") {
+		t.Errorf("expected plist to contain '<string>rewst</string>', got:\n%s", content)
+	}
+}
+
+func TestDefaultServiceManager_Create_WithoutServiceUsername_NoUserNameKey(t *testing.T) {
+	tmpFile := newTempPlistPath(t)
+	mock := &mockLaunchCtl{plistPath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+	params := AgentParams{
+		Name:                "my-service",
+		AgentExecutablePath: "/usr/bin/agent",
+		OrgId:               "org-abc",
+		ConfigFilePath:      "/etc/agent.json",
+		LogFilePath:         "/var/log/agent.log",
+	}
+
+	if _, err := sm.Create(params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read plist file: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "<key>UserName</key>") {
+		t.Errorf("expected plist not to contain '<key>UserName</key>', got:\n%s", content)
+	}
+}

--- a/internal/service/service_darwin_test.go
+++ b/internal/service/service_darwin_test.go
@@ -414,3 +414,26 @@ func TestDefaultServiceManager_Create_WithoutServiceUsername_NoUserNameKey(t *te
 		t.Errorf("expected plist not to contain '<key>UserName</key>', got:\n%s", content)
 	}
 }
+
+func TestDefaultServiceManager_Create_ChownDirError(t *testing.T) {
+	tmpFile := newTempPlistPath(t)
+	mock := &mockLaunchCtl{plistPath: tmpFile}
+	chownErr := errors.New("chown failed")
+	sm := &defaultServiceManager{
+		system: mock,
+		chownDir: func(dir, username string) error {
+			return chownErr
+		},
+	}
+	params := AgentParams{
+		Name:            "my-service",
+		ConfigFilePath:  "/Library/Application Support/rewst/config.json",
+		ServiceUsername: "rewst",
+	}
+
+	_, err := sm.Create(params)
+
+	if err == nil {
+		t.Error("expected error from chownDir, got nil")
+	}
+}

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -6,11 +6,34 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
+
+func chownR(dir, username string) error {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("user %q not found: %w", username, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return err
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return err
+	}
+	return filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(path, uid, gid)
+	})
+}
 
 type systemCtl interface {
 	Run(args ...string) error
@@ -65,7 +88,8 @@ func (linuxSvc *linuxService) IsActive() bool {
 }
 
 type defaultServiceManager struct {
-	system systemCtl
+	system   systemCtl
+	chownDir func(dir, username string) error
 }
 
 func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
@@ -101,6 +125,12 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		return nil, err
 	}
 
+	if params.ServiceUsername != "" && s.chownDir != nil {
+		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+			return nil, err
+		}
+	}
+
 	return &linuxService{
 		name:   params.Name,
 		system: s.system,
@@ -124,6 +154,7 @@ func (s *defaultServiceManager) Open(name string) (Service, error) {
 
 func NewServiceManager() ServiceManager {
 	return &defaultServiceManager{
-		system: &defaultSystemCtl{},
+		system:   &defaultSystemCtl{},
+		chownDir: chownR,
 	}
 }

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -74,13 +74,16 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	fmt.Fprintf(&serviceConfig, "[Unit]\nDescription=%s\n\n", params.Name)
 	fmt.Fprintf(
 		&serviceConfig,
-		"[Service]\nExecStart=%s --org-id %s --config-file %s --log-file %s\nRestart=always\n\n",
+		"[Service]\nExecStart=%s --org-id %s --config-file %s --log-file %s\nRestart=always\n",
 		params.AgentExecutablePath,
 		params.OrgId,
 		params.ConfigFilePath,
 		params.LogFilePath,
 	)
-	fmt.Fprintf(&serviceConfig, "[Install]\nWantedBy=multi-user.target\n")
+	if params.ServiceUsername != "" {
+		fmt.Fprintf(&serviceConfig, "User=%s\nGroup=%s\n", params.ServiceUsername, params.ServiceUsername)
+	}
+	fmt.Fprintf(&serviceConfig, "\n[Install]\nWantedBy=multi-user.target\n")
 
 	serviceConfigFilePath := s.system.ServiceConfigFilePath(params.Name)
 	err := os.WriteFile(serviceConfigFilePath, []byte(serviceConfig.String()), utils.DefaultFileMod)

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -131,7 +131,10 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	}
 
 	if params.ServiceUsername != "" && s.chownDir != nil {
-		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+		if err := s.chownDir(
+			filepath.Dir(params.ConfigFilePath),
+			params.ServiceUsername,
+		); err != nil {
 			return nil, err
 		}
 		if params.ScriptsDirectory != "" {

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -105,7 +105,12 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.LogFilePath,
 	)
 	if params.ServiceUsername != "" {
-		fmt.Fprintf(&serviceConfig, "User=%s\nGroup=%s\n", params.ServiceUsername, params.ServiceUsername)
+		fmt.Fprintf(
+			&serviceConfig,
+			"User=%s\nGroup=%s\n",
+			params.ServiceUsername,
+			params.ServiceUsername,
+		)
 	}
 	fmt.Fprintf(&serviceConfig, "\n[Install]\nWantedBy=multi-user.target\n")
 

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -129,6 +129,14 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		if err := s.chownDir(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
 			return nil, err
 		}
+		if params.ScriptsDirectory != "" {
+			if err := os.MkdirAll(params.ScriptsDirectory, 0o755); err != nil {
+				return nil, err
+			}
+			if err := s.chownDir(params.ScriptsDirectory, params.ServiceUsername); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return &linuxService{

--- a/internal/service/service_linux_test.go
+++ b/internal/service/service_linux_test.go
@@ -357,3 +357,26 @@ func TestDefaultServiceManager_Create_WithoutServiceUsername_NoUserDirective(t *
 		t.Errorf("expected config not to contain 'User=', got:\n%s", content)
 	}
 }
+
+func TestDefaultServiceManager_Create_ChownDirError(t *testing.T) {
+	tmpFile := newTempConfigPath(t)
+	mock := &mockSystemCtl{configFilePath: tmpFile}
+	chownErr := errors.New("chown failed")
+	sm := &defaultServiceManager{
+		system: mock,
+		chownDir: func(dir, username string) error {
+			return chownErr
+		},
+	}
+	params := AgentParams{
+		Name:            "my-service",
+		ConfigFilePath:  "/etc/agent.json",
+		ServiceUsername: "rewst",
+	}
+
+	_, err := sm.Create(params)
+
+	if err == nil {
+		t.Error("expected error from chownDir, got nil")
+	}
+}

--- a/internal/service/service_linux_test.go
+++ b/internal/service/service_linux_test.go
@@ -299,3 +299,61 @@ func TestDefaultServiceManager_Open_Error(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
+
+func TestDefaultServiceManager_Create_WithServiceUsername(t *testing.T) {
+	tmpFile := newTempConfigPath(t)
+	mock := &mockSystemCtl{configFilePath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+	params := AgentParams{
+		Name:                "my-service",
+		AgentExecutablePath: "/usr/bin/agent",
+		OrgId:               "org-abc",
+		ConfigFilePath:      "/etc/agent.json",
+		LogFilePath:         "/var/log/agent.log",
+		ServiceUsername:     "rewst",
+	}
+
+	if _, err := sm.Create(params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "User=rewst") {
+		t.Errorf("expected config to contain 'User=rewst', got:\n%s", content)
+	}
+	if !strings.Contains(content, "Group=rewst") {
+		t.Errorf("expected config to contain 'Group=rewst', got:\n%s", content)
+	}
+}
+
+func TestDefaultServiceManager_Create_WithoutServiceUsername_NoUserDirective(t *testing.T) {
+	tmpFile := newTempConfigPath(t)
+	mock := &mockSystemCtl{configFilePath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+	params := AgentParams{
+		Name:                "my-service",
+		AgentExecutablePath: "/usr/bin/agent",
+		OrgId:               "org-abc",
+		ConfigFilePath:      "/etc/agent.json",
+		LogFilePath:         "/var/log/agent.log",
+	}
+
+	if _, err := sm.Create(params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "User=") {
+		t.Errorf("expected config not to contain 'User=', got:\n%s", content)
+	}
+}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -130,8 +130,10 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		config.Password = params.ServicePassword
 	}
 
-	svc, err := svcMgr.CreateService(params.Name, params.AgentExecutablePath, config,
-		"--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath)
+	svc, err := svcMgr.CreateService(
+		params.Name, params.AgentExecutablePath, config,
+		"--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -132,7 +132,9 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 
 	svc, err := svcMgr.CreateService(
 		params.Name, params.AgentExecutablePath, config,
-		"--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath,
+		"--org-id", params.OrgId,
+		"--config-file", params.ConfigFilePath,
+		"--log-file", params.LogFilePath,
 	)
 	if err != nil {
 		return nil, err
@@ -142,7 +144,10 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		if err := s.grantAccess(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
 			return nil, fmt.Errorf("failed to grant access to data directory: %w", err)
 		}
-		if err := s.grantAccess(filepath.Dir(params.AgentExecutablePath), params.ServiceUsername); err != nil {
+		if err := s.grantAccess(
+			filepath.Dir(params.AgentExecutablePath),
+			params.ServiceUsername,
+		); err != nil {
 			return nil, fmt.Errorf("failed to grant access to program directory: %w", err)
 		}
 		if params.ScriptsDirectory != "" {

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/windows/svc"
@@ -18,6 +19,12 @@ import (
 func icaclsGrantFullControl(dir, username string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
+	}
+	// icacls does not resolve .\ on all runners; expand to COMPUTERNAME\
+	if strings.HasPrefix(username, `.\`) {
+		if computerName := os.Getenv("COMPUTERNAME"); computerName != "" {
+			username = computerName + username[1:]
+		}
 	}
 	cmd := exec.Command("icacls", dir, "/grant", fmt.Sprintf("%s:(OI)(CI)F", username), "/T", "/Q")
 	out, err := cmd.CombinedOutput()

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -97,11 +97,18 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	}
 	defer func() { _ = svcMgr.Disconnect() }() // Cleanup - error can be ignored
 
-	svc, err := svcMgr.CreateService(params.Name, params.AgentExecutablePath, mgr.Config{
+	config := mgr.Config{
 		StartType:        mgr.StartAutomatic,
 		Description:      fmt.Sprintf("Rewst Remote Agent for Org %s", params.OrgId),
 		DelayedAutoStart: true,
-	}, "--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath)
+	}
+	if params.ServiceUsername != "" {
+		config.ServiceStartName = params.ServiceUsername
+		config.Password = params.ServicePassword
+	}
+
+	svc, err := svcMgr.CreateService(params.Name, params.AgentExecutablePath, config,
+		"--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -141,7 +141,10 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	}
 
 	if params.ServiceUsername != "" && s.grantAccess != nil {
-		if err := s.grantAccess(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+		if err := s.grantAccess(
+			filepath.Dir(params.ConfigFilePath),
+			params.ServiceUsername,
+		); err != nil {
 			return nil, fmt.Errorf("failed to grant access to data directory: %w", err)
 		}
 		if err := s.grantAccess(

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -6,11 +6,26 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
+
+func icaclsGrantFullControl(dir, username string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	cmd := exec.Command("icacls", dir, "/grant", fmt.Sprintf("%s:(OI)(CI)F", username), "/T", "/Q")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("icacls: %s", out)
+	}
+	return nil
+}
 
 const pollingInterval = 250 * time.Millisecond
 
@@ -87,7 +102,8 @@ func (f *defaultWindowsServiceManagerFactory) Connect() (windowsServiceManager, 
 }
 
 type defaultServiceManager struct {
-	factory windowsServiceManagerFactory
+	factory     windowsServiceManagerFactory
+	grantAccess func(dir, username string) error
 }
 
 func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
@@ -111,6 +127,17 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		"--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params.ServiceUsername != "" && s.grantAccess != nil {
+		if err := s.grantAccess(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
+			return nil, fmt.Errorf("failed to grant access to data directory: %w", err)
+		}
+		if params.ScriptsDirectory != "" {
+			if err := s.grantAccess(params.ScriptsDirectory, params.ServiceUsername); err != nil {
+				return nil, fmt.Errorf("failed to grant access to scripts directory: %w", err)
+			}
+		}
 	}
 
 	return &windowsService{
@@ -137,7 +164,8 @@ func (s *defaultServiceManager) Open(name string) (Service, error) {
 
 func NewServiceManager() ServiceManager {
 	return &defaultServiceManager{
-		factory: &defaultWindowsServiceManagerFactory{},
+		factory:     &defaultWindowsServiceManagerFactory{},
+		grantAccess: icaclsGrantFullControl,
 	}
 }
 

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -140,6 +140,9 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		if err := s.grantAccess(filepath.Dir(params.ConfigFilePath), params.ServiceUsername); err != nil {
 			return nil, fmt.Errorf("failed to grant access to data directory: %w", err)
 		}
+		if err := s.grantAccess(filepath.Dir(params.AgentExecutablePath), params.ServiceUsername); err != nil {
+			return nil, fmt.Errorf("failed to grant access to program directory: %w", err)
+		}
 		if params.ScriptsDirectory != "" {
 			if err := s.grantAccess(params.ScriptsDirectory, params.ServiceUsername); err != nil {
 				return nil, fmt.Errorf("failed to grant access to scripts directory: %w", err)

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -347,6 +347,27 @@ func TestDefaultServiceManager_Create_WithoutServiceUsername_NoCredentials(t *te
 	}
 }
 
+func TestDefaultServiceManager_Create_GrantAccessError(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	grantErr := errors.New("icacls failed")
+	sm := &defaultServiceManager{
+		factory: factory,
+		grantAccess: func(dir, username string) error {
+			return grantErr
+		},
+	}
+
+	_, err := sm.Create(AgentParams{
+		ConfigFilePath:  `C:\ProgramData\Rewst\config.json`,
+		ServiceUsername: `.\rewst_agent_it`,
+	})
+
+	if err == nil {
+		t.Error("expected error from grantAccess, got nil")
+	}
+}
+
 func TestDefaultServiceManager_Create_DisconnectsOnSuccess(t *testing.T) {
 	manager := &mockWindowsServiceManager{}
 	factory := &mockWindowsServiceManagerFactory{manager: manager}

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -415,7 +415,6 @@ func TestDefaultServiceManager_Create_GrantsAllDirectories(t *testing.T) {
 		ScriptsDirectory:    `C:\RewstRemoteAgent\scripts\org1`,
 		ServiceUsername:     `.\rewst_agent_it`,
 	})
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -368,6 +368,62 @@ func TestDefaultServiceManager_Create_GrantAccessError(t *testing.T) {
 	}
 }
 
+func TestDefaultServiceManager_Create_GrantAccessError_ProgramDir(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	callCount := 0
+	sm := &defaultServiceManager{
+		factory: factory,
+		grantAccess: func(dir, username string) error {
+			callCount++
+			if callCount == 2 {
+				return errors.New("icacls program dir failed")
+			}
+			return nil
+		},
+	}
+
+	_, err := sm.Create(AgentParams{
+		ConfigFilePath:      `C:\ProgramData\Rewst\config.json`,
+		AgentExecutablePath: `C:\Program Files\Rewst\agent_smith.exe`,
+		ServiceUsername:     `.\rewst_agent_it`,
+	})
+
+	if err == nil {
+		t.Error("expected error from program dir grantAccess, got nil")
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 grantAccess calls before failure, got %d", callCount)
+	}
+}
+
+func TestDefaultServiceManager_Create_GrantsAllDirectories(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	var grantedDirs []string
+	sm := &defaultServiceManager{
+		factory: factory,
+		grantAccess: func(dir, username string) error {
+			grantedDirs = append(grantedDirs, dir)
+			return nil
+		},
+	}
+
+	_, err := sm.Create(AgentParams{
+		ConfigFilePath:      `C:\ProgramData\Rewst\config.json`,
+		AgentExecutablePath: `C:\Program Files\Rewst\agent_smith.exe`,
+		ScriptsDirectory:    `C:\RewstRemoteAgent\scripts\org1`,
+		ServiceUsername:     `.\rewst_agent_it`,
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(grantedDirs) != 3 {
+		t.Errorf("expected 3 grantAccess calls, got %d: %v", len(grantedDirs), grantedDirs)
+	}
+}
+
 func TestDefaultServiceManager_Create_DisconnectsOnSuccess(t *testing.T) {
 	manager := &mockWindowsServiceManager{}
 	factory := &mockWindowsServiceManagerFactory{manager: manager}

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -323,7 +323,10 @@ func TestDefaultServiceManager_Create_WithServiceUsername(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if manager.capturedConfig.ServiceStartName != `DOMAIN\svc_rewst` {
-		t.Errorf("expected ServiceStartName 'DOMAIN\\svc_rewst', got %q", manager.capturedConfig.ServiceStartName)
+		t.Errorf(
+			"expected ServiceStartName 'DOMAIN\\svc_rewst', got %q",
+			manager.capturedConfig.ServiceStartName,
+		)
 	}
 	if manager.capturedConfig.Password != "p@ssw0rd" {
 		t.Errorf("expected Password 'p@ssw0rd', got %q", manager.capturedConfig.Password)

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -343,7 +343,10 @@ func TestDefaultServiceManager_Create_WithoutServiceUsername_NoCredentials(t *te
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if manager.capturedConfig.ServiceStartName != "" {
-		t.Errorf("expected empty ServiceStartName when not provided, got %q", manager.capturedConfig.ServiceStartName)
+		t.Errorf(
+			"expected empty ServiceStartName when not provided, got %q",
+			manager.capturedConfig.ServiceStartName,
+		)
 	}
 	if manager.capturedConfig.Password != "" {
 		t.Errorf("expected empty Password when not provided, got %q", manager.capturedConfig.Password)

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -64,9 +64,10 @@ func (m *mockWindowsServiceHandle) Query() (svc.Status, error) {
 // mockWindowsServiceManager
 
 type mockWindowsServiceManager struct {
-	createErr    error
-	openErr      error
-	disconnected bool
+	createErr      error
+	openErr        error
+	disconnected   bool
+	capturedConfig mgr.Config
 }
 
 func (m *mockWindowsServiceManager) Disconnect() error {
@@ -79,6 +80,7 @@ func (m *mockWindowsServiceManager) CreateService(
 	c mgr.Config,
 	args ...string,
 ) (*mgr.Service, error) {
+	m.capturedConfig = c
 	return nil, m.createErr
 }
 
@@ -305,6 +307,43 @@ func TestDefaultServiceManager_Create_CreateServiceError(t *testing.T) {
 	}
 	if !manager.disconnected {
 		t.Error("expected Disconnect to be called on error")
+	}
+}
+
+func TestDefaultServiceManager_Create_WithServiceUsername(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	sm := &defaultServiceManager{factory: factory}
+
+	_, err := sm.Create(AgentParams{
+		ServiceUsername: `DOMAIN\svc_rewst`,
+		ServicePassword: "p@ssw0rd",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manager.capturedConfig.ServiceStartName != `DOMAIN\svc_rewst` {
+		t.Errorf("expected ServiceStartName 'DOMAIN\\svc_rewst', got %q", manager.capturedConfig.ServiceStartName)
+	}
+	if manager.capturedConfig.Password != "p@ssw0rd" {
+		t.Errorf("expected Password 'p@ssw0rd', got %q", manager.capturedConfig.Password)
+	}
+}
+
+func TestDefaultServiceManager_Create_WithoutServiceUsername_NoCredentials(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	sm := &defaultServiceManager{factory: factory}
+
+	_, err := sm.Create(AgentParams{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manager.capturedConfig.ServiceStartName != "" {
+		t.Errorf("expected empty ServiceStartName when not provided, got %q", manager.capturedConfig.ServiceStartName)
+	}
+	if manager.capturedConfig.Password != "" {
+		t.Errorf("expected empty Password when not provided, got %q", manager.capturedConfig.Password)
 	}
 }
 

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -349,7 +349,10 @@ func TestDefaultServiceManager_Create_WithoutServiceUsername_NoCredentials(t *te
 		)
 	}
 	if manager.capturedConfig.Password != "" {
-		t.Errorf("expected empty Password when not provided, got %q", manager.capturedConfig.Password)
+		t.Errorf(
+			"expected empty Password when not provided, got %q",
+			manager.capturedConfig.Password,
+		)
 	}
 }
 

--- a/internal/syslog/syslog_darwin.go
+++ b/internal/syslog/syslog_darwin.go
@@ -51,6 +51,8 @@ func New(name string, out io.Writer) (Syslog, error) {
 	return newWithRunner(name, out, &loggerCommandRunner{}), nil
 }
 
+func EnsureSource(_ string) error { return nil }
+
 func newWithRunner(name string, out io.Writer, runner commandRunner) Syslog {
 	return &darwinSyslog{out: out, source: name, runner: runner}
 }

--- a/internal/syslog/syslog_linux.go
+++ b/internal/syslog/syslog_linux.go
@@ -51,6 +51,8 @@ func New(name string, out io.Writer) (Syslog, error) {
 	return newWithRunner(name, out, &loggerCommandRunner{}), nil
 }
 
+func EnsureSource(_ string) error { return nil }
+
 func newWithRunner(name string, out io.Writer, runner commandRunner) Syslog {
 	return &linuxSyslog{out: out, source: name, runner: runner}
 }

--- a/internal/syslog/syslog_windows.go
+++ b/internal/syslog/syslog_windows.go
@@ -91,9 +91,10 @@ func newWithFactory(name string, out io.Writer, factory eventLogFactory) (Syslog
 		}
 	} else if errors.Is(err, registry.ErrNotExist) ||
 		errors.Is(err, syscall.ERROR_PATH_NOT_FOUND) {
-		if err = factory.Install(name); err != nil {
-			return nil, err
-		}
+		// Best-effort: service accounts without HKLM write access can't install the
+		// source, but RegisterEventSource still works — events appear in the log
+		// without a message DLL. The admin-side commands pre-register via EnsureSource.
+		_ = factory.Install(name)
 	} else {
 		return nil, err
 	}
@@ -104,4 +105,21 @@ func newWithFactory(name string, out io.Writer, factory eventLogFactory) (Syslog
 	}
 
 	return &windowsSyslog{out: out, log: log}, nil
+}
+
+// EnsureSource pre-registers the Windows Event Log source while the process has
+// admin rights so the service can open it without needing HKLM write access.
+func EnsureSource(name string) error {
+	return ensureSourceWithFactory(name, &windowsEventLogFactory{})
+}
+
+func ensureSourceWithFactory(name string, factory eventLogFactory) error {
+	k, err := factory.OpenKey(name)
+	if err == nil {
+		return k.Close()
+	}
+	if errors.Is(err, registry.ErrNotExist) || errors.Is(err, syscall.ERROR_PATH_NOT_FOUND) {
+		return factory.Install(name)
+	}
+	return err
 }

--- a/internal/syslog/syslog_windows_test.go
+++ b/internal/syslog/syslog_windows_test.go
@@ -265,7 +265,6 @@ func TestEnsureSourceWithFactory_KeyExists_SkipsInstall(t *testing.T) {
 	factory := &mockEventLogFactory{}
 
 	err := ensureSourceWithFactory("test", factory)
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -280,7 +279,6 @@ func TestEnsureSourceWithFactory_KeyNotExist_Installs(t *testing.T) {
 	}
 
 	err := ensureSourceWithFactory("test", factory)
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/syslog/syslog_windows_test.go
+++ b/internal/syslog/syslog_windows_test.go
@@ -250,7 +250,6 @@ func TestNewWithFactory_InstallError_ProceedsToOpen(t *testing.T) {
 	}
 
 	syslogger, err := newWithFactory("test", &bytes.Buffer{}, factory)
-
 	if err != nil {
 		t.Fatalf("expected no error when install fails, got %v", err)
 	}

--- a/internal/syslog/syslog_windows_test.go
+++ b/internal/syslog/syslog_windows_test.go
@@ -241,19 +241,77 @@ func TestNewWithFactory_OpenKeyUnknownError_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestNewWithFactory_InstallError_ReturnsError(t *testing.T) {
+func TestNewWithFactory_InstallError_ProceedsToOpen(t *testing.T) {
+	logger := &mockEventLogger{}
+	factory := &mockEventLogFactory{
+		openKeyErr: registry.ErrNotExist,
+		installErr: errors.New("access denied"),
+		openResult: logger,
+	}
+
+	syslogger, err := newWithFactory("test", &bytes.Buffer{}, factory)
+
+	if err != nil {
+		t.Fatalf("expected no error when install fails, got %v", err)
+	}
+	if syslogger == nil {
+		t.Fatal("expected non-nil Syslog even when install fails")
+	}
+	if !factory.installCalled {
+		t.Error("expected Install to be attempted")
+	}
+}
+
+func TestEnsureSourceWithFactory_KeyExists_SkipsInstall(t *testing.T) {
+	factory := &mockEventLogFactory{}
+
+	err := ensureSourceWithFactory("test", factory)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if factory.installCalled {
+		t.Error("expected Install not to be called when key already exists")
+	}
+}
+
+func TestEnsureSourceWithFactory_KeyNotExist_Installs(t *testing.T) {
+	factory := &mockEventLogFactory{
+		openKeyErr: registry.ErrNotExist,
+	}
+
+	err := ensureSourceWithFactory("test", factory)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !factory.installCalled {
+		t.Error("expected Install to be called when key does not exist")
+	}
+}
+
+func TestEnsureSourceWithFactory_InstallError_ReturnsError(t *testing.T) {
 	factory := &mockEventLogFactory{
 		openKeyErr: registry.ErrNotExist,
 		installErr: errors.New("install failed"),
 	}
 
-	_, err := newWithFactory("test", &bytes.Buffer{}, factory)
+	err := ensureSourceWithFactory("test", factory)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if err.Error() != "install failed" {
-		t.Errorf("expected 'install failed', got %q", err.Error())
+}
+
+func TestEnsureSourceWithFactory_OtherKeyError_ReturnsError(t *testing.T) {
+	factory := &mockEventLogFactory{
+		openKeyErr: errors.New("unexpected registry error"),
+	}
+
+	err := ensureSourceWithFactory("test", factory)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--service-username` and `--service-password` flags to the `--config` and `--update` commands so the agent service can be registered under a specific OS user account instead of the default `LocalSystem`/`root`
- On Windows: grants the service account full control of the data directory, program directory, and scripts directory via `icacls`, and pre-registers the Windows Event Log source while running as admin so a restricted account can write syslog events without HKLM write access
- On Linux/macOS: recursively chowns the data directory and scripts directory to the service account after service creation

## Changes

**Core feature**
- `cmd/agent_smith/config.go` / `update.go` — pass `ServiceUsername` / `ServicePassword` through to `ServiceManager.Create()`; call `syslog.EnsureSource()` when `--syslog` is set
- `internal/service/service.go` — adds `ServiceUsername`, `ServicePassword`, `ScriptsDirectory` to `AgentParams`
- `internal/service/service_windows.go` — `icaclsGrantFullControl` helper; grants data dir, program dir, and scripts dir; expands `.\username` to `COMPUTERNAME\username` for icacls
- `internal/service/service_linux.go` / `service_darwin.go` — `chownR` helper; chowns data dir and scripts dir to the service account

**Syslog resilience (Windows)**
- `internal/syslog/syslog_windows.go` — `Install()` is now best-effort in `newWithFactory` (restricted accounts can't write HKLM but `RegisterEventSource` works without a registered source); adds `EnsureSource()` for pre-registration from admin commands
- `internal/syslog/syslog_linux.go` / `syslog_darwin.go` — no-op `EnsureSource()` stubs

**Retry on Windows exe file lock**
- `cmd/agent_smith/update.go` — retries the agent executable write up to 10 times at 3-second intervals to handle the Windows process exe lock that persists briefly after the SCM reports `Stopped`

**Integration tests**
- All three platform jobs now include: create service account → update with `--service-username` → verify service logon → send whoami → validate output → re-install with `--service-username` → verify again

## Test plan

- [ ] `go test ./...` passes locally
- [ ] CI integration tests pass on all three platform jobs (`test-ubuntu-latest`, `test-macos-latest`, `test-windows-latest`)
- [ ] Windows: service logon account confirmed as `rewst_agent_it` via `sc.exe qc` after `--update --service-username`
- [ ] Windows: whoami command returns `rewst_agent_it` after both update and re-install
- [ ] Windows: syslog events appear in Windows Event Log after `--update --syslog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)