### PR TITLE
feat: [sc-89411] Add host information option to diagnostic mode

### DIFF
--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -496,7 +496,13 @@ func runHostInfo(ctx context.Context, params *diagnosticContext, target agentInf
 		return
 	}
 
-	info, err := agent.NewHostInfo(ctx, target.OrgId, hclog.NewNullLogger(), params.Sys, params.Domain)
+	info, err := agent.NewHostInfo(
+		ctx,
+		target.OrgId,
+		hclog.NewNullLogger(),
+		params.Sys,
+		params.Domain,
+	)
 	if err != nil {
 		printResult(false, fmt.Sprintf("Failed to gather host information: %v", err))
 		return

--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/version"
+	"github.com/hashicorp/go-hclog"
 )
 
 // tlsDialer abstracts TLS connectivity checks so tests can inject fakes.
@@ -125,7 +126,9 @@ func runDiagnosticFull(
 		case "5":
 			runLiveLogsWith(ctx, target, opener)
 		case "6":
-			runAllChecksWith(params, agents, target, dialer)
+			runAllChecksWith(ctx, params, agents, target, dialer)
+		case "7":
+			runHostInfo(ctx, params, target)
 		case "0", "q", "quit", "exit":
 			fmt.Println("\n  Exiting diagnostic mode.")
 			return
@@ -155,6 +158,7 @@ func printMenu() {
 	fmt.Println("  │  [4] Test temp directory write access            │")
 	fmt.Println("  │  [5] View live log data                          │")
 	fmt.Println("  │  [6] Run all checks                              │")
+	fmt.Println("  │  [7] Show host information                       │")
 	fmt.Println("  │  [0] Exit                                        │")
 	fmt.Println("  └──────────────────────────────────────────────────┘")
 }
@@ -469,6 +473,7 @@ func runLiveLogsWith(ctx context.Context, target agentInfo, opener logFileOpener
 // ── Check 6: Run all checks ──
 
 func runAllChecksWith(
+	ctx context.Context,
 	params *diagnosticContext,
 	agents []agentInfo,
 	target agentInfo,
@@ -478,6 +483,53 @@ func runAllChecksWith(
 	runCommandTest()
 	runConnectivityTestWith(target, dialer)
 	runTempDirTest(target)
+	runHostInfo(ctx, params, target)
+}
+
+// ── Check 7: Host information ──
+
+func runHostInfo(ctx context.Context, params *diagnosticContext, target agentInfo) {
+	printSection("Host Information")
+
+	if params.Sys == nil || params.Domain == nil {
+		printResult(false, "System or domain provider not available")
+		return
+	}
+
+	info, err := agent.NewHostInfo(ctx, target.OrgId, hclog.NewNullLogger(), params.Sys, params.Domain)
+	if err != nil {
+		printResult(false, fmt.Sprintf("Failed to gather host information: %v", err))
+		return
+	}
+
+	printResult(true, "Host information collected")
+	fmt.Printf("      Hostname:                 %s\n", strOrNA(info.HostName))
+	fmt.Printf("      MAC Address:              %s\n", ptrOrNA(info.MacAddress))
+	fmt.Printf("      Operating System:         %s\n", strOrNA(info.OperatingSystem))
+	fmt.Printf("      CPU Model:                %s\n", strOrNA(info.CpuModel))
+	fmt.Printf("      RAM (GB):                 %s\n", strOrNA(info.RamGb))
+	fmt.Printf("      Agent Version:            %s\n", strOrNA(info.AgentVersion))
+	fmt.Printf("      Agent Executable Path:    %s\n", strOrNA(info.AgentExecutablePath))
+	fmt.Printf("      Service Executable Path:  %s\n", strOrNA(info.ServiceExecutablePath))
+	fmt.Printf("      AD Domain:                %s\n", ptrOrNA(info.AdDomain))
+	fmt.Printf("      AD Domain Controller:     %v\n", info.IsAdDomainController)
+	fmt.Printf("      Entra Connect Server:     %v\n", info.IsEntraConnectServer)
+	fmt.Printf("      Entra Domain:             %s\n", ptrOrNA(info.EntraDomain))
+	fmt.Printf("      Org ID:                   %s\n", strOrNA(info.OrgId))
+}
+
+func strOrNA(s string) string {
+	if s == "" {
+		return "N/A"
+	}
+	return s
+}
+
+func ptrOrNA(s *string) string {
+	if s == nil || *s == "" {
+		return "N/A"
+	}
+	return *s
 }
 
 // ── Formatting helpers ──

--- a/cmd/agent_smith/diagnostic_test.go
+++ b/cmd/agent_smith/diagnostic_test.go
@@ -356,6 +356,8 @@ func TestRunDiagnosticWith_Option5_LiveLogs(t *testing.T) {
 
 func TestRunDiagnosticWith_Option6_AllChecks(t *testing.T) {
 	params := newDiagnosticParams("org-diag-opt6")
+	params.Sys = &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"}
+	params.Domain = &mockDomainInfoProvider{}
 	runDiag(t, params, "6\n0\n", &mockTLSDialer{result: true}, &mockLogFileOpener{content: "log\n"})
 	_ = os.RemoveAll(agent.GetScriptsDirectory(params.OrgId))
 }
@@ -392,6 +394,8 @@ func TestRunDiagnosticWith_AgentSelectionFromScan(t *testing.T) {
 func TestRunAllChecksWith(t *testing.T) {
 	params := &diagnosticContext{
 		ServiceManager: &mockServiceManager{openService: &mockService{isActive: false}},
+		Sys:            &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"},
+		Domain:         &mockDomainInfoProvider{},
 	}
 	agents := []agentInfo{{OrgId: "org-1", ServiceName: "svc-1"}}
 	target := agentInfo{
@@ -399,6 +403,85 @@ func TestRunAllChecksWith(t *testing.T) {
 		LogFile: "fake.log",
 		Device:  &agent.Device{AzureIotHubHost: "hub.example.com"},
 	}
-	runAllChecksWith(params, agents, target, &mockTLSDialer{result: true})
+	runAllChecksWith(context.Background(), params, agents, target, &mockTLSDialer{result: true})
 	_ = os.RemoveAll(agent.GetScriptsDirectory(target.OrgId))
+}
+
+// ── runHostInfo ───────────────────────────────────────────────────────────────
+
+func TestRunHostInfo_Success(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:ff"
+	adDomain := "example.local"
+	entraDomain := "example.onmicrosoft.com"
+	params := &diagnosticContext{
+		Sys: &mockSystemInfoProvider{
+			hostname:         "test-host",
+			hostPlatform:     "linux",
+			cpuModelName:     "Test CPU",
+			totalMemoryBytes: 8 * 1024 * 1024 * 1024,
+			macAddress:       &mac,
+		},
+		Domain: &mockDomainInfoProvider{
+			adDomain:             &adDomain,
+			isAdDomainController: true,
+			isEntraConnectServer: false,
+			entraDomain:          &entraDomain,
+		},
+	}
+	runHostInfo(context.Background(), params, agentInfo{OrgId: "org-1"})
+}
+
+func TestRunHostInfo_NilDomainPointers(t *testing.T) {
+	// Linux/macOS scenario: AD/Entra fields return nil → should display N/A
+	params := &diagnosticContext{
+		Sys: &mockSystemInfoProvider{
+			hostname:         "linux-host",
+			hostPlatform:     "linux",
+			cpuModelName:     "Test CPU",
+			totalMemoryBytes: 4 * 1024 * 1024 * 1024,
+		},
+		Domain: &mockDomainInfoProvider{},
+	}
+	runHostInfo(context.Background(), params, agentInfo{OrgId: "org-1"})
+}
+
+func TestRunHostInfo_DomainProviderErrors(t *testing.T) {
+	// Domain provider errors should be logged (and swallowed) by NewHostInfo,
+	// not aborting the diagnostic output.
+	params := &diagnosticContext{
+		Sys: &mockSystemInfoProvider{
+			hostname:         "host",
+			hostPlatform:     "windows",
+			cpuModelName:     "CPU",
+			totalMemoryBytes: 1024 * 1024 * 1024,
+		},
+		Domain: &mockDomainInfoProvider{
+			adDomainErr:             errors.New("ad lookup failed"),
+			isAdDomainControllerErr: errors.New("dc lookup failed"),
+			isEntraConnectServerErr: errors.New("entra connect failed"),
+			entraDomainErr:          errors.New("entra domain failed"),
+		},
+	}
+	runHostInfo(context.Background(), params, agentInfo{OrgId: "org-1"})
+}
+
+func TestRunHostInfo_SystemProviderError(t *testing.T) {
+	// A system info error (e.g. HostPlatform) should surface as a single
+	// failure line rather than panicking.
+	params := &diagnosticContext{
+		Sys:    &mockSystemInfoProvider{hostPlatformErr: errors.New("platform error")},
+		Domain: &mockDomainInfoProvider{},
+	}
+	runHostInfo(context.Background(), params, agentInfo{OrgId: "org-1"})
+}
+
+func TestRunHostInfo_NilProviders(t *testing.T) {
+	runHostInfo(context.Background(), &diagnosticContext{}, agentInfo{OrgId: "org-1"})
+}
+
+func TestRunDiagnosticWith_Option7_HostInfo(t *testing.T) {
+	params := newDiagnosticParams("org-1")
+	params.Sys = &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"}
+	params.Domain = &mockDomainInfoProvider{}
+	runDiag(t, params, "7\n0\n", &mockTLSDialer{}, &mockLogFileOpener{})
 }


### PR DESCRIPTION
## Summary
- Adds menu option `[7] Show host information` to diagnostic mode, displaying every `HostInfo` field collected by `agent.NewHostInfo()` (hostname, MAC, OS, CPU, RAM, paths, AD/Entra fields, org id) in a human-readable layout.
- Fields that are unavailable on the current platform (e.g. AD/Entra on Linux/macOS) or returned as nil/empty render as `N/A` instead of aborting.
- Threads `context.Context` through `runAllChecksWith` and includes the new host-info section in `[6] Run all checks`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Windows AD-joined: run `rewst_agent_config.win.exe --diagnostic` → option `[7]` shows populated `ad_domain`, `is_ad_domain_controller`, `is_entra_connect_server`
- [x] Linux: option `[7]` displays `N/A` for AD/Entra fields with no errors
- [x] macOS: same `N/A` handling as Linux
- [x] Option `[6]` includes the host information section after the existing checks
- [x] Cross-check `cpu_model`, `ram_gb`, `hostname`, `mac_address`, `operating_system` against `uname` / `sysctl` / `wmic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)