### PR TITLE
fix: [sc-89442] Combine temp file Close and Remove into single deferred cleanup

### DIFF
--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -101,17 +102,17 @@ func (e *baseExecutor) Execute(
 		return errorResultBytes(logger, err)
 	}
 
-	// Defers run LIFO — Close runs before Remove, which is required on Windows
-	// where an open handle prevents the file from being deleted.
+	// Single cleanup: close the handle (Windows blocks Remove on open files), then
+	// remove the file. Runs on every exit path. ErrClosed is expected on the success
+	// path because we close explicitly before exec.
 	defer func() {
-		if err := os.Remove(tempfile.Name()); err != nil {
-			logger.Error("Failed to remove temp file", "file", tempfile.Name(), "error", err)
+		name := tempfile.Name()
+		if err := tempfile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			logger.Error("Failed to close temp file", "file", name, "error", err)
 		}
-	}()
-	defer func() {
-		// Best-effort safety net for error paths. On the success path the explicit
-		// Close below has already run, so this returns "file already closed" — ignore.
-		_ = tempfile.Close()
+		if err := os.Remove(name); err != nil {
+			logger.Error("Failed to remove temp file", "file", name, "error", err)
+		}
 	}()
 
 	if e.WriteUtf8BOM {
@@ -131,7 +132,7 @@ func (e *baseExecutor) Execute(
 	logger.Info("Command saved to", "message_id", message.PostId, "path", tempfile.Name())
 
 	// Close explicitly before exec so the shell can open the script (required on Windows).
-	// The deferred Close above becomes a no-op in this path.
+	// The deferred cleanup will still run Remove; its Close becomes a no-op (ErrClosed).
 	if err := tempfile.Close(); err != nil {
 		logger.Error("Failed to close temp file handle", "error", err)
 		return errorResultBytes(logger, err)


### PR DESCRIPTION
## Summary
- Combined the two LIFO-ordered `defer` blocks in [base_executor.go](internal/interpreter/base_executor.go) into a single cleanup function deferred immediately after `os.CreateTemp`, so Close + Remove always run together on every exit path.
- Close errors are now logged via `logger.Error` instead of being silently dropped. `errors.Is(err, os.ErrClosed)` filters out the expected "already closed" case from the success path (where the explicit pre-exec Close has already run).
- Remove errors continue to be logged, giving operators visibility when Windows refuses deletion because of an external handle.

This addresses sc-89442: when the explicit `tempfile.Close()` before exec fails, the previous code returned early and the deferred `os.Remove()` silently failed on Windows (open files cannot be deleted), leaving orphaned `exec-*.ps1` script files in the temp directory.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/interpreter/...`
- [ ] On a Windows machine, execute 20+ commands via the agent (mix of success and failure cases) and verify no `exec-*.ps1` files remain in the scripts directory afterward.
- [ ] Simulate a `Close()` failure (e.g. by exhausting handles) and confirm the failure is logged and the file is still removed (or, if the OS holds the handle, the Remove failure is logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)