### PR TITLE
fix: [sc-89441] Unsubscribe MQTT topic before Disconnect to prevent duplicate command delivery

### DIFF
--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -217,8 +217,12 @@ func (svc *serviceContext) Execute(
 // established and the reconnect backoff should be reset.
 //
 // Cleanup is guaranteed on all exit paths: drainWorkers is deferred first, then
-// client.Disconnect is deferred after the client is created (LIFO order means
-// Disconnect runs before drainWorkers).
+// the MQTT teardown (Unsubscribe → Disconnect) is deferred after the client is
+// created (LIFO order means MQTT teardown runs before drainWorkers).
+// Consolidating Unsubscribe and Disconnect in one defer ensures persistent
+// (non-clean) Azure IoT Hub sessions don't retain server-side subscriptions
+// across reconnects, which would re-deliver buffered messages and cause
+// duplicate command execution.
 func (svc *serviceContext) runCycle(
 	ctx context.Context,
 	device agent.Device,
@@ -273,9 +277,23 @@ func (svc *serviceContext) runCycle(
 		lost <- struct{}{}
 	}
 
+	topic := fmt.Sprintf("devices/%s/messages/devicebound/#", device.DeviceId)
+	qos := byte(1)
+	if device.MqttQos != nil {
+		qos = *device.MqttQos
+	}
+
 	disconnectQuiesce := (uint)(mqtt.DefaultDisconnectQuiesce / time.Millisecond)
 	client := mqtt.NewClient(opts)
-	defer client.Disconnect(disconnectQuiesce)
+	subscribed := false
+	defer func() {
+		if subscribed && client.IsConnected() {
+			if token := client.Unsubscribe(topic); token.Wait() && token.Error() != nil {
+				logger.Warn("Failed to unsubscribe", "topic", topic, "error", token.Error())
+			}
+		}
+		client.Disconnect(disconnectQuiesce)
+	}()
 
 	token := client.Connect()
 	if token.Wait() && token.Error() != nil {
@@ -292,11 +310,6 @@ func (svc *serviceContext) runCycle(
 		logger.Info("Device twin reported properties updated", "agent_version", version.Version)
 	}
 
-	topic := fmt.Sprintf("devices/%s/messages/devicebound/#", device.DeviceId)
-	qos := byte(1)
-	if device.MqttQos != nil {
-		qos = *device.MqttQos
-	}
 	token = client.Subscribe(topic, qos, func(client mqtt.Client, msg mqtt.Message) {
 		payload := msg.Payload()
 		select {
@@ -314,6 +327,7 @@ func (svc *serviceContext) runCycle(
 		logger.Error("Failed to subscribe", "error", token.Error())
 		return false, false, 0
 	}
+	subscribed = true
 
 	logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
 	_ = notifier.Notify("AgentStatus:Online") // Best effort notification

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -630,6 +630,35 @@ func (m *mockMQTTClient) OptionsReader() pahomqtt.ClientOptionsReader {
 	return pahomqtt.NewOptionsReader(pahomqtt.NewClientOptions())
 }
 
+// teardownTrackingClient wraps mockMQTTClient and records the order in which
+// Unsubscribe and Disconnect are called. Used by the sc-89441 regression test
+// to verify Unsubscribe runs before Disconnect on every cycle exit path.
+type teardownTrackingClient struct {
+	mockMQTTClient
+	calls         *[]string
+	subscribeArgs *string
+}
+
+func (m *teardownTrackingClient) Subscribe(
+	topic string,
+	qos byte,
+	cb pahomqtt.MessageHandler,
+) pahomqtt.Token {
+	if m.subscribeArgs != nil {
+		*m.subscribeArgs = topic
+	}
+	return m.mockMQTTClient.Subscribe(topic, qos, cb)
+}
+
+func (m *teardownTrackingClient) Unsubscribe(topics ...string) pahomqtt.Token {
+	*m.calls = append(*m.calls, "unsubscribe:"+strings.Join(topics, ","))
+	return &mockMQTTToken{}
+}
+
+func (m *teardownTrackingClient) Disconnect(_ uint) {
+	*m.calls = append(*m.calls, "disconnect")
+}
+
 // blockingToken is a mock MQTT token whose Wait blocks until release is closed.
 // started is a buffered channel that receives one item when Wait is first called.
 type blockingToken struct {
@@ -1130,5 +1159,139 @@ func TestExecute_ConnectionLostChannelIsBuffered(t *testing.T) {
 	case <-done:
 	case <-time.After(10 * time.Second):
 		t.Fatal("Execute did not exit within timeout")
+	}
+}
+
+// TestExecute_UnsubscribeBeforeDisconnectOnStop is the regression test for
+// sc-89441: the client must call Unsubscribe(topic) before Disconnect on the
+// stop path so persistent (non-clean) Azure IoT Hub sessions don't retain
+// server-side subscriptions and re-deliver buffered messages on reconnect.
+func TestExecute_UnsubscribeBeforeDisconnectOnStop(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	device := agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		LoggingLevel:         "error",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+	configBytes, _ := json.Marshal(device)
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	var calls []string
+	var subscribedTopic string
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &teardownTrackingClient{
+			calls:         &calls,
+			subscribeArgs: &subscribedTopic,
+		}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+
+	expectedTopic := "devices/test-device/messages/devicebound/#"
+	expected := []string{"unsubscribe:" + expectedTopic, "disconnect"}
+	if len(calls) != len(expected) || calls[0] != expected[0] || calls[1] != expected[1] {
+		t.Fatalf("expected teardown order %v, got %v", expected, calls)
+	}
+	if subscribedTopic != expectedTopic {
+		t.Errorf("expected Subscribe called with %q, got %q", expectedTopic, subscribedTopic)
+	}
+}
+
+// TestExecute_NoUnsubscribeWhenSubscribeFails verifies that Unsubscribe is not
+// issued when Subscribe never succeeded. Calling Unsubscribe in that case would
+// be a no-op on the broker (no subscription exists) and just produce log noise.
+func TestExecute_NoUnsubscribeWhenSubscribeFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	device := agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		LoggingLevel:         "error",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+	configBytes, _ := json.Marshal(device)
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	var calls []string
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &teardownTrackingClient{
+			mockMQTTClient: mockMQTTClient{subscribeErr: errors.New("broker denied")},
+			calls:          &calls,
+		}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+
+	for _, c := range calls {
+		if strings.HasPrefix(c, "unsubscribe:") {
+			t.Errorf("Unsubscribe should not be called when Subscribe failed; got calls=%v", calls)
+			break
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Consolidates MQTT teardown into a single deferred closure that calls `client.Unsubscribe(topic)` before `client.Disconnect(disconnectQuiesce)`, guarded by `subscribed && client.IsConnected()` so it only fires when there's actually a server-side subscription to remove.
- Without this, persistent (non-clean) Azure IoT Hub sessions retain server-side subscriptions across reconnects, causing previously-buffered messages to be re-delivered and commands to execute twice.
- Single-defer cleanup covers every exit path (stop, lost, connect failure, subscribe failure), so future early-returns added to `runCycle` automatically go through the same teardown.

## Test plan
- [x] `go test ./...` passes locally.
- [x] New regression test `TestExecute_UnsubscribeBeforeDisconnectOnStop` asserts `Unsubscribe(devices/{id}/messages/devicebound/#)` is recorded before `Disconnect` on the stop path.
- [x] New negative test `TestExecute_NoUnsubscribeWhenSubscribeFails` asserts no Unsubscribe is issued when Subscribe never succeeded (avoids broker no-op + log noise).
- [ ] QA: Send a command to the agent, force-disconnect before processing, reconnect, verify the command runs exactly once.
- [ ] QA: Repeat across stop/start, reconnect, and OS-signal shutdown paths to confirm Unsubscribe precedes Disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)