### PR TITLE
fix: diagnostic mode lists ghost agents and improve agent navigation

### DIFF
--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -107,7 +108,12 @@ func runDiagnosticFull(
 	if len(agents) == 1 {
 		target = agents[0]
 	} else {
-		target = selectAgent(reader, agents)
+		selected, ok := selectAgent(reader, agents)
+		if !ok {
+			fmt.Println("\n  Exiting diagnostic mode.")
+			return
+		}
+		target = selected
 	}
 
 	for {
@@ -169,7 +175,7 @@ func prompt(reader *bufio.Reader, message string) string {
 	return strings.TrimSpace(input)
 }
 
-func selectAgent(reader *bufio.Reader, agents []agentInfo) agentInfo {
+func selectAgent(reader *bufio.Reader, agents []agentInfo) (agentInfo, bool) {
 	fmt.Println("\n  Multiple agents found. Select one to diagnose:")
 	fmt.Println()
 	for i, a := range agents {
@@ -179,16 +185,26 @@ func selectAgent(reader *bufio.Reader, agents []agentInfo) agentInfo {
 		}
 		fmt.Printf("  [%d] %s (%s)\n", i+1, a.OrgId, status)
 	}
+	fmt.Printf("  [0] Exit\n")
 	fmt.Println()
 
 	for {
 		choice := prompt(reader, "  Select agent number: ")
+		if strings.TrimSpace(choice) == "0" {
+			return agentInfo{}, false
+		}
 		var idx int
 		if _, err := fmt.Sscanf(choice, "%d", &idx); err == nil && idx >= 1 && idx <= len(agents) {
-			return agents[idx-1]
+			return agents[idx-1], true
 		}
 		fmt.Println("  Invalid selection. Please try again.")
 	}
+}
+
+var uuidRE = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func isValidOrgId(s string) bool {
+	return uuidRE.MatchString(s)
 }
 
 // scanAgentsFrom is the testable core of scanAgents.
@@ -205,6 +221,10 @@ func scanAgentsFrom(root string) []agentInfo {
 		}
 
 		orgId := entry.Name()
+		if !isValidOrgId(orgId) {
+			continue
+		}
+
 		configPath := filepath.Join(root, orgId, "config.json")
 
 		// Verify this is an agent directory by checking for config.json

--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -109,43 +109,51 @@ func runDiagnosticFull(
 		}
 	}
 
-	// Select agent to diagnose
-	var target agentInfo
-	if len(agents) == 1 {
-		target = agents[0]
-	} else {
-		selected, ok := selectAgent(reader, agents)
-		if !ok {
-			fmt.Println("\n  Exiting diagnostic mode.")
-			return
-		}
-		target = selected
-	}
+	hasMultiple := len(agents) > 1
 
+selectLoop:
 	for {
-		printMenu()
-		choice := prompt(reader, "  Select an option: ")
+		// Select agent to diagnose
+		var target agentInfo
+		if !hasMultiple {
+			target = agents[0]
+		} else {
+			selected, ok := selectAgent(reader, agents)
+			if !ok {
+				fmt.Println("\n  Exiting diagnostic mode.")
+				return
+			}
+			target = selected
+		}
 
-		switch strings.TrimSpace(choice) {
-		case "1":
-			runCheckAgents(params, agents)
-		case "2":
-			runCommandTest()
-		case "3":
-			runConnectivityTestWith(target, dialer)
-		case "4":
-			runTempDirTest(target)
-		case "5":
-			runLiveLogsWith(ctx, target, opener)
-		case "6":
-			runAllChecksWith(ctx, params, agents, target, dialer)
-		case "7":
-			runHostInfo(ctx, params, target)
-		case "0", "q", "quit", "exit":
-			fmt.Println("\n  Exiting diagnostic mode.")
-			return
-		default:
-			fmt.Println("\n  Invalid option. Please try again.")
+		for {
+			printMenu(target, hasMultiple)
+			choice := prompt(reader, "  Select an option: ")
+
+			switch strings.TrimSpace(choice) {
+			case "1":
+				runCheckServiceStatus(params, target)
+			case "2":
+				runCommandTest()
+			case "3":
+				runConnectivityTestWith(target, dialer)
+			case "4":
+				runTempDirTest(target)
+			case "5":
+				runLiveLogsWith(ctx, target, opener)
+			case "6":
+				runAllChecksWith(ctx, params, target, dialer)
+			case "7":
+				runHostInfo(ctx, params, target)
+			case "0", "q", "quit", "exit":
+				if hasMultiple {
+					continue selectLoop
+				}
+				fmt.Println("\n  Exiting diagnostic mode.")
+				return
+			default:
+				fmt.Println("\n  Invalid option. Please try again.")
+			}
 		}
 	}
 }
@@ -159,20 +167,25 @@ func printHeader() {
 	fmt.Println("  ╚══════════════════════════════════════════════════╝")
 }
 
-func printMenu() {
+func printMenu(target agentInfo, hasMultiple bool) {
+	lastOption := "  │  [0] Exit                                        │"
+	if hasMultiple {
+		lastOption = "  │  [0] Back                                        │"
+	}
 	fmt.Println()
 	fmt.Println("  ┌──────────────────────────────────────────────────┐")
 	fmt.Println("  │  Diagnostic Options                              │")
 	fmt.Println("  ├──────────────────────────────────────────────────┤")
-	fmt.Println("  │  [1] Scan installed agents and check status      │")
+	fmt.Println("  │  [1] Check service status                        │")
 	fmt.Println("  │  [2] Test command execution                      │")
 	fmt.Println("  │  [3] Test MQTT/WebSocket connectivity            │")
 	fmt.Println("  │  [4] Test temp directory write access            │")
 	fmt.Println("  │  [5] View live log data                          │")
 	fmt.Println("  │  [6] Run all checks                              │")
 	fmt.Println("  │  [7] Show host information                       │")
-	fmt.Println("  │  [0] Exit                                        │")
+	fmt.Println(lastOption)
 	fmt.Println("  └──────────────────────────────────────────────────┘")
+	fmt.Printf("  Current agent: %s\n", target.OrgId)
 }
 
 func prompt(reader *bufio.Reader, message string) string {
@@ -185,11 +198,7 @@ func selectAgent(reader *bufio.Reader, agents []agentInfo) (agentInfo, bool) {
 	fmt.Println("\n  Multiple agents found. Select one to diagnose:")
 	fmt.Println()
 	for i, a := range agents {
-		status := "stopped"
-		if a.IsRunning {
-			status = "running"
-		}
-		fmt.Printf("  [%d] %s (%s)\n", i+1, a.OrgId, status)
+		fmt.Printf("  [%d] %s\n", i+1, a.OrgId)
 	}
 	fmt.Printf("  [0] Exit\n")
 	fmt.Println()
@@ -263,45 +272,24 @@ func scanAgentsFrom(root string) []agentInfo {
 	return agents
 }
 
-// ── Check 1: Scan agents and show status ──
+// ── Check 1: Service status for the selected agent ──
 
-func runCheckAgents(params *diagnosticContext, agents []agentInfo) {
-	printSection("Installed Agents")
+func runCheckServiceStatus(params *diagnosticContext, target agentInfo) {
+	printSection("Service Status")
 
-	if len(agents) == 0 {
-		printResult(false, "No installed agents found")
+	svc, err := params.ServiceManager.Open(target.ServiceName)
+	if err != nil {
+		printResult(false, fmt.Sprintf("Service not found (%s)", target.ServiceName))
 		return
 	}
+	running := svc.IsActive()
+	_ = svc.Close()
 
-	for _, a := range agents {
-		// Re-check status
-		svc, err := params.ServiceManager.Open(a.ServiceName)
-		if err != nil {
-			printResult(false, fmt.Sprintf("%s - service not found (%s)", a.OrgId, a.ServiceName))
-			continue
-		}
-		running := svc.IsActive()
-		_ = svc.Close()
-
-		status := "STOPPED"
-		if running {
-			status = "RUNNING"
-		}
-		printResult(running, fmt.Sprintf("%s - %s (%s)", a.OrgId, status, a.ServiceName))
-
-		// Show config details if available
-		if a.Device != nil {
-			fmt.Printf("      Device ID:    %s\n", a.Device.DeviceId)
-			fmt.Printf("      IoT Hub:      %s\n", a.Device.AzureIotHubHost)
-			fmt.Printf("      Engine Host:  %s\n", a.Device.RewstEngineHost)
-			fmt.Printf("      Log Level:    %s\n", a.Device.LoggingLevel)
-			fmt.Printf("      Syslog:       %v\n", a.Device.UseSyslog)
-			fmt.Printf("      Auto-Updates: %v\n", !a.Device.DisableAutoUpdates)
-			if a.Device.MqttQos != nil {
-				fmt.Printf("      MQTT QoS:     %d\n", *a.Device.MqttQos)
-			}
-		}
+	status := "STOPPED"
+	if running {
+		status = "RUNNING"
 	}
+	printResult(running, fmt.Sprintf("%s - %s (%s)", target.OrgId, status, target.ServiceName))
 }
 
 // ── Check 2: Command execution test ──
@@ -501,11 +489,10 @@ func runLiveLogsWith(ctx context.Context, target agentInfo, opener logFileOpener
 func runAllChecksWith(
 	ctx context.Context,
 	params *diagnosticContext,
-	agents []agentInfo,
 	target agentInfo,
 	dialer tlsDialer,
 ) {
-	runCheckAgents(params, agents)
+	runCheckServiceStatus(params, target)
 	runCommandTest()
 	runConnectivityTestWith(target, dialer)
 	runTempDirTest(target)

--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -60,6 +60,7 @@ func runDiagnostic(params *diagnosticContext) {
 		&defaultTLSDialer{},
 		&osLogFileOpener{},
 		getAgentDataRoot(),
+		fallbackScanAgents,
 	)
 }
 
@@ -70,13 +71,18 @@ func runDiagnosticFull(
 	dialer tlsDialer,
 	opener logFileOpener,
 	agentRoot string,
+	fallback func(string) []agentInfo,
 ) {
 	reader := bufio.NewReader(input)
 
 	printHeader()
 
-	// Scan for installed agents
+	// Scan for installed agents; fall back to platform-specific discovery
+	// (e.g. Windows SCM) if the data-directory scan returns nothing.
 	agents := scanAgentsFrom(agentRoot)
+	if len(agents) == 0 && fallback != nil {
+		agents = fallback(agentRoot)
+	}
 
 	if len(agents) == 0 && params.OrgId == "" {
 		fmt.Println("\n  No installed agents found.")

--- a/cmd/agent_smith/diagnostic.go
+++ b/cmd/agent_smith/diagnostic.go
@@ -216,7 +216,9 @@ func selectAgent(reader *bufio.Reader, agents []agentInfo) (agentInfo, bool) {
 	}
 }
 
-var uuidRE = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+var uuidRE = regexp.MustCompile(
+	`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+)
 
 func isValidOrgId(s string) bool {
 	return uuidRE.MatchString(s)

--- a/cmd/agent_smith/diagnostic_scanner_darwin.go
+++ b/cmd/agent_smith/diagnostic_scanner_darwin.go
@@ -18,7 +18,7 @@ func formatServiceName(orgId string) string {
 	return fmt.Sprintf("io.rewst.remote_agent_%s", orgId)
 }
 
-// queryServiceStatus checks the plist file for installation and launchctl list
+// queryServiceStatus checks the plist file for installation and launchctl print
 // for running state. Returns (installed, running).
 func queryServiceStatus(name string) (bool, bool) {
 	plistPath := filepath.Join("/Library/LaunchDaemons", fmt.Sprintf("%s.plist", name))
@@ -26,17 +26,19 @@ func queryServiceStatus(name string) (bool, bool) {
 		return false, false
 	}
 
-	// "launchctl list <name>" prints a tab-separated line: PID  LastExit  Label
-	// If PID is non-zero the service is running.
-	out, err := exec.Command("launchctl", "list", name).CombinedOutput() // #nosec G204
+	// "launchctl print system/<name>" outputs a plist-style dict; parse the
+	// "state = running" line — consistent with IsActive() in service_darwin.go.
+	out, err := exec.Command("launchctl", "print", fmt.Sprintf("system/%s", name)).CombinedOutput() // #nosec G204
 	if err != nil {
-		// Plist exists but not loaded — installed, stopped
+		// Plist exists but service is not loaded — installed, stopped
 		return true, false
 	}
 
-	parts := strings.Fields(string(out))
-	if len(parts) >= 1 && parts[0] != "-" && parts[0] != "0" {
-		return true, true
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), "=", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) == "state" {
+			return true, strings.TrimSpace(parts[1]) == "running"
+		}
 	}
 	return true, false
 }

--- a/cmd/agent_smith/diagnostic_scanner_darwin.go
+++ b/cmd/agent_smith/diagnostic_scanner_darwin.go
@@ -30,7 +30,9 @@ func queryServiceStatus(name string) (bool, bool) {
 
 	// "launchctl print system/<name>" outputs a plist-style dict; parse the
 	// "state = running" line — consistent with IsActive() in service_darwin.go.
-	out, err := exec.Command("launchctl", "print", fmt.Sprintf("system/%s", name)).CombinedOutput() // #nosec G204
+	// #nosec G204 - launchctl is a fixed system binary; name comes from internal config
+	out, err := exec.Command("launchctl", "print", fmt.Sprintf("system/%s", name)).
+		CombinedOutput()
 	if err != nil {
 		// Plist exists but service is not loaded — installed, stopped
 		return true, false

--- a/cmd/agent_smith/diagnostic_scanner_darwin.go
+++ b/cmd/agent_smith/diagnostic_scanner_darwin.go
@@ -18,6 +18,8 @@ func formatServiceName(orgId string) string {
 	return fmt.Sprintf("io.rewst.remote_agent_%s", orgId)
 }
 
+func fallbackScanAgents(_ string) []agentInfo { return nil }
+
 // queryServiceStatus checks the plist file for installation and launchctl print
 // for running state. Returns (installed, running).
 func queryServiceStatus(name string) (bool, bool) {

--- a/cmd/agent_smith/diagnostic_scanner_linux.go
+++ b/cmd/agent_smith/diagnostic_scanner_linux.go
@@ -17,6 +17,8 @@ func formatServiceName(orgId string) string {
 	return fmt.Sprintf("rewst_remote_agent_%s", orgId)
 }
 
+func fallbackScanAgents(_ string) []agentInfo { return nil }
+
 // queryServiceStatus queries systemd for both existence and active state.
 // Returns (installed, running).
 func queryServiceStatus(name string) (bool, bool) {

--- a/cmd/agent_smith/diagnostic_scanner_windows.go
+++ b/cmd/agent_smith/diagnostic_scanner_windows.go
@@ -31,7 +31,9 @@ func formatServiceName(orgId string) string {
 // (e.g. when PROGRAMDATA was unset during installation or the directory
 // cannot be read in the current process context).
 func fallbackScanAgents(root string) []agentInfo {
-	out, err := exec.Command("sc", "query", "type=", "service", "state=", "all", "bufsize=", "65536").CombinedOutput() // #nosec G204
+	out, err := exec.Command( // #nosec G204
+		"sc", "query", "type=", "service", "state=", "all", "bufsize=", "65536",
+	).CombinedOutput()
 	if err != nil {
 		return nil
 	}

--- a/cmd/agent_smith/diagnostic_scanner_windows.go
+++ b/cmd/agent_smith/diagnostic_scanner_windows.go
@@ -3,19 +3,77 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/RewstApp/agent-smith-go/internal/agent"
 )
 
 func getAgentDataRoot() string {
-	return filepath.Join(os.Getenv("PROGRAMDATA"), "RewstRemoteAgent")
+	programData := os.Getenv("PROGRAMDATA")
+	if programData == "" {
+		programData = `C:\ProgramData`
+	}
+	return filepath.Join(programData, "RewstRemoteAgent")
 }
 
 func formatServiceName(orgId string) string {
 	return fmt.Sprintf("RewstRemoteAgent_%s", orgId)
+}
+
+// fallbackScanAgents queries the Windows SCM for services named
+// RewstRemoteAgent_{uuid} and builds agentInfo entries from them.
+// This handles the case where the data-directory scan finds nothing
+// (e.g. when PROGRAMDATA was unset during installation or the directory
+// cannot be read in the current process context).
+func fallbackScanAgents(root string) []agentInfo {
+	out, err := exec.Command("sc", "query", "type=", "service", "state=", "all", "bufsize=", "65536").CombinedOutput() // #nosec G204
+	if err != nil {
+		return nil
+	}
+
+	const svcPrefix = "RewstRemoteAgent_"
+	seen := make(map[string]bool)
+	var agents []agentInfo
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "SERVICE_NAME: ") {
+			continue
+		}
+		svcName := strings.TrimSpace(strings.TrimPrefix(line, "SERVICE_NAME: "))
+		if !strings.HasPrefix(svcName, svcPrefix) {
+			continue
+		}
+		orgId := strings.TrimPrefix(svcName, svcPrefix)
+		if !isValidOrgId(orgId) || seen[orgId] {
+			continue
+		}
+		seen[orgId] = true
+
+		info := agentInfo{
+			OrgId:       orgId,
+			ConfigFile:  agent.GetConfigFilePath(orgId),
+			LogFile:     agent.GetLogFilePath(orgId),
+			ServiceName: formatServiceName(orgId),
+		}
+
+		configPath := filepath.Join(root, orgId, "config.json")
+		if configBytes, err := os.ReadFile(configPath); err == nil {
+			var device agent.Device
+			if json.Unmarshal(configBytes, &device) == nil {
+				info.Device = &device
+			}
+		}
+
+		_, info.IsRunning = queryServiceStatus(info.ServiceName)
+		agents = append(agents, info)
+	}
+	return agents
 }
 
 // queryServiceStatus queries the Windows SCM via sc.exe.

--- a/cmd/agent_smith/diagnostic_test.go
+++ b/cmd/agent_smith/diagnostic_test.go
@@ -369,7 +369,7 @@ func runDiag(
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	runDiagnosticFull(ctx, params, strings.NewReader(input), dialer, opener, t.TempDir())
+	runDiagnosticFull(ctx, params, strings.NewReader(input), dialer, opener, t.TempDir(), nil)
 }
 
 func TestRunDiagnosticWith_ExitImmediately(t *testing.T) {
@@ -459,6 +459,7 @@ func TestRunDiagnosticWith_AgentSelectionFromScan(t *testing.T) {
 		&mockTLSDialer{},
 		&mockLogFileOpener{},
 		root,
+		nil,
 	)
 }
 

--- a/cmd/agent_smith/diagnostic_test.go
+++ b/cmd/agent_smith/diagnostic_test.go
@@ -192,44 +192,27 @@ func TestScanAgentsFrom_MultipleOrgs(t *testing.T) {
 	}
 }
 
-// ── runCheckAgents ────────────────────────────────────────────────────────────
+// ── runCheckServiceStatus ─────────────────────────────────────────────────────
 
-func TestRunCheckAgents_Empty(t *testing.T) {
-	params := &diagnosticContext{ServiceManager: &mockServiceManager{}}
-	runCheckAgents(params, nil)
-}
-
-func TestRunCheckAgents_ServiceOpenFails(t *testing.T) {
+func TestRunCheckServiceStatus_ServiceOpenFails(t *testing.T) {
 	params := &diagnosticContext{
 		ServiceManager: &mockServiceManager{openErr: errors.New("not found")},
 	}
-	runCheckAgents(params, []agentInfo{{OrgId: "org-1", ServiceName: "svc-1"}})
+	runCheckServiceStatus(params, agentInfo{OrgId: "org-1", ServiceName: "svc-1"})
 }
 
-func TestRunCheckAgents_RunningService(t *testing.T) {
+func TestRunCheckServiceStatus_RunningService(t *testing.T) {
 	params := &diagnosticContext{
 		ServiceManager: &mockServiceManager{openService: &mockService{isActive: true}},
 	}
-	runCheckAgents(params, []agentInfo{{OrgId: "org-1", ServiceName: "svc-1"}})
+	runCheckServiceStatus(params, agentInfo{OrgId: "org-1", ServiceName: "svc-1"})
 }
 
-func TestRunCheckAgents_StoppedService(t *testing.T) {
+func TestRunCheckServiceStatus_StoppedService(t *testing.T) {
 	params := &diagnosticContext{
 		ServiceManager: &mockServiceManager{openService: &mockService{isActive: false}},
 	}
-	runCheckAgents(params, []agentInfo{{OrgId: "org-1", ServiceName: "svc-1"}})
-}
-
-func TestRunCheckAgents_WithDeviceDetails(t *testing.T) {
-	params := &diagnosticContext{
-		ServiceManager: &mockServiceManager{openService: &mockService{isActive: true}},
-	}
-	device := &agent.Device{
-		DeviceId:        "dev-xyz",
-		AzureIotHubHost: "hub.example.com",
-		RewstEngineHost: "engine.example.com",
-	}
-	runCheckAgents(params, []agentInfo{{OrgId: "org-1", ServiceName: "svc-1", Device: device}})
+	runCheckServiceStatus(params, agentInfo{OrgId: "org-1", ServiceName: "svc-1"})
 }
 
 // ── runConnectivityTestWith ───────────────────────────────────────────────────
@@ -437,7 +420,8 @@ func TestRunDiagnosticWith_InvalidOption(t *testing.T) {
 }
 
 func TestRunDiagnosticWith_AgentSelectionFromScan(t *testing.T) {
-	// Two agents in the temp root → selectAgent is called; "1" picks first, "0" exits
+	// Two agents in the temp root → selectAgent is called; "1" picks first,
+	// "0" goes Back to selection, then "0" exits the selection.
 	root := t.TempDir()
 	for _, orgId := range []string{
 		"43fb08b0-92cf-462a-924d-0b6be7a43a48",
@@ -455,7 +439,7 @@ func TestRunDiagnosticWith_AgentSelectionFromScan(t *testing.T) {
 		&diagnosticContext{
 			ServiceManager: &mockServiceManager{openService: &mockService{isActive: true}},
 		},
-		strings.NewReader("1\n0\n"),
+		strings.NewReader("1\n0\n0\n"),
 		&mockTLSDialer{},
 		&mockLogFileOpener{},
 		root,
@@ -471,13 +455,13 @@ func TestRunAllChecksWith(t *testing.T) {
 		Sys:            &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"},
 		Domain:         &mockDomainInfoProvider{},
 	}
-	agents := []agentInfo{{OrgId: "org-1", ServiceName: "svc-1"}}
 	target := agentInfo{
-		OrgId:   "org-all",
-		LogFile: "fake.log",
-		Device:  &agent.Device{AzureIotHubHost: "hub.example.com"},
+		OrgId:       "org-all",
+		ServiceName: "svc-all",
+		LogFile:     "fake.log",
+		Device:      &agent.Device{AzureIotHubHost: "hub.example.com"},
 	}
-	runAllChecksWith(context.Background(), params, agents, target, &mockTLSDialer{result: true})
+	runAllChecksWith(context.Background(), params, target, &mockTLSDialer{result: true})
 	_ = os.RemoveAll(agent.GetScriptsDirectory(target.OrgId))
 }
 

--- a/cmd/agent_smith/diagnostic_test.go
+++ b/cmd/agent_smith/diagnostic_test.go
@@ -39,6 +39,34 @@ func (m *mockLogFileOpener) Open(_ string) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader(m.content)), nil
 }
 
+// ── isValidOrgId ─────────────────────────────────────────────────────────────
+
+func TestIsValidOrgId(t *testing.T) {
+	valid := []string{
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48",
+		"53f5b9c3-a168-4fa4-b155-e2dca1d1d40a",
+		"00000000-0000-0000-0000-000000000000",
+	}
+	for _, id := range valid {
+		if !isValidOrgId(id) {
+			t.Errorf("expected %q to be a valid org ID", id)
+		}
+	}
+
+	invalid := []string{
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48--syslog",
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48-syslog",
+		"not-a-uuid",
+		"",
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48 ",
+	}
+	for _, id := range invalid {
+		if isValidOrgId(id) {
+			t.Errorf("expected %q to be an invalid org ID", id)
+		}
+	}
+}
+
 // ── scanAgentsFrom ────────────────────────────────────────────────────────────
 
 func TestScanAgentsFrom_NonExistentRoot(t *testing.T) {
@@ -53,6 +81,27 @@ func TestScanAgentsFrom_EmptyRoot(t *testing.T) {
 	agents := scanAgentsFrom(root)
 	if len(agents) != 0 {
 		t.Errorf("expected 0 agents, got %d", len(agents))
+	}
+}
+
+func TestScanAgentsFrom_SkipsSyslogSuffixedEntries(t *testing.T) {
+	root := t.TempDir()
+	realOrgId := "43fb08b0-92cf-462a-924d-0b6be7a43a48"
+	syslogOrgId := realOrgId + "--syslog"
+
+	for _, dir := range []string{realOrgId, syslogOrgId} {
+		orgDir := filepath.Join(root, dir)
+		_ = os.MkdirAll(orgDir, 0o755)
+		data, _ := json.Marshal(agent.Device{DeviceId: dir})
+		_ = os.WriteFile(filepath.Join(orgDir, "config.json"), data, 0o644)
+	}
+
+	agents := scanAgentsFrom(root)
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent (syslog entry filtered), got %d", len(agents))
+	}
+	if agents[0].OrgId != realOrgId {
+		t.Errorf("expected OrgId %q, got %q", realOrgId, agents[0].OrgId)
 	}
 }
 
@@ -78,7 +127,7 @@ func TestScanAgentsFrom_SkipsFiles(t *testing.T) {
 
 func TestScanAgentsFrom_ValidConfig(t *testing.T) {
 	root := t.TempDir()
-	orgId := "test-org-123"
+	orgId := "43fb08b0-92cf-462a-924d-0b6be7a43a48"
 	orgDir := filepath.Join(root, orgId)
 	_ = os.MkdirAll(orgDir, 0o755)
 
@@ -109,7 +158,7 @@ func TestScanAgentsFrom_ValidConfig(t *testing.T) {
 
 func TestScanAgentsFrom_InvalidConfigJSON(t *testing.T) {
 	root := t.TempDir()
-	orgId := "org-bad-json"
+	orgId := "53f5b9c3-a168-4fa4-b155-e2dca1d1d40a"
 	orgDir := filepath.Join(root, orgId)
 	_ = os.MkdirAll(orgDir, 0o755)
 	_ = os.WriteFile(filepath.Join(orgDir, "config.json"), []byte("not-json"), 0o644)
@@ -125,7 +174,11 @@ func TestScanAgentsFrom_InvalidConfigJSON(t *testing.T) {
 
 func TestScanAgentsFrom_MultipleOrgs(t *testing.T) {
 	root := t.TempDir()
-	for _, orgId := range []string{"org-a", "org-b", "org-c"} {
+	for _, orgId := range []string{
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48",
+		"53f5b9c3-a168-4fa4-b155-e2dca1d1d40a",
+		"60a1c2d3-e4f5-6789-abcd-ef0123456789",
+	} {
 		orgDir := filepath.Join(root, orgId)
 		_ = os.MkdirAll(orgDir, 0o755)
 		data, _ := json.Marshal(agent.Device{DeviceId: orgId})
@@ -249,7 +302,10 @@ func TestRunLiveLogs_SmallFile(t *testing.T) {
 
 func TestSelectAgent_ValidChoice(t *testing.T) {
 	agents := []agentInfo{{OrgId: "org-a", IsRunning: true}, {OrgId: "org-b"}}
-	result := selectAgent(bufio.NewReader(strings.NewReader("2\n")), agents)
+	result, ok := selectAgent(bufio.NewReader(strings.NewReader("2\n")), agents)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
 	if result.OrgId != "org-b" {
 		t.Errorf("expected 'org-b', got %q", result.OrgId)
 	}
@@ -257,7 +313,10 @@ func TestSelectAgent_ValidChoice(t *testing.T) {
 
 func TestSelectAgent_InvalidThenValid(t *testing.T) {
 	agents := []agentInfo{{OrgId: "org-a"}, {OrgId: "org-b"}}
-	result := selectAgent(bufio.NewReader(strings.NewReader("abc\n1\n")), agents)
+	result, ok := selectAgent(bufio.NewReader(strings.NewReader("abc\n1\n")), agents)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
 	if result.OrgId != "org-a" {
 		t.Errorf("expected 'org-a', got %q", result.OrgId)
 	}
@@ -265,9 +324,20 @@ func TestSelectAgent_InvalidThenValid(t *testing.T) {
 
 func TestSelectAgent_OutOfRangeThenValid(t *testing.T) {
 	agents := []agentInfo{{OrgId: "org-a"}}
-	result := selectAgent(bufio.NewReader(strings.NewReader("99\n1\n")), agents)
+	result, ok := selectAgent(bufio.NewReader(strings.NewReader("99\n1\n")), agents)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
 	if result.OrgId != "org-a" {
 		t.Errorf("expected 'org-a', got %q", result.OrgId)
+	}
+}
+
+func TestSelectAgent_ExitChoice(t *testing.T) {
+	agents := []agentInfo{{OrgId: "org-a"}, {OrgId: "org-b"}}
+	_, ok := selectAgent(bufio.NewReader(strings.NewReader("0\n")), agents)
+	if ok {
+		t.Error("expected ok=false when user selects exit")
 	}
 }
 
@@ -369,7 +439,10 @@ func TestRunDiagnosticWith_InvalidOption(t *testing.T) {
 func TestRunDiagnosticWith_AgentSelectionFromScan(t *testing.T) {
 	// Two agents in the temp root → selectAgent is called; "1" picks first, "0" exits
 	root := t.TempDir()
-	for _, orgId := range []string{"org-a", "org-b"} {
+	for _, orgId := range []string{
+		"43fb08b0-92cf-462a-924d-0b6be7a43a48",
+		"53f5b9c3-a168-4fa4-b155-e2dca1d1d40a",
+	} {
 		orgDir := filepath.Join(root, orgId)
 		_ = os.MkdirAll(orgDir, 0o755)
 		data, _ := json.Marshal(agent.Device{DeviceId: orgId, RewstOrgId: orgId})


### PR DESCRIPTION
## Summary
- Fix ghost agents appearing in diagnostic mode (`e3e0fec`).
- Fix diagnostic mode not listing installed agents on Windows (`600f98d`).
- Tighten the diagnostic UX: drop status from the agent picker, show the current agent under the menu, narrow option [1] to a service status check for the selected agent, and replace [0] Exit with [0] Back when multiple agents are installed (`40ad2fb`).

## Test plan
- [ ] `go test ./...` passes.
- [ ] Run on Windows with multiple installed agents and confirm the picker lists each org id without trailing status.
- [ ] Pick an agent, run option [1], confirm only RUNNING/STOPPED is shown for the selected agent.
- [ ] With multiple agents, confirm `[0]` returns to the picker; with a single agent, confirm `[0]` exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)