### PR TITLE
fix: validate Windows installation env vars at startup

### DIFF
--- a/cmd/agent_smith/main.go
+++ b/cmd/agent_smith/main.go
@@ -35,6 +35,15 @@ func getAllowedConfigLevelsString(separator string) string {
 }
 
 func main() {
+	// Validate platform-specific installation environment before any mode
+	// resolves installation paths. On Windows this surfaces missing
+	// PROGRAMFILES / PROGRAMDATA / SYSTEMDRIVE early instead of producing
+	// malformed paths like `\RewstRemoteAgent\<orgId>`.
+	if err := agent.ValidateInstallationEnvironment(); err != nil {
+		fmt.Fprintf(os.Stderr, "environment error: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Create providers
 	sys := agent.NewSystemInfoProvider()
 	domain := agent.NewDomainInfoProvider()

--- a/internal/agent/installation_darwin.go
+++ b/internal/agent/installation_darwin.go
@@ -8,6 +8,12 @@ import (
 	"path/filepath"
 )
 
+// ValidateInstallationEnvironment is a no-op on macOS; installation paths
+// are derived from fixed locations rather than environment variables.
+func ValidateInstallationEnvironment() error {
+	return nil
+}
+
 func GetProgramDirectory(orgId string) string {
 	// Get program files directory
 	programFilesDir := "/usr/local/bin"

--- a/internal/agent/installation_linux.go
+++ b/internal/agent/installation_linux.go
@@ -8,6 +8,12 @@ import (
 	"path/filepath"
 )
 
+// ValidateInstallationEnvironment is a no-op on Linux; installation paths
+// are derived from fixed locations rather than environment variables.
+func ValidateInstallationEnvironment() error {
+	return nil
+}
+
 func GetProgramDirectory(orgId string) string {
 	// Get program files directory
 	programFilesDir := "/usr/local/bin"

--- a/internal/agent/installation_windows.go
+++ b/internal/agent/installation_windows.go
@@ -6,7 +6,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// ValidateInstallationEnvironment checks that the Windows environment
+// variables used to build installation paths are set. On stripped or
+// misconfigured systems (e.g. Server Core, locked-down GPO, containers)
+// these may be empty, which would otherwise produce malformed paths like
+// `\RewstRemoteAgent\<orgId>` instead of `C:\Program Files\RewstRemoteAgent\<orgId>`.
+func ValidateInstallationEnvironment() error {
+	required := []string{"PROGRAMFILES", "PROGRAMDATA", "SYSTEMDRIVE"}
+	var missing []string
+	for _, name := range required {
+		if os.Getenv(name) == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"required Windows environment variable(s) not set: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
 
 func GetProgramDirectory(orgId string) string {
 	// Get program files directory

--- a/internal/agent/installation_windows_test.go
+++ b/internal/agent/installation_windows_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +13,45 @@ func setEnvVars(t *testing.T) {
 	t.Setenv("PROGRAMFILES", "C:\\Program Files")
 	t.Setenv("PROGRAMDATA", "C:\\ProgramData")
 	t.Setenv("SYSTEMDRIVE", "C:")
+}
+
+func TestValidateInstallationEnvironment_AllSet(t *testing.T) {
+	setEnvVars(t)
+
+	if err := ValidateInstallationEnvironment(); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestValidateInstallationEnvironment_MissingSingle(t *testing.T) {
+	setEnvVars(t)
+	t.Setenv("PROGRAMFILES", "")
+
+	err := ValidateInstallationEnvironment()
+	if err == nil {
+		t.Fatal("expected error for missing PROGRAMFILES, got nil")
+	}
+	if !strings.Contains(err.Error(), "PROGRAMFILES") {
+		t.Errorf("expected error to identify PROGRAMFILES, got %q", err.Error())
+	}
+}
+
+func TestValidateInstallationEnvironment_MissingMultiple(t *testing.T) {
+	setEnvVars(t)
+	t.Setenv("PROGRAMFILES", "")
+	t.Setenv("SYSTEMDRIVE", "")
+
+	err := ValidateInstallationEnvironment()
+	if err == nil {
+		t.Fatal("expected error for missing variables, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "PROGRAMFILES") || !strings.Contains(msg, "SYSTEMDRIVE") {
+		t.Errorf("expected error to identify PROGRAMFILES and SYSTEMDRIVE, got %q", msg)
+	}
+	if strings.Contains(msg, "PROGRAMDATA") {
+		t.Errorf("did not expect PROGRAMDATA in error, got %q", msg)
+	}
 }
 
 func TestGetProgramDirectory(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `agent.ValidateInstallationEnvironment()` that checks `PROGRAMFILES`, `PROGRAMDATA`, and `SYSTEMDRIVE` on Windows and returns an error naming every missing variable. No-op stub on Linux/macOS.
- Call the validator at the top of `main()` so every mode (config, service, uninstall, update, diagnostic) fails fast with a clear message instead of resolving malformed paths like `\RewstRemoteAgent\<orgId>` on stripped or locked-down Windows hosts.
- Adds tests covering all-set, single-missing, and multiple-missing cases on Windows.

## Test plan
- [x] `go build ./...` on darwin
- [x] `GOOS=windows go build ./...` and `GOOS=linux go build ./...`
- [x] `go test ./...` on darwin
- [x] `GOOS=windows go vet ./internal/agent/...`
- [ ] On Windows, unset `PROGRAMFILES` and run the config/install command — agent logs a clear error identifying the missing variable and does not install
- [ ] On a correctly configured Windows host, install path resolution is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)