### PR TITLE
fix: [sc-89445] Retry failed postbacks with exponential backoff

### DIFF
--- a/cmd/agent_smith/process_message_test.go
+++ b/cmd/agent_smith/process_message_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/hashicorp/go-hclog"
@@ -24,10 +26,12 @@ func postbackPayload(commands, postID string) []byte {
 
 func newProcessMessageSvc(exec *mockExecutor, httpClient *http.Client) *serviceContext {
 	return &serviceContext{
-		Executor:   exec,
-		Sys:        &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"},
-		Domain:     &mockDomainInfoProvider{},
-		HTTPClient: httpClient,
+		Executor:                 exec,
+		Sys:                      &mockSystemInfoProvider{hostname: "host", hostPlatform: "linux"},
+		Domain:                   &mockDomainInfoProvider{},
+		HTTPClient:               httpClient,
+		PostbackMaxAttempts:      postbackMaxAttempts,
+		PostbackBaseRetryBackoff: time.Millisecond,
 	}
 }
 
@@ -211,3 +215,225 @@ func (t *schemeRewriteTransport) RoundTrip(req *http.Request) (*http.Response, e
 	r.URL.Scheme = t.scheme
 	return http.DefaultTransport.RoundTrip(r)
 }
+
+// TestProcessMessage_PostbackRetriesOnServerError verifies that a transient
+// 5xx response is retried and that a later success delivers the result.
+func TestProcessMessage_PostbackRetriesOnServerError(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"transient"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	svc.processMessage(postbackPayload("echo hi", "id:retry-5xx"), ctx, device, logger, notifier)
+
+	if got := calls.Load(); got != 3 {
+		t.Errorf("expected 3 postback attempts, got %d", got)
+	}
+}
+
+// TestProcessMessage_PostbackRetriesOnNetworkError verifies that a transient
+// network failure is retried and that a later success delivers the result.
+func TestProcessMessage_PostbackRetriesOnNetworkError(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Fail the first two requests at the transport layer; let the third
+	// pass through to the live test server.
+	failing := &failingThenPassTransport{
+		failures: 2,
+		fallback: &schemeRewriteTransport{scheme: "http"},
+	}
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{Transport: failing})
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	svc.processMessage(postbackPayload("echo hi", "id:retry-net"), ctx, device, logger, notifier)
+
+	if got := failing.attempts.Load(); got != 3 {
+		t.Errorf("expected 3 transport attempts, got %d", got)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected exactly one server-side delivery, got %d", got)
+	}
+}
+
+// TestProcessMessage_PostbackExhaustsRetries verifies that when every attempt
+// fails the loop stops after the configured maximum and surfaces the failure.
+func TestProcessMessage_PostbackExhaustsRetries(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"bad gateway"}`))
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	svc.processMessage(postbackPayload("echo hi", "id:exhaust"), ctx, device, logger, notifier)
+
+	if got := calls.Load(); int(got) != svc.PostbackMaxAttempts {
+		t.Errorf("expected %d attempts before giving up, got %d", svc.PostbackMaxAttempts, got)
+	}
+}
+
+// TestProcessMessage_PostbackSuccessFirstAttemptNoRetry verifies that a
+// first-attempt 200 OK does not trigger any additional requests.
+func TestProcessMessage_PostbackSuccessFirstAttemptNoRetry(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	start := time.Now()
+	svc.processMessage(postbackPayload("echo hi", "id:fast"), ctx, device, logger, notifier)
+	elapsed := time.Since(start)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected exactly one postback on first-try success, got %d", got)
+	}
+	// First-attempt success must not pay any backoff cost. The base backoff
+	// is only 1ms in tests but real-world is seconds — assert that the call
+	// returns well below a single backoff window.
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("first-attempt success took unexpectedly long: %v", elapsed)
+	}
+}
+
+// TestProcessMessage_PostbackTerminalOn4xxNoRetry verifies that a 4xx
+// response (with a parseable error body and not "fulfilled") is treated as
+// terminal and not retried.
+func TestProcessMessage_PostbackTerminalOn4xxNoRetry(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"malformed request"}`))
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	svc.processMessage(postbackPayload("echo hi", "id:4xx"), ctx, device, logger, notifier)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 4xx to be terminal (1 attempt), got %d", got)
+	}
+}
+
+// TestProcessMessage_PostbackContextCancelStopsRetries verifies that a
+// cancelled context aborts the retry loop instead of waiting out the backoff.
+func TestProcessMessage_PostbackContextCancelStopsRetries(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"down"}`))
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+	// Use a longer backoff so the cancellation observably short-circuits the wait.
+	svc.PostbackBaseRetryBackoff = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	// Cancel after a short delay so the first attempt completes but the
+	// retry-backoff sleep is interrupted.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	svc.processMessage(postbackPayload("echo hi", "id:cancel"), ctx, device, logger, notifier)
+	elapsed := time.Since(start)
+
+	if elapsed >= 5*time.Second {
+		t.Errorf("expected retry loop to abort on cancel, elapsed=%v", elapsed)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected exactly one server attempt before cancel, got %d", got)
+	}
+}
+
+// failingThenPassTransport fails the first N requests with a transport error
+// and then delegates to fallback. The total number of round-trips it has
+// observed is exposed via attempts for assertions.
+type failingThenPassTransport struct {
+	failures int32
+	attempts atomic.Int32
+	fallback http.RoundTripper
+}
+
+func (t *failingThenPassTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := t.attempts.Add(1)
+	if n <= t.failures {
+		return nil, &simulatedNetError{msg: "simulated transport failure"}
+	}
+	return t.fallback.RoundTrip(req)
+}
+
+type simulatedNetError struct{ msg string }
+
+func (e *simulatedNetError) Error() string { return e.msg }

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -25,9 +25,11 @@ import (
 )
 
 const (
-	workerCount         = 10
-	messageQueueSize    = 100
-	postbackHTTPTimeout = 30 * time.Second
+	workerCount              = 10
+	messageQueueSize         = 100
+	postbackHTTPTimeout      = 30 * time.Second
+	postbackMaxAttempts      = 3
+	postbackBaseRetryBackoff = 1 * time.Second
 )
 
 type errorResponse struct {
@@ -390,75 +392,171 @@ func (svc *serviceContext) processMessage(
 		return
 	}
 
-	// Postback the response
+	svc.sendPostbackWithRetry(ctx, &message, device, resultBytes, logger)
+}
+
+// sendPostbackWithRetry posts the command result to the Rewst engine, retrying
+// transient failures (network errors and 5xx responses) with exponential
+// backoff. Non-retryable responses (2xx success, 400 "already fulfilled", and
+// other 4xx errors) terminate the loop immediately. When all attempts fail the
+// final failure is surfaced clearly so the result is not silently dropped.
+func (svc *serviceContext) sendPostbackWithRetry(
+	ctx context.Context,
+	message *interpreter.Message,
+	device agent.Device,
+	resultBytes []byte,
+	logger hclog.Logger,
+) {
+	maxAttempts := svc.PostbackMaxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = postbackMaxAttempts
+	}
+	baseBackoff := svc.PostbackBaseRetryBackoff
+	if baseBackoff <= 0 {
+		baseBackoff = postbackBaseRetryBackoff
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := baseBackoff * (1 << (attempt - 2))
+			logger.Info(
+				"Retrying postback",
+				"post_id", message.PostId,
+				"attempt", attempt,
+				"max_attempts", maxAttempts,
+				"backoff", backoff,
+			)
+			select {
+			case <-ctx.Done():
+				logger.Error(
+					"Postback aborted before retry: context cancelled",
+					"post_id", message.PostId,
+					"attempts", attempt-1,
+					"error", ctx.Err(),
+				)
+				return
+			case <-time.After(backoff):
+			}
+		}
+
+		done, err := svc.attemptPostback(ctx, message, device, resultBytes, logger, attempt)
+		if done {
+			return
+		}
+		lastErr = err
+	}
+
+	logger.Error(
+		"Postback failed: all retries exhausted, result dropped",
+		"post_id", message.PostId,
+		"attempts", maxAttempts,
+		"last_error", lastErr,
+	)
+}
+
+// attemptPostback performs a single postback attempt. It returns done=true
+// when no further retries should occur (success, "already fulfilled", or a
+// non-retryable 4xx response). When done=false the caller should retry; the
+// returned error describes the most recent failure for the final summary log.
+func (svc *serviceContext) attemptPostback(
+	ctx context.Context,
+	message *interpreter.Message,
+	device agent.Device,
+	resultBytes []byte,
+	logger hclog.Logger,
+	attempt int,
+) (bool, error) {
 	postbackReq, err := message.CreatePostbackRequest(
 		ctx,
 		device,
 		bytes.NewReader(resultBytes),
 	)
 	if err != nil {
-		logger.Error("Failed to create postback request", "error", err)
-		return
+		logger.Error(
+			"Failed to create postback request",
+			"post_id", message.PostId,
+			"attempt", attempt,
+			"error", err,
+		)
+		return true, err
 	}
 
-	logger.Info("Sending postback", "post_id", message.PostId, "url", postbackReq.URL)
+	if attempt == 1 {
+		logger.Info("Sending postback", "post_id", message.PostId, "url", postbackReq.URL)
+	}
+
 	res, err := svc.HTTPClient.Do(postbackReq)
 	if err != nil {
-		logger.Error("Failed to send postback", "error", err)
-		return
+		logger.Error(
+			"Failed to send postback",
+			"post_id", message.PostId,
+			"attempt", attempt,
+			"error", err,
+		)
+		return false, err
 	}
 	defer func() {
-		err = res.Body.Close()
-		if err != nil {
-			logger.Error("Failed to close response", "error", err)
+		if cerr := res.Body.Close(); cerr != nil {
+			logger.Error("Failed to close response", "error", cerr)
 		}
 	}()
 
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
-		logger.Error("Failed to read postback response body", "error", err)
-		return
+		logger.Error(
+			"Failed to read postback response body",
+			"post_id", message.PostId,
+			"attempt", attempt,
+			"error", err,
+		)
+		return false, err
 	}
 
 	if res.StatusCode == http.StatusOK {
-		logger.Info("Postback sent", "post_id", message.PostId)
+		logger.Info("Postback sent", "post_id", message.PostId, "attempt", attempt)
 		if len(bodyBytes) > 0 {
 			logger.Info("Received response", "data", string(bodyBytes))
 		}
-		return
+		return true, nil
 	}
 
 	var response errorResponse
-	err = json.Unmarshal(bodyBytes, &response)
-	if err != nil {
-		logger.Error(
-			"Postback failed",
-			"post_id",
-			message.PostId,
-			"status_code",
-			res.StatusCode,
-		)
-		if len(bodyBytes) > 0 {
-			logger.Error("Received error response", "data", string(bodyBytes))
-		}
-		return
-	}
+	parseErr := json.Unmarshal(bodyBytes, &response)
 
-	if res.StatusCode == http.StatusBadRequest &&
+	if parseErr == nil && res.StatusCode == http.StatusBadRequest &&
 		strings.Contains(strings.ToLower(response.Error), "fulfilled") {
 		logger.Info("Postback already sent", "post_id", message.PostId)
-		return
+		return true, nil
+	}
+
+	// 5xx responses (and any other unexpected non-2xx without a parseable body)
+	// are treated as transient. 4xx responses with a parseable error body are
+	// terminal — retrying a malformed request will not help.
+	retryable := res.StatusCode >= 500 || parseErr != nil
+
+	if retryable {
+		logger.Error(
+			"Postback failed (will retry if attempts remain)",
+			"post_id", message.PostId,
+			"attempt", attempt,
+			"status_code", res.StatusCode,
+			"message", response.Error,
+		)
+		if parseErr != nil && len(bodyBytes) > 0 {
+			logger.Error("Received error response", "data", string(bodyBytes))
+		}
+		return false, fmt.Errorf("postback failed: status %d: %s", res.StatusCode, response.Error)
 	}
 
 	logger.Error(
-		"Postback failed",
-		"post_id",
-		message.PostId,
-		"status_code",
-		res.StatusCode,
-		"message",
-		response.Error,
+		"Postback failed (non-retryable)",
+		"post_id", message.PostId,
+		"attempt", attempt,
+		"status_code", res.StatusCode,
+		"message", response.Error,
 	)
+	return true, fmt.Errorf("postback failed: status %d: %s", res.StatusCode, response.Error)
 }
 
 func runService(params *serviceContext) {

--- a/cmd/agent_smith/service_context.go
+++ b/cmd/agent_smith/service_context.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/interpreter"
@@ -20,6 +21,13 @@ type serviceContext struct {
 
 	Executor   interpreter.Executor
 	HTTPClient *http.Client
+
+	// PostbackMaxAttempts is the total number of postback attempts (including
+	// the initial try) before giving up. Defaults to postbackMaxAttempts.
+	PostbackMaxAttempts int
+	// PostbackBaseRetryBackoff is the base delay used for exponential backoff
+	// between postback attempts. Defaults to postbackBaseRetryBackoff.
+	PostbackBaseRetryBackoff time.Duration
 }
 
 func newServiceContext(
@@ -57,6 +65,8 @@ func newServiceContext(
 	params.Domain = domain
 	params.Executor = executor
 	params.HTTPClient = &http.Client{Timeout: postbackHTTPTimeout}
+	params.PostbackMaxAttempts = postbackMaxAttempts
+	params.PostbackBaseRetryBackoff = postbackBaseRetryBackoff
 
 	return &params, nil
 }


### PR DESCRIPTION
## Summary
- Add a retry loop with exponential backoff for postbacks so transient failures (network errors, 5xx responses) no longer silently drop command results; non-retryable cases (success, 400 \"already fulfilled\", other 4xx) still terminate immediately.
- Make retry behavior configurable via `PostbackMaxAttempts` and `PostbackBaseRetryBackoff` on `serviceContext` (defaults: 3 attempts, 1s base backoff). Context cancellation short-circuits the backoff sleep so disconnects don't block.
- Cover the new behavior with tests for 5xx retry-then-succeed, network-error retry-then-succeed, retry exhaustion, first-attempt success (no extra calls / no backoff cost), 4xx terminal, and context-cancel mid-retry.

## Test plan
- [x] `go test ./cmd/agent_smith/...` passes locally
- [x] CI test workflow is green
- [x] Integration test workflow run (`workflow_dispatch`, `os: all`) passes end-to-end, including the existing \"Sending postback\" / \"Postback sent\" / \"Postback already sent\" assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)