### PR TITLE
ci: [sc-94314] Collapse per-OS integration-test jobs into matrix backed by composite actions

### DIFF
--- a/.github/actions/assert-log-contains/action.yml
+++ b/.github/actions/assert-log-contains/action.yml
@@ -1,0 +1,70 @@
+name: Assert log contains
+description: Assert that a log file contains every supplied pattern (substring match). Optionally sleeps before reading the log.
+
+inputs:
+  log_file:
+    description: "Path to the log file"
+    required: true
+  patterns:
+    description: "Newline-separated list of required substrings"
+    required: true
+  wait_seconds:
+    description: "Seconds to sleep before reading the log"
+    required: false
+    default: "0"
+  subscribed_topic_qos:
+    description: "When 'true', additionally require the matching line to include 'topic=' and 'qos=' tokens (used by the 'Subscribed to messages' check)"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Assert log contains
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+        PATTERNS: ${{ inputs.patterns }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+        SUBSCRIBED: ${{ inputs.subscribed_topic_qos }}
+      run: |
+        if ([int]$env:WAIT_SECONDS -gt 0) {
+          Start-Sleep -Seconds ([int]$env:WAIT_SECONDS)
+        }
+
+        if (-not (Test-Path $env:LOG_FILE)) {
+          Write-Error "Log file not found: $env:LOG_FILE"
+          exit 1
+        }
+        $logContent = Get-Content $env:LOG_FILE -Raw
+        Write-Output $logContent
+
+        $patternList = $env:PATTERNS -split "`r?`n" | Where-Object { $_ -and $_.Trim() }
+        $failed = $false
+        foreach ($pattern in $patternList) {
+          if ($logContent -notmatch [regex]::Escape($pattern)) {
+            Write-Error "Expected log line not found: $pattern"
+            $failed = $true
+          } else {
+            Write-Output "OK: found '$pattern'"
+          }
+        }
+
+        if ($env:SUBSCRIBED -eq "true") {
+          $subscribedLine = ($logContent -split "`r?`n" | Where-Object { $_ -match "Subscribed to messages" } | Select-Object -First 1)
+          if (-not $subscribedLine) {
+            Write-Error "Expected 'Subscribed to messages' not found in logs"
+            $failed = $true
+          } else {
+            foreach ($token in @("topic=", "qos=")) {
+              if ($subscribedLine -notmatch [regex]::Escape($token)) {
+                Write-Error "Expected '$token' not found in 'Subscribed to messages' log line"
+                $failed = $true
+              }
+            }
+            Write-Output "Subscribed messages log: $subscribedLine"
+          }
+        }
+
+        if ($failed) { exit 1 }
+        Write-Output "All expected log patterns found"

--- a/.github/actions/assert-log-missing/action.yml
+++ b/.github/actions/assert-log-missing/action.yml
@@ -1,0 +1,55 @@
+name: Assert log missing
+description: Assert that a log file does NOT contain the supplied pattern. Can optionally wait for the log file to be created first and/or sleep before reading.
+
+inputs:
+  log_file:
+    description: "Path to the log file"
+    required: true
+  pattern:
+    description: "Substring that must NOT appear in the log"
+    required: true
+  wait_seconds:
+    description: "Seconds to sleep before reading the log"
+    required: false
+    default: "0"
+  wait_for_file_seconds:
+    description: "Maximum seconds to wait for the log file to exist before reading (polls every second)"
+    required: false
+    default: "0"
+
+runs:
+  using: composite
+  steps:
+    - name: Assert log missing
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+        PATTERN: ${{ inputs.pattern }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+        WAIT_FOR_FILE_SECONDS: ${{ inputs.wait_for_file_seconds }}
+      run: |
+        $waitForFile = [int]$env:WAIT_FOR_FILE_SECONDS
+        if ($waitForFile -gt 0) {
+          for ($i = 1; $i -le $waitForFile; $i++) {
+            if (Test-Path $env:LOG_FILE) { break }
+            Write-Output "Waiting for log file to be created... ($i/$waitForFile)"
+            Start-Sleep -Seconds 1
+          }
+        }
+
+        if ([int]$env:WAIT_SECONDS -gt 0) {
+          Start-Sleep -Seconds ([int]$env:WAIT_SECONDS)
+        }
+
+        if (-not (Test-Path $env:LOG_FILE)) {
+          Write-Error "Log file not found: $env:LOG_FILE"
+          exit 1
+        }
+        $logContent = Get-Content $env:LOG_FILE -Raw
+        Write-Output $logContent
+
+        if ($logContent -match [regex]::Escape($env:PATTERN)) {
+          Write-Error "Unexpected log line found: $env:PATTERN"
+          exit 1
+        }
+        Write-Output "Confirmed: '$env:PATTERN' not present in log"

--- a/.github/actions/assert-syslog-contains/action.yml
+++ b/.github/actions/assert-syslog-contains/action.yml
@@ -1,0 +1,72 @@
+name: Assert syslog contains
+description: Assert that the platform system log (journalctl / Windows Event Log / macOS unified log) contains the supplied pattern for the given service.
+
+inputs:
+  service:
+    description: "Service name used as syslog tag / Event Log provider name"
+    required: true
+  pattern:
+    description: "Substring that must appear in the syslog entries"
+    required: true
+  wait_seconds:
+    description: "Seconds to sleep before reading the syslog"
+    required: false
+    default: "15"
+
+runs:
+  using: composite
+  steps:
+    - name: Assert syslog contains (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        PATTERN: ${{ inputs.pattern }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      run: |
+        sleep "$WAIT_SECONDS"
+        entries=$(journalctl -t "$SERVICE" --no-pager 2>/dev/null || sudo grep "$SERVICE" /var/log/syslog 2>/dev/null || sudo grep "$SERVICE" /var/log/messages 2>/dev/null || true)
+        echo "$entries"
+
+        if ! echo "$entries" | grep -qF "$PATTERN"; then
+          echo "ERROR: Expected '$PATTERN' entry not found in syslog"
+          exit 1
+        fi
+        echo "Found '$PATTERN' in syslog"
+
+    - name: Assert syslog contains (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        PATTERN: ${{ inputs.pattern }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      run: |
+        Start-Sleep -Seconds ([int]$env:WAIT_SECONDS)
+        $events = Get-WinEvent -LogName Application -FilterXPath "*[System[Provider[@Name='$env:SERVICE']]]"
+        Write-Output "Found $($events.Count) event(s)"
+        $events | ForEach-Object { Write-Output $_.Message }
+
+        $matched = $events | Where-Object { $_.Message -match [regex]::Escape($env:PATTERN) }
+        if (-not $matched) {
+          Write-Error "Expected '$env:PATTERN' entry not found in Windows Event Log"
+          exit 1
+        }
+        Write-Output "Found '$env:PATTERN' in Windows Event Log"
+
+    - name: Assert syslog contains (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        PATTERN: ${{ inputs.pattern }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+      run: |
+        sleep "$WAIT_SECONDS"
+        entries=$(log show --predicate 'processImagePath contains "logger"' --info --last 5m 2>/dev/null || true)
+        echo "$entries"
+
+        if ! echo "$entries" | grep -qF "$PATTERN"; then
+          echo "ERROR: Expected '$PATTERN' entry not found in syslog"
+          exit 1
+        fi
+        echo "Found '$PATTERN' in syslog"

--- a/.github/actions/assert-uninstalled/action.yml
+++ b/.github/actions/assert-uninstalled/action.yml
@@ -1,0 +1,29 @@
+name: Assert uninstalled
+description: Assert that the supplied list of paths no longer exists. Each line is treated as one path. Pwsh-style environment variables (e.g. $env:TMPDIR) are expanded before checking.
+
+inputs:
+  paths:
+    description: "Newline-separated list of paths that must not exist"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Assert uninstalled
+      shell: pwsh
+      env:
+        PATHS: ${{ inputs.paths }}
+      run: |
+        $pathList = $env:PATHS -split "`r?`n" | Where-Object { $_ -and $_.Trim() }
+        $failed = $false
+        foreach ($path in $pathList) {
+          $expanded = $ExecutionContext.InvokeCommand.ExpandString($path).Trim()
+          if (Test-Path -Path $expanded) {
+            Write-Error "Path still exists: $expanded"
+            $failed = $true
+          } else {
+            Write-Output "OK: $expanded is gone"
+          }
+        }
+        if ($failed) { exit 1 }
+        Write-Output "All directories have been deleted"

--- a/.github/actions/check-profile-noise/action.yml
+++ b/.github/actions/check-profile-noise/action.yml
@@ -1,0 +1,34 @@
+name: Check install output for profile noise
+description: Assert that the injected PowerShell profile noise is NOT present in the captured install output, proving that the agent installer suppresses the PowerShell profile via -NoProfile. Windows-only - a no-op on other runners.
+
+inputs:
+  install_output_path:
+    description: "Path to the file containing the captured install output"
+    required: true
+  noise:
+    description: "Marker injected by the inject-profile-noise action"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check install output for profile noise
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        INSTALL_OUTPUT_PATH: ${{ inputs.install_output_path }}
+        NOISE: ${{ inputs.noise }}
+      run: |
+        if (-not (Test-Path $env:INSTALL_OUTPUT_PATH)) {
+          Write-Error "Install output file not found: $env:INSTALL_OUTPUT_PATH"
+          exit 1
+        }
+        $installOutput = Get-Content $env:INSTALL_OUTPUT_PATH -Raw
+        Write-Output "=== Install output ==="
+        Write-Output $installOutput
+        Write-Output "======================"
+        if ($installOutput -match [regex]::Escape($env:NOISE)) {
+          Write-Error "FAIL: Profile noise '$env:NOISE' found in install output - PowerShell profile output contaminated agent data"
+          exit 1
+        }
+        Write-Output "PASS: Profile noise not found in install output - -NoProfile flag correctly suppresses profile output"

--- a/.github/actions/check-service/action.yml
+++ b/.github/actions/check-service/action.yml
@@ -1,0 +1,28 @@
+name: Check service
+description: Query the platform service manager to confirm the agent service is registered.
+
+inputs:
+  service:
+    description: "Service name"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check service (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        systemctl status "${{ inputs.service }}"
+
+    - name: Check service (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        sc.exe query "${{ inputs.service }}"
+
+    - name: Check service (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        sudo launchctl print "system/${{ inputs.service }}"

--- a/.github/actions/delete-log/action.yml
+++ b/.github/actions/delete-log/action.yml
@@ -1,0 +1,26 @@
+name: Delete log
+description: Delete the agent log file at the supplied path. Uses sudo on Unix.
+
+inputs:
+  log_file:
+    description: "Path to the log file"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Delete log (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+      run: |
+        sudo rm -f "$LOG_FILE"
+
+    - name: Delete log (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+      run: |
+        Remove-Item -Force "$env:LOG_FILE"

--- a/.github/actions/inject-profile-noise/action.yml
+++ b/.github/actions/inject-profile-noise/action.yml
@@ -1,0 +1,22 @@
+name: Inject PowerShell profile noise
+description: Inject a unique marker into the all-users Windows PowerShell profile so a downstream step can verify that -NoProfile is honoured during agent install. Windows-only - a no-op on other runners.
+
+outputs:
+  noise:
+    description: "Unique marker string injected into the profile (empty on non-Windows runners)"
+    value: ${{ steps.inject.outputs.noise }}
+
+runs:
+  using: composite
+  steps:
+    - name: Inject profile noise
+      id: inject
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        $noise = "PROFILE_NOISE_$(New-Guid)"
+        $profilePath = $PROFILE.AllUsersAllHosts
+        New-Item -ItemType Directory -Force -Path (Split-Path $profilePath) | Out-Null
+        Add-Content -Path $profilePath -Value "Write-Output '$noise'"
+        Write-Output "Profile noise '$noise' injected to: $profilePath"
+        "noise=$noise" >> $env:GITHUB_OUTPUT

--- a/.github/actions/install-agent/action.yml
+++ b/.github/actions/install-agent/action.yml
@@ -1,0 +1,76 @@
+name: Install agent
+description: Download compiled and integration test binaries, install the agent, and tee install output for later assertions.
+
+inputs:
+  os:
+    description: "Matrix OS (ubuntu-latest, windows-latest, macos-latest)"
+    required: true
+  binary:
+    description: "File name of the compiled agent binary (e.g. rewst_agent_config.linux.bin)"
+    required: true
+  it_binary:
+    description: "File name of the integration test agent binary"
+    required: true
+  config_url:
+    description: "Rewst config URL"
+    required: true
+  config_secret:
+    description: "Rewst config secret"
+    required: true
+  org_id:
+    description: "Rewst org id"
+    required: true
+  github_token:
+    description: "GitHub token used by the agent installer"
+    required: true
+
+outputs:
+  install_output_path:
+    description: "Path of the file containing the captured install output"
+    value: ${{ steps.install-unix.outputs.path || steps.install-windows.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download compiled binary
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.os }}
+        path: ./dist
+
+    - name: Download integration test binary
+      uses: actions/download-artifact@v8
+      with:
+        name: it-${{ inputs.os }}
+        path: ./dist
+
+    - name: Make binaries executable
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        chmod +x "./dist/${{ inputs.binary }}"
+        chmod +x "./dist/${{ inputs.it_binary }}"
+
+    - name: Install agent (Unix)
+      id: install-unix
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        sudo "./dist/${{ inputs.binary }}" \
+          --config-url "${{ inputs.config_url }}" \
+          --config-secret "${{ inputs.config_secret }}" \
+          --org-id "${{ inputs.org_id }}" \
+          --github-token "${{ inputs.github_token }}" 2>&1 | tee install_output.txt
+        echo "path=install_output.txt" >> "$GITHUB_OUTPUT"
+
+    - name: Install agent (Windows)
+      id: install-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        ./dist/${{ inputs.binary }} `
+          --config-url "${{ inputs.config_url }}" `
+          --config-secret "${{ inputs.config_secret }}" `
+          --org-id "${{ inputs.org_id }}" `
+          --github-token "${{ inputs.github_token }}" 2>&1 | Tee-Object -FilePath install_output.txt
+        "path=install_output.txt" >> $env:GITHUB_OUTPUT

--- a/.github/actions/run-agent/action.yml
+++ b/.github/actions/run-agent/action.yml
@@ -1,0 +1,25 @@
+name: Run agent command
+description: Run the agent binary with the supplied arguments. Uses sudo on Unix and runs natively on Windows.
+
+inputs:
+  binary:
+    description: "File name (under ./dist) of the agent binary to invoke"
+    required: true
+  args:
+    description: "Arguments to pass to the agent binary"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run agent (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        sudo "./dist/${{ inputs.binary }}" ${{ inputs.args }}
+
+    - name: Run agent (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        & "./dist/${{ inputs.binary }}" ${{ inputs.args }}

--- a/.github/actions/send-command/action.yml
+++ b/.github/actions/send-command/action.yml
@@ -1,0 +1,27 @@
+name: Send command
+description: Send a command to the agent via the Rewst trigger webhook using curl.
+
+inputs:
+  trigger_url:
+    description: "Rewst trigger URL"
+    required: true
+  device_id:
+    description: "Target device id"
+    required: true
+  commands:
+    description: "Raw value for the curl --form commands=... field. Should already include any surrounding quoting expected by the Rewst engine."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send command
+      shell: bash
+      env:
+        TRIGGER_URL: ${{ inputs.trigger_url }}
+        DEVICE_ID: ${{ inputs.device_id }}
+        COMMANDS: ${{ inputs.commands }}
+      run: |
+        curl --location "$TRIGGER_URL" \
+          --form "device_id=\"$DEVICE_ID\"" \
+          --form "commands=$COMMANDS"

--- a/.github/actions/stop-service/action.yml
+++ b/.github/actions/stop-service/action.yml
@@ -1,0 +1,28 @@
+name: Stop service
+description: Stop the agent service via the appropriate platform service manager.
+
+inputs:
+  service:
+    description: "Service name"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Stop service (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo systemctl stop "${{ inputs.service }}"
+
+    - name: Stop service (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        sc.exe stop "${{ inputs.service }}"
+
+    - name: Stop service (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        sudo launchctl stop "system/${{ inputs.service }}" || true

--- a/.github/actions/validate-config/action.yml
+++ b/.github/actions/validate-config/action.yml
@@ -1,0 +1,51 @@
+name: Validate config
+description: Assert config.json contains the required fields and rewst_org_id matches the expected value. Also exposes device_id as an output.
+
+inputs:
+  config_dir:
+    description: "Directory containing the per-org agent config (without org id suffix)"
+    required: true
+  org_id:
+    description: "Expected rewst_org_id"
+    required: true
+
+outputs:
+  device_id:
+    description: "device_id read from config.json"
+    value: ${{ steps.parse.outputs.device_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse and validate config.json
+      id: parse
+      shell: pwsh
+      run: |
+        $configPath = "${{ inputs.config_dir }}/${{ inputs.org_id }}/config.json"
+        if (-not (Test-Path $configPath)) {
+          Write-Error "config.json not found at $configPath"
+          exit 1
+        }
+        $config = Get-Content $configPath -Raw | ConvertFrom-Json
+
+        $required = @("device_id", "rewst_org_id", "rewst_engine_host", "shared_access_key", "azure_iot_hub_host")
+        $failed = $false
+        foreach ($field in $required) {
+          $value = $config.$field
+          if ([string]::IsNullOrWhiteSpace($value)) {
+            Write-Error "Config field '$field' is missing or empty"
+            $failed = $true
+          } else {
+            Write-Output "OK: $field = $value"
+          }
+        }
+
+        if ($config.rewst_org_id -ne "${{ inputs.org_id }}") {
+          Write-Error "rewst_org_id '$($config.rewst_org_id)' does not match expected '${{ inputs.org_id }}'"
+          $failed = $true
+        }
+
+        if ($failed) { exit 1 }
+
+        "device_id=$($config.device_id)" >> $env:GITHUB_OUTPUT
+        Write-Output "All config.json fields validated"

--- a/.github/actions/verify-auto-update/action.yml
+++ b/.github/actions/verify-auto-update/action.yml
@@ -1,0 +1,50 @@
+name: Verify auto update completed
+description: Assert the agent's log shows the auto updater ran and that the agent is no longer running the integration-test version (v0.0.0-it).
+
+inputs:
+  log_file:
+    description: "Path to the agent log file"
+    required: true
+  wait_seconds:
+    description: "Seconds to sleep before reading the log"
+    required: false
+    default: "15"
+  it_version:
+    description: "Version token expected to be absent from the last 'Agent Smith started' line"
+    required: false
+    default: "version=v0.0.0-it"
+
+runs:
+  using: composite
+  steps:
+    - name: Verify auto update completed
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+        WAIT_SECONDS: ${{ inputs.wait_seconds }}
+        IT_VERSION: ${{ inputs.it_version }}
+      run: |
+        Start-Sleep -Seconds ([int]$env:WAIT_SECONDS)
+        if (-not (Test-Path $env:LOG_FILE)) {
+          Write-Error "Log file not found: $env:LOG_FILE"
+          exit 1
+        }
+        $logContent = Get-Content $env:LOG_FILE -Raw
+        Write-Output $logContent
+
+        $failed = $false
+        foreach ($pattern in @("Checking for updates", "Updating agent")) {
+          if ($logContent -notmatch [regex]::Escape($pattern)) {
+            Write-Error "Expected auto update log line not found: $pattern"
+            $failed = $true
+          }
+        }
+
+        $lastStartLine = ($logContent -split "`r?`n" | Where-Object { $_ -match "Agent Smith started" } | Select-Object -Last 1)
+        if ($lastStartLine -and ($lastStartLine -match [regex]::Escape($env:IT_VERSION))) {
+          Write-Error "Agent is still running the integration test version after update: $lastStartLine"
+          $failed = $true
+        }
+
+        if ($failed) { exit 1 }
+        Write-Output "Auto updater integration test passed"

--- a/.github/actions/wait-for-log-line/action.yml
+++ b/.github/actions/wait-for-log-line/action.yml
@@ -1,0 +1,42 @@
+name: Wait for log line
+description: Poll a log file until it contains the supplied pattern or the attempt budget is exhausted. Does not fail if the pattern never appears - asserting presence is the caller's job.
+
+inputs:
+  log_file:
+    description: "Path to the log file"
+    required: true
+  pattern:
+    description: "Substring to wait for"
+    required: true
+  max_attempts:
+    description: "Maximum number of poll attempts"
+    required: false
+    default: "60"
+  interval_seconds:
+    description: "Seconds between poll attempts"
+    required: false
+    default: "2"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for log line
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ inputs.log_file }}
+        PATTERN: ${{ inputs.pattern }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        INTERVAL: ${{ inputs.interval_seconds }}
+      run: |
+        $maxAttempts = [int]$env:MAX_ATTEMPTS
+        $interval = [int]$env:INTERVAL
+        Write-Output "Waiting for '$env:PATTERN' in $env:LOG_FILE (up to $maxAttempts attempts, $interval s interval)..."
+        for ($i = 1; $i -le $maxAttempts; $i++) {
+          $logContent = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          if ($logContent -and ($logContent -match [regex]::Escape($env:PATTERN))) {
+            Write-Output "Pattern '$env:PATTERN' found after $i attempt(s) (~$($i * $interval)s)"
+            exit 0
+          }
+          Start-Sleep -Seconds $interval
+        }
+        Write-Output "Pattern '$env:PATTERN' did not appear within $maxAttempts attempts; downstream assertions will surface the failure"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -63,406 +63,22 @@ jobs:
           name: it-${{ matrix.os }}
           path: ${{ steps.build.outputs.binary_path || './dist/*' }}
 
-  test-ubuntu-latest:
+  set-matrix:
     permissions:
       contents: read
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [build, build-integration-test]
-    if: inputs.os == 'ubuntu-latest' || inputs.os == 'all'
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
     steps:
-      - name: Download compiled binary
-        uses: actions/download-artifact@v8
-        with:
-          name: ubuntu-latest
-          path: ./dist
-
-      - name: Download integration test binary
-        uses: actions/download-artifact@v8
-        with:
-          name: it-ubuntu-latest
-          path: ./dist
-
-      - name: Make binaries executable
-        run: |
-          chmod +x ./dist/rewst_agent_config.linux.bin
-          chmod +x ./dist/rewst_agent_config.linux.it.bin
-
-      - name: Install agent
-        id: install_agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.bin --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "service=rewst_remote_agent_${{ vars.IT_ORG_ID }}" >> $GITHUB_OUTPUT
-
-      - name: Check service
-        shell: bash
-        run: |
-          systemctl status ${{ steps.install_agent.outputs.service }}
-
-      - name: Get device id
-        id: get_device_id
-        shell: bash
-        run: |
-          echo "value=$(cat /etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/config.json | jq -r '.device_id')" >> "$GITHUB_OUTPUT"
-
-      - name: Validate config.json fields
-        shell: bash
-        run: |
-          config="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/config.json"
-          failed=false
-
-          for field in device_id rewst_org_id rewst_engine_host shared_access_key azure_iot_hub_host; do
-            val=$(jq -r ".$field" "$config")
-            if [ -z "$val" ] || [ "$val" = "null" ]; then
-              echo "ERROR: Config field '$field' is missing or empty"
-              failed=true
-            else
-              echo "OK: $field = $val"
-            fi
-          done
-
-          org_id=$(jq -r '.rewst_org_id' "$config")
-          if [ "$org_id" != "${{ vars.IT_ORG_ID }}" ]; then
-            echo "ERROR: rewst_org_id '$org_id' does not match expected '${{ vars.IT_ORG_ID }}'"
-            failed=true
-          fi
-
-          if [ "$failed" = true ]; then exit 1; fi
-          echo "All config.json fields validated"
-
-      - name: Check subscribed messages log for topic and QoS
-        shell: bash
-        run: |
-          sleep 10
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          subscribedLine=$(echo "$logContent" | grep "Subscribed to messages" | head -1)
-          if [ -z "$subscribedLine" ]; then
-            echo "ERROR: Expected 'Subscribed to messages' not found in logs"
-            exit 1
-          fi
-          if ! echo "$subscribedLine" | grep -qF "topic="; then
-            echo "ERROR: Expected 'topic=' not found in 'Subscribed to messages' log line"
-            exit 1
-          fi
-          if ! echo "$subscribedLine" | grep -qF "qos="; then
-            echo "ERROR: Expected 'qos=' not found in 'Subscribed to messages' log line"
-            exit 1
-          fi
-          echo "Subscribed messages log includes topic and QoS: $subscribedLine"
-
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
-
-      - name: Check logs
-        shell: bash
-        run: |
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          for pattern in "Command completed" "Sending postback" "Postback sent"; do
-            if ! echo "$logContent" | grep -qF "$pattern"; then
-              echo "ERROR: Expected log line not found: $pattern"
-              exit 1
-            fi
-          done
-          echo "All expected log lines found"
-
-      - name: Send failing command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="exit 1"'
-
-      - name: Check logs for error handling
-        shell: bash
-        run: |
-          sleep 15
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          if ! echo "$logContent" | grep -qF "Command failed"; then
-            echo "ERROR: Expected 'Command failed' not found in logs"
-            exit 1
-          fi
-          echo "Error handling verified: failing command error was captured"
-
-      - name: Install integration test binary (old version)
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.it.bin --update --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "Installed integration test binary (version v0.0.0-it)"
-
-      - name: Wait for auto updater to trigger and update
-        shell: bash
-        run: |
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          echo "Waiting for auto updater to detect newer version and update..."
-          for i in $(seq 1 60); do
-            logContent=$(cat "$logFile" 2>/dev/null || true)
-            if echo "$logContent" | grep -qF "Updating agent"; then
-              echo "Auto update triggered after ${i}s"
-              break
-            fi
-            sleep 2
-          done
-
-      - name: Verify auto update completed
-        shell: bash
-        run: |
-          sleep 15
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          for pattern in "Checking for updates" "Updating agent"; do
-            if ! echo "$logContent" | grep -qF "$pattern"; then
-              echo "ERROR: Expected auto update log line not found: $pattern"
-              exit 1
-            fi
-          done
-
-          if echo "$logContent" | grep -qF "version=v0.0.0-it"; then
-            lastVersion=$(echo "$logContent" | grep "Agent Smith started" | tail -1)
-            if echo "$lastVersion" | grep -qF "version=v0.0.0-it"; then
-              echo "ERROR: Agent is still running the integration test version after update"
-              exit 1
-            fi
-          fi
-          echo "Auto updater integration test passed"
-
-      - name: Update logging level to debug
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.bin --update --org-id ${{ vars.IT_ORG_ID }} --logging-level debug --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "Logging level successfully updated to debug"
-
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
-
-      - name: Check logs for debug level
-        shell: bash
-        run: |
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          if ! echo "$logContent" | grep -qF "DEBUG"; then
-            echo "ERROR: Expected log line not found: DEBUG"
-            exit 1
-          fi
-          echo "All expected log lines found"
-
-      - name: Stop service
-        shell: bash
-        run: |
-          sudo systemctl stop ${{ steps.install_agent.outputs.service }}
-
-      - name: Delete log file
-        shell: bash
-        run: |
-          sudo rm -f "/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-
-      - name: Update agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.bin --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates --github-token ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check logs for no auto updater
-        shell: bash
-        run: |
-          logFile="/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          for i in $(seq 1 30); do
-            [ -f "$logFile" ] && break
-            echo "Waiting for log file to be created... ($i/30)"
-            sleep 1
-          done
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          if echo "$logContent" | grep -qF "Starting auto updater"; then
-            echo "ERROR: Unexpected log line found: Starting auto updater"
-            exit 1
-          fi
-          echo "Confirmed: no 'Starting auto updater' log line found"
-
-      - name: Update agent with syslog
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.bin --update --org-id ${{ vars.IT_ORG_ID }} --syslog --github-token ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
-
-      - name: Check syslog for command completed
-        shell: bash
-        run: |
-          sleep 15
-          entries=$(journalctl -t "rewst_remote_agent_${{ vars.IT_ORG_ID }}" --no-pager 2>/dev/null || sudo grep "rewst_remote_agent_${{ vars.IT_ORG_ID }}" /var/log/syslog 2>/dev/null || sudo grep "rewst_remote_agent_${{ vars.IT_ORG_ID }}" /var/log/messages 2>/dev/null || true)
-          echo "$entries"
-
-          if ! echo "$entries" | grep -qF "Command completed"; then
-            echo "ERROR: Expected 'Command completed' entry not found in syslog"
-            exit 1
-          fi
-          echo "Found 'Command completed' in syslog"
-
-      - name: Uninstall agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.linux.bin --uninstall --org-id ${{ vars.IT_ORG_ID }}
-
-      - name: Check deleted directories
+      - name: Build test matrix include
+        id: gen
         shell: pwsh
+        env:
+          OS_INPUT: ${{ inputs.os }}
+          ORG_ID: ${{ vars.IT_ORG_ID }}
         run: |
-          if (Test-Path -Path "/etc/rewst_remote_agent/${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "/usr/local/bin/rewst_remote_agent/${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "/tmp/rewst_remote_agent/scripts/${{ vars.IT_ORG_ID }}") { exit 1 }
-          echo "All directories have been deleted"
-
-  test-windows-latest:
-    permissions:
-      contents: read
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [build, build-integration-test]
-    if: inputs.os == 'windows-latest' || inputs.os == 'all'
-    runs-on: windows-latest
-    steps:
-      - name: Download compiled binary
-        uses: actions/download-artifact@v8
-        with:
-          name: windows-latest
-          path: ./dist
-
-      - name: Download integration test binary
-        uses: actions/download-artifact@v8
-        with:
-          name: it-windows-latest
-          path: ./dist
-
-      - name: Inject PowerShell profile noise
-        id: inject_profile_noise
-        shell: powershell
-        run: |
-          $noise = "PROFILE_NOISE_$(New-Guid)"
-          $profilePath = $PROFILE.AllUsersAllHosts
-          New-Item -ItemType Directory -Force -Path (Split-Path $profilePath) | Out-Null
-          Add-Content -Path $profilePath -Value "Write-Output '$noise'"
-          Write-Output "Profile noise '$noise' injected to: $profilePath"
-          "noise=$noise" >> $env:GITHUB_OUTPUT
-
-      - name: Install agent
-        id: install_agent
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.exe --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }} 2>&1 | Tee-Object -FilePath install_output.txt
-          Write-Output "service=RewstRemoteAgent_${{ vars.IT_ORG_ID }}" >> $env:GITHUB_OUTPUT
-
-      - name: Check install output for profile noise
-        shell: pwsh
-        run: |
-          $noise = "${{ steps.inject_profile_noise.outputs.noise }}"
-          $installOutput = Get-Content install_output.txt -Raw
-          Write-Output "=== Install output ==="
-          Write-Output $installOutput
-          Write-Output "======================"
-          if ($installOutput -match [regex]::Escape($noise)) {
-            Write-Error "FAIL: Profile noise '$noise' found in install output — PowerShell profile output contaminated agent data"
-            exit 1
-          }
-          Write-Output "PASS: Profile noise not found in install output — -NoProfile flag correctly suppresses profile output"
-
-      - name: Check service
-        shell: pwsh
-        run: |
-          sc.exe query ${{ steps.install_agent.outputs.service }}
-
-      - name: Get device id
-        id: get_device_id
-        shell: pwsh
-        run: |
-          (Get-Content C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\config.json | ConvertFrom-Json).device_id | % { "value=$_" } >> $env:GITHUB_OUTPUT
-
-      - name: Validate config.json fields
-        shell: pwsh
-        run: |
-          $config = Get-Content C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\config.json | ConvertFrom-Json
-
-          $requiredFields = @(
-            @{ Name = "device_id";          Value = $config.device_id },
-            @{ Name = "rewst_org_id";       Value = $config.rewst_org_id },
-            @{ Name = "rewst_engine_host";  Value = $config.rewst_engine_host },
-            @{ Name = "shared_access_key";  Value = $config.shared_access_key },
-            @{ Name = "azure_iot_hub_host"; Value = $config.azure_iot_hub_host }
-          )
-
-          $failed = $false
-          foreach ($field in $requiredFields) {
-            if ([string]::IsNullOrWhiteSpace($field.Value)) {
-              Write-Error "Config field '$($field.Name)' is missing or empty"
-              $failed = $true
-            } else {
-              Write-Output "OK: $($field.Name) = $($field.Value)"
-            }
-          }
-
-          if ($config.rewst_org_id -ne "${{ vars.IT_ORG_ID }}") {
-            Write-Error "rewst_org_id '$($config.rewst_org_id)' does not match expected '${{ vars.IT_ORG_ID }}'"
-            $failed = $true
-          }
-
-          if ($failed) { exit 1 }
-          Write-Output "All config.json fields validated"
-
-      - name: Check subscribed messages log for topic and QoS
-        shell: pwsh
-        run: |
-          Start-Sleep -Seconds 10
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
-
-          $subscribedLine = ($logContent -split "`n" | Where-Object { $_ -match "Subscribed to messages" } | Select-Object -First 1)
-          if (-not $subscribedLine) {
-            Write-Error "Expected 'Subscribed to messages' not found in logs"
-            exit 1
-          }
-          if ($subscribedLine -notmatch [regex]::Escape("topic=")) {
-            Write-Error "Expected 'topic=' not found in 'Subscribed to messages' log line"
-            exit 1
-          }
-          if ($subscribedLine -notmatch [regex]::Escape("qos=")) {
-            Write-Error "Expected 'qos=' not found in 'Subscribed to messages' log line"
-            exit 1
-          }
-          Write-Output "Subscribed messages log includes topic and QoS: $subscribedLine"
-
-      - name: Send test command
-        shell: pwsh
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $winSuccess = @'
+          "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
           $PS_Results = New-Object -TypeName psobject
 
@@ -472,35 +88,11 @@ jobs:
 
           # Post results back to Rewst
           $postData = $PS_Results | ConvertTo-Json
-          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
+          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""
+          '@
 
-      - name: Check logs
-        shell: pwsh
-        run: |
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
-
-          $expectedPatterns = @(
-            "Command completed",
-            "Sending postback",
-            "Postback already sent"
-          )
-
-          foreach ($pattern in $expectedPatterns) {
-            if ($logContent -notmatch [regex]::Escape($pattern)) {
-              Write-Error "Expected log line not found: $pattern"
-              exit 1
-            }
-          }
-          Write-Output "All expected log lines found"
-
-      - name: Send failing command
-        shell: pwsh
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $winFailure = @'
+          "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
           $PS_Results = New-Object -TypeName psobject
 
@@ -509,486 +101,254 @@ jobs:
 
           # Post results back to Rewst
           $postData = $PS_Results | ConvertTo-Json
-          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
+          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""
+          '@
 
-      - name: Check logs for error handling
-        shell: pwsh
-        run: |
-          Start-Sleep -Seconds 15
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
+          $orgId = $env:ORG_ID
 
-          if ($logContent -notmatch "Command failed") {
-            Write-Error "Expected error message 'Command failed' not found in logs"
-            exit 1
-          }
-          Write-Output "Error handling verified: failing command error was captured"
-
-      - name: Install integration test binary (old version)
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.it.exe --update --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
-          Write-Output "Installed integration test binary (version v0.0.0-it)"
-
-      - name: Wait for auto updater to trigger and update
-        shell: pwsh
-        run: |
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          Write-Output "Waiting for auto updater to detect newer version and update..."
-          for ($i = 1; $i -le 60; $i++) {
-            $logContent = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
-            if ($logContent -match [regex]::Escape("Updating agent")) {
-              Write-Output "Auto update triggered after ${i}s"
-              break
+          $entries = @(
+            [ordered]@{
+              os = 'ubuntu-latest'
+              binary = 'rewst_agent_config.linux.bin'
+              it_binary = 'rewst_agent_config.linux.it.bin'
+              config_dir = '/etc/rewst_remote_agent'
+              log_file = "/etc/rewst_remote_agent/$orgId/rewst_agent.log"
+              service = "rewst_remote_agent_$orgId"
+              success_commands = '"echo \"hello world\""'
+              failure_commands = '"exit 1"'
+              success_patterns = "Command completed`nSending postback`nPostback sent"
+              no_auto_updates_extra = ''
+              uninstall_paths = "/etc/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n/tmp/rewst_remote_agent/scripts/$orgId"
+            },
+            [ordered]@{
+              os = 'windows-latest'
+              binary = 'rewst_agent_config.win.exe'
+              it_binary = 'rewst_agent_config.win.it.exe'
+              config_dir = 'C:\ProgramData\RewstRemoteAgent'
+              log_file = "C:\ProgramData\RewstRemoteAgent\$orgId\rewst_agent.log"
+              service = "RewstRemoteAgent_$orgId"
+              success_commands = $winSuccess
+              failure_commands = $winFailure
+              success_patterns = "Command completed`nSending postback`nPostback already sent"
+              no_auto_updates_extra = '--disable-agent-postback'
+              uninstall_paths = "C:\ProgramData\RewstRemoteAgent\$orgId`nC:\Program Files\RewstRemoteAgent\$orgId`nC:\RewstRemoteAgent\scripts\$orgId"
+            },
+            [ordered]@{
+              os = 'macos-latest'
+              binary = 'rewst_agent_config.mac-os.bin'
+              it_binary = 'rewst_agent_config.mac-os.it.bin'
+              config_dir = '/Library/Application Support/rewst_remote_agent'
+              log_file = "/Library/Application Support/rewst_remote_agent/$orgId/rewst_agent.log"
+              service = "io.rewst.remote_agent_$orgId"
+              success_commands = '"echo \"hello world\""'
+              failure_commands = '"exit 1"'
+              success_patterns = "Command completed`nSending postback`nPostback sent"
+              no_auto_updates_extra = ''
+              uninstall_paths = "/Library/Application Support/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n`$env:TMPDIR/rewst_remote_agent/scripts/$orgId"
             }
-            Start-Sleep -Seconds 2
+          )
+
+          if ($env:OS_INPUT -ne 'all') {
+            $entries = @($entries | Where-Object { $_.os -eq $env:OS_INPUT })
           }
 
-      - name: Verify auto update completed
-        shell: pwsh
-        run: |
-          Start-Sleep -Seconds 15
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
+          $payload = @{ include = $entries }
+          $json = ConvertTo-Json -InputObject $payload -Depth 10 -Compress
+          Write-Output $json
+          "matrix=$json" >> $env:GITHUB_OUTPUT
 
-          foreach ($pattern in @("Checking for updates", "Updating agent")) {
-            if ($logContent -notmatch [regex]::Escape($pattern)) {
-              Write-Error "Expected auto update log line not found: $pattern"
-              exit 1
-            }
-          }
-
-          $lastStartLine = ($logContent -split "`n" | Where-Object { $_ -match "Agent Smith started" } | Select-Object -Last 1)
-          if ($lastStartLine -match [regex]::Escape("version=v0.0.0-it")) {
-            Write-Error "Agent is still running the integration test version after update"
-            exit 1
-          }
-          Write-Output "Auto updater integration test passed"
-
-      - name: Update logging level to debug
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.exe --update --org-id ${{ vars.IT_ORG_ID }} --logging-level debug --github-token ${{ secrets.GITHUB_TOKEN }}
-          Write-Output "Logging level successfully updated to debug"
-
-      - name: Send test command
-        shell: pwsh
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-          $PS_Results = New-Object -TypeName psobject
-
-          # Start of typed powershell
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value \"hello world`n\"
-
-          # Post results back to Rewst
-          $postData = $PS_Results | ConvertTo-Json
-          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
-
-      - name: Check logs
-        shell: pwsh
-        run: |
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
-
-          if ($logContent -notmatch [regex]::Escape("DEBUG")) {
-            Write-Error "Expected log line not found: DEBUG"
-          }
-          Write-Output "All expected log lines found"
-
-      - name: Stop service
-        shell: pwsh
-        run: |
-          sc.exe stop ${{ steps.install_agent.outputs.service }}
-
-      - name: Delete log file
-        shell: pwsh
-        run: |
-          Remove-Item -Force "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-
-      - name: Update agent
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.exe --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates --disable-agent-postback --github-token ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check logs for no auto updater
-        shell: pwsh
-        run: |
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          for ($i = 1; $i -le 30; $i++) {
-            if (Test-Path $logFile) { break }
-            Write-Output "Waiting for log file to be created... ($i/30)"
-            Start-Sleep -Seconds 1
-          }
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
-
-          if ($logContent -match [regex]::Escape("Starting auto updater")) {
-            Write-Error "Unexpected log line found: Starting auto updater"
-            exit 1
-          }
-          Write-Output "Confirmed: no 'Starting auto updater' log line found"
-
-      - name: Send test command
-        shell: pwsh
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-          $PS_Results = New-Object -TypeName psobject
-
-          # Start of typed powershell
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value \"hello world`n\"
-
-          # Post results back to Rewst
-          $postData = $PS_Results | ConvertTo-Json
-          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
-
-      - name: Check logs for command received
-        shell: pwsh
-        run: |
-          $logFile = "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}\rewst_agent.log"
-          $logContent = Get-Content $logFile -Raw
-          Write-Output $logContent
-
-          if ($logContent -notmatch [regex]::Escape("Command completed")) {
-            Write-Error "Expected log line not found: Command completed"
-            exit 1
-          }
-
-          if ($logContent -match [regex]::Escape("Postback already sent")) {
-            Write-Error "Unexpected log line found: Postback already sent"
-            exit 1
-          }
-          Write-Output "All log checks passed"
-
-      - name: Update agent with syslog
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.exe --update --org-id ${{ vars.IT_ORG_ID }} --syslog --github-token ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Send test command
-        shell: pwsh
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' `
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' `
-          --form 'commands="[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-          $PS_Results = New-Object -TypeName psobject
-
-          # Start of typed powershell
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"error\" -Value \"\"
-          $PS_Results | Add-Member -MemberType NoteProperty -Name \"output\" -Value \"hello world`n\"
-
-          # Post results back to Rewst
-          $postData = $PS_Results | ConvertTo-Json
-          Invoke-RestMethod -Method \"Post\" -Uri $post_url -Body $postData -ContentType \"application/json\""'
-
-      - name: Check Windows Event Log for command completed
-        shell: pwsh
-        run: |
-          $events = Get-WinEvent -LogName Application -FilterXPath "*[System[Provider[@Name='RewstRemoteAgent_${{ vars.IT_ORG_ID }}']]]"
-          Write-Output "Found $($events.Count) event(s)"
-          $events | ForEach-Object { Write-Output $_.Message }
-
-          $matched = $events | Where-Object { $_.Message -match "Command completed" }
-          if (-not $matched) {
-            Write-Error "Expected 'Command completed' entry not found in Windows Event Log"
-            exit 1
-          }
-          Write-Output "Found 'Command completed' in Windows Event Log"
-
-      - name: Uninstall agent
-        shell: pwsh
-        run: |
-          ./dist/rewst_agent_config.win.exe --uninstall --org-id ${{ vars.IT_ORG_ID }}
-
-      - name: Check deleted directories
-        shell: pwsh
-        run: |
-          if (Test-Path -Path "C:\ProgramData\RewstRemoteAgent\${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "C:\Program Files\RewstRemoteAgent\${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "C:\RewstRemoteAgent\scripts\${{ vars.IT_ORG_ID }}") { exit 1 }
-          echo "All directories have been deleted"
-
-  test-macos-latest:
+  test:
     permissions:
       contents: read
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    needs: [build, build-integration-test]
-    if: inputs.os == 'macos-latest' || inputs.os == 'all'
-    runs-on: macos-latest
+    needs: [build, build-integration-test, set-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Download compiled binary
-        uses: actions/download-artifact@v8
-        with:
-          name: macos-latest
-          path: ./dist
+      - name: Checkout code
+        uses: actions/checkout@v5
 
-      - name: Download integration test binary
-        uses: actions/download-artifact@v8
-        with:
-          name: it-macos-latest
-          path: ./dist
-
-      - name: Make binaries executable
-        run: |
-          chmod +x ./dist/rewst_agent_config.mac-os.bin
-          chmod +x ./dist/rewst_agent_config.mac-os.it.bin
+      - name: Inject PowerShell profile noise
+        if: matrix.os == 'windows-latest'
+        id: inject_profile_noise
+        uses: ./.github/actions/inject-profile-noise
 
       - name: Install agent
         id: install_agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.bin --config-url ${{ vars.IT_CONFIG_URL }} --config-secret ${{ secrets.IT_CONFIG_SECRET }} --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "service=io.rewst.remote_agent_${{ vars.IT_ORG_ID }}" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/install-agent
+        with:
+          os: ${{ matrix.os }}
+          binary: ${{ matrix.binary }}
+          it_binary: ${{ matrix.it_binary }}
+          config_url: ${{ vars.IT_CONFIG_URL }}
+          config_secret: ${{ secrets.IT_CONFIG_SECRET }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check install output for profile noise
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/check-profile-noise
+        with:
+          install_output_path: ${{ steps.install_agent.outputs.install_output_path }}
+          noise: ${{ steps.inject_profile_noise.outputs.noise }}
 
       - name: Check service
-        shell: bash
-        run: |
-          sudo launchctl print system/${{ steps.install_agent.outputs.service }}
+        uses: ./.github/actions/check-service
+        with:
+          service: ${{ matrix.service }}
 
-      - name: Get device id
-        id: get_device_id
-        shell: bash
-        run: |
-          echo "value=$(cat "/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/config.json" | jq -r '.device_id')" >> "$GITHUB_OUTPUT"
-
-      - name: Validate config.json fields
-        shell: bash
-        run: |
-          config="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/config.json"
-          failed=false
-
-          for field in device_id rewst_org_id rewst_engine_host shared_access_key azure_iot_hub_host; do
-            val=$(jq -r ".$field" "$config")
-            if [ -z "$val" ] || [ "$val" = "null" ]; then
-              echo "ERROR: Config field '$field' is missing or empty"
-              failed=true
-            else
-              echo "OK: $field = $val"
-            fi
-          done
-
-          org_id=$(jq -r '.rewst_org_id' "$config")
-          if [ "$org_id" != "${{ vars.IT_ORG_ID }}" ]; then
-            echo "ERROR: rewst_org_id '$org_id' does not match expected '${{ vars.IT_ORG_ID }}'"
-            failed=true
-          fi
-
-          if [ "$failed" = true ]; then exit 1; fi
-          echo "All config.json fields validated"
+      - name: Validate config and get device id
+        id: config
+        uses: ./.github/actions/validate-config
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
 
       - name: Check subscribed messages log for topic and QoS
-        shell: bash
-        run: |
-          sleep 10
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: Subscribed to messages
+          subscribed_topic_qos: "true"
+          wait_seconds: "10"
 
-          subscribedLine=$(echo "$logContent" | grep "Subscribed to messages" | head -1)
-          if [ -z "$subscribedLine" ]; then
-            echo "ERROR: Expected 'Subscribed to messages' not found in logs"
-            exit 1
-          fi
-          if ! echo "$subscribedLine" | grep -qF "topic="; then
-            echo "ERROR: Expected 'topic=' not found in 'Subscribed to messages' log line"
-            exit 1
-          fi
-          if ! echo "$subscribedLine" | grep -qF "qos="; then
-            echo "ERROR: Expected 'qos=' not found in 'Subscribed to messages' log line"
-            exit 1
-          fi
-          echo "Subscribed messages log includes topic and QoS: $subscribedLine"
+      - name: Send success command
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
 
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
-
-      - name: Check logs
-        shell: bash
-        run: |
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          for pattern in "Command completed" "Sending postback" "Postback sent"; do
-            if ! echo "$logContent" | grep -qF "$pattern"; then
-              echo "ERROR: Expected log line not found: $pattern"
-              exit 1
-            fi
-          done
-          echo "All expected log lines found"
+      - name: Check logs for successful command
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: ${{ matrix.success_patterns }}
 
       - name: Send failing command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="exit 1"'
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.failure_commands }}
 
       - name: Check logs for error handling
-        shell: bash
-        run: |
-          sleep 15
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          if ! echo "$logContent" | grep -qF "Command failed"; then
-            echo "ERROR: Expected 'Command failed' not found in logs"
-            exit 1
-          fi
-          echo "Error handling verified: failing command error was captured"
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: Command failed
+          wait_seconds: "15"
 
       - name: Install integration test binary (old version)
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.it.bin --update --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "Installed integration test binary (version v0.0.0-it)"
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.it_binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for auto updater to trigger and update
-        shell: bash
-        run: |
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          echo "Waiting for auto updater to detect newer version and update..."
-          for i in $(seq 1 60); do
-            logContent=$(cat "$logFile" 2>/dev/null || true)
-            if echo "$logContent" | grep -qF "Updating agent"; then
-              echo "Auto update triggered after ${i}s"
-              break
-            fi
-            sleep 2
-          done
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Updating agent
 
       - name: Verify auto update completed
-        shell: bash
-        run: |
-          sleep 15
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          for pattern in "Checking for updates" "Updating agent"; do
-            if ! echo "$logContent" | grep -qF "$pattern"; then
-              echo "ERROR: Expected auto update log line not found: $pattern"
-              exit 1
-            fi
-          done
-
-          lastVersion=$(echo "$logContent" | grep "Agent Smith started" | tail -1)
-          if echo "$lastVersion" | grep -qF "version=v0.0.0-it"; then
-            echo "ERROR: Agent is still running the integration test version after update"
-            exit 1
-          fi
-          echo "Auto updater integration test passed"
+        uses: ./.github/actions/verify-auto-update
+        with:
+          log_file: ${{ matrix.log_file }}
 
       - name: Update logging level to debug
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.bin --update --org-id ${{ vars.IT_ORG_ID }} --logging-level debug --github-token ${{ secrets.GITHUB_TOKEN }}
-          echo "Logging level successfully updated to debug"
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --logging-level debug --github-token ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
+      - name: Send test command (debug)
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
 
       - name: Check logs for debug level
-        shell: bash
-        run: |
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          logContent=$(cat "$logFile")
-          echo "$logContent"
-
-          if ! echo "$logContent" | grep -qF "DEBUG"; then
-            echo "ERROR: Expected log line not found: DEBUG"
-            exit 1
-          fi
-          echo "All expected log lines found"
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: DEBUG
 
       - name: Stop service
-        shell: bash
-        run: |
-          sudo launchctl stop system/${{ steps.install_agent.outputs.service }} || true
+        uses: ./.github/actions/stop-service
+        with:
+          service: ${{ matrix.service }}
 
       - name: Delete log file
-        shell: bash
-        run: |
-          sudo rm -f "/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
+        uses: ./.github/actions/delete-log
+        with:
+          log_file: ${{ matrix.log_file }}
 
-      - name: Update agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.bin --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates --github-token ${{ secrets.GITHUB_TOKEN }}
+      - name: Update agent (no auto updates)
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates ${{ matrix.no_auto_updates_extra }} --github-token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check logs for no auto updater
-        shell: bash
-        run: |
-          logFile="/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}/rewst_agent.log"
-          for i in $(seq 1 30); do
-            [ -f "$logFile" ] && break
-            echo "Waiting for log file to be created... ($i/30)"
-            sleep 1
-          done
-          logContent=$(cat "$logFile")
-          echo "$logContent"
+        uses: ./.github/actions/assert-log-missing
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Starting auto updater
+          wait_for_file_seconds: "30"
 
-          if echo "$logContent" | grep -qF "Starting auto updater"; then
-            echo "ERROR: Unexpected log line found: Starting auto updater"
-            exit 1
-          fi
-          echo "Confirmed: no 'Starting auto updater' log line found"
+      - name: Send test command (windows postback verification)
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Check logs for command received (windows)
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: Command completed
+
+      - name: Check logs absent postback (windows)
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/assert-log-missing
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Postback already sent
 
       - name: Update agent with syslog
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.bin --update --org-id ${{ vars.IT_ORG_ID }} --syslog --github-token ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --syslog --github-token ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Send test command
-        shell: bash
-        run: |
-          curl --location '${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}' \
-          --form 'device_id="${{ steps.get_device_id.outputs.value }}"' \
-          --form 'commands="echo \"hello world\""'
+      - name: Send test command (syslog)
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
 
       - name: Check syslog for command completed
-        shell: bash
-        run: |
-          sleep 15
-          entries=$(log show --predicate 'processImagePath contains "logger"' --info --last 5m 2>/dev/null || true)
-          echo "$entries"
-
-          if ! echo "$entries" | grep -qF "Command completed"; then
-            echo "ERROR: Expected 'Command completed' entry not found in syslog"
-            exit 1
-          fi
-          echo "Found 'Command completed' in syslog"
+        uses: ./.github/actions/assert-syslog-contains
+        with:
+          service: ${{ matrix.service }}
+          pattern: Command completed
 
       - name: Uninstall agent
-        shell: bash
-        run: |
-          sudo ./dist/rewst_agent_config.mac-os.bin --uninstall --org-id ${{ vars.IT_ORG_ID }}
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --uninstall --org-id ${{ vars.IT_ORG_ID }}
 
       - name: Check deleted directories
-        shell: pwsh
-        run: |
-          if (Test-Path -Path "/Library/Application Support/rewst_remote_agent/${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "/usr/local/bin/rewst_remote_agent/${{ vars.IT_ORG_ID }}") { exit 1 }
-          if (Test-Path -Path "$env:TMPDIR/rewst_remote_agent/scripts/${{ vars.IT_ORG_ID }}") { exit 1 }
-          echo "All directories have been deleted"
+        uses: ./.github/actions/assert-uninstalled
+        with:
+          paths: ${{ matrix.uninstall_paths }}


### PR DESCRIPTION
## Summary
- Extract shared integration test plan into reusable composite actions under `.github/actions/` (assert-log-contains, install-agent, send-command, etc.).
- Replace `test-ubuntu-latest`, `test-windows-latest`, and `test-macos-latest` with a single matrix-based test job; a `set-matrix` prep job filters the matrix include based on `workflow_dispatch` `inputs.os` so selecting a single OS spawns only that leg.
- Workflow drops from 995 to 354 lines (~35% of original) while preserving every original assertion.

## Test plan
- [ ] Trigger workflow with `workflow_dispatch` and `os=all` — confirm Ubuntu, Windows, and macOS legs run.
- [ ] Trigger with `os=ubuntu-latest` — confirm only that leg spawns.
- [ ] Trigger with `os=windows-latest` — confirm only that leg spawns and the profile-noise check runs.
- [ ] Trigger with `os=macos-latest` — confirm only that leg spawns.
- [ ] Verify preserved assertions: config validation, subscribed-topic/QoS, success/failure log checks, auto-updater verification, debug-level log check, no-auto-updater check, cross-platform syslog/Event Log check, `--disable-agent-postback` postback-absent assertion, and post-uninstall directory cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)