### PR TITLE
feat: [sc-89424] Allow config and update mode to run service as a specified user account

### DIFF
--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -215,6 +215,8 @@ func runConfig(params *configContext) error {
 		OrgId:               params.OrgId,
 		ConfigFilePath:      configFilePath,
 		LogFilePath:         agent.GetLogFilePath(params.OrgId),
+		ServiceUsername:     params.ServiceUsername,
+		ServicePassword:     params.ServicePassword,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create service: %w", err)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -24,6 +24,8 @@ type configContext struct {
 	NoAutoUpdates        bool
 	GithubToken          string
 	MqttQos              int
+	ServiceUsername      string
+	ServicePassword      string
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -62,6 +64,18 @@ func newConfigContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.StringVar(
+		&params.ServiceUsername,
+		"service-username",
+		"",
+		"User account the service should run as (e.g. DOMAIN\\svc_rewst on Windows, rewst on Linux/macOS)",
+	)
+	fs.StringVar(
+		&params.ServicePassword,
+		"service-password",
+		"",
+		"Password for --service-username (Windows only; not persisted to disk)",
+	)
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)
@@ -87,6 +101,10 @@ func newConfigContext(
 
 	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
 		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
+	}
+
+	if params.ServicePassword != "" && params.ServiceUsername == "" {
+		return nil, fmt.Errorf("service-password requires service-username")
 	}
 
 	params.Sys = sys

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -76,7 +76,11 @@ func TestNewConfigContext(t *testing.T) {
 		t.Fatalf("expected no error with service credentials, got %v", err)
 	}
 	if resultWithCreds.ServiceUsername != "DOMAIN\\svc_rewst" {
-		t.Errorf("expected ServiceUsername %q, got %q", "DOMAIN\\svc_rewst", resultWithCreds.ServiceUsername)
+		t.Errorf(
+			"expected ServiceUsername %q, got %q",
+			"DOMAIN\\svc_rewst",
+			resultWithCreds.ServiceUsername,
+		)
 	}
 	if resultWithCreds.ServicePassword != "p@ss" {
 		t.Errorf("expected ServicePassword %q, got %q", "p@ss", resultWithCreds.ServicePassword)

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -55,6 +55,33 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf("expected MqttQos 2, got %v", resultWithQos.MqttQos)
 	}
 
+	if result.ServiceUsername != "" {
+		t.Errorf("expected empty ServiceUsername by default, got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "" {
+		t.Errorf("expected empty ServicePassword by default, got %q", result.ServicePassword)
+	}
+
+	resultWithCreds, err := newConfigContext(
+		[]string{
+			"--org-id", orgId,
+			"--config-url", configUrl,
+			"--config-secret", configSecret,
+			"--service-username", "DOMAIN\\svc_rewst",
+			"--service-password", "p@ss",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error with service credentials, got %v", err)
+	}
+	if resultWithCreds.ServiceUsername != "DOMAIN\\svc_rewst" {
+		t.Errorf("expected ServiceUsername %q, got %q", "DOMAIN\\svc_rewst", resultWithCreds.ServiceUsername)
+	}
+	if resultWithCreds.ServicePassword != "p@ss" {
+		t.Errorf("expected ServicePassword %q, got %q", "p@ss", resultWithCreds.ServicePassword)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -88,6 +115,19 @@ func TestNewConfigContext(t *testing.T) {
 				"3",
 			},
 			"invalid mqtt-qos",
+		},
+		{
+			[]string{
+				"--org-id",
+				orgId,
+				"--config-url",
+				configUrl,
+				"--config-secret",
+				configSecret,
+				"--service-password",
+				"p@ss",
+			},
+			"service-password requires service-username",
 		},
 	}
 

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -411,6 +411,69 @@ func TestRunConfig_ServiceStartFails(t *testing.T) {
 	}
 }
 
+func TestRunConfig_PassesServiceCredentialsToServiceManager(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	mgr := &mockServiceManager{
+		openErr:       errors.New("no existing service"),
+		createService: &mockService{},
+	}
+
+	params := newBaseConfigParams(srv.URL)
+	params.ServiceManager = mgr
+	params.ServiceUsername = "DOMAIN\\svc_rewst"
+	params.ServicePassword = "p@ss"
+
+	if err := runConfig(params); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(mgr.createCalls) != 1 {
+		t.Fatalf("expected 1 Create call, got %d", len(mgr.createCalls))
+	}
+	got := mgr.createCalls[0]
+	if got.ServiceUsername != "DOMAIN\\svc_rewst" {
+		t.Errorf(
+			"expected ServiceUsername %q, got %q",
+			"DOMAIN\\svc_rewst",
+			got.ServiceUsername,
+		)
+	}
+	if got.ServicePassword != "p@ss" {
+		t.Errorf("expected ServicePassword %q, got %q", "p@ss", got.ServicePassword)
+	}
+}
+
+func TestRunConfig_PasswordNotPersistedToDisk(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	writtenFiles := map[string][]byte{}
+	params := newBaseConfigParams(srv.URL)
+	params.FS = &mockFileSystem{
+		mkdirAllFunc: func(string) error { return nil },
+		writeFileFunc: func(name string, data []byte, _ os.FileMode) error {
+			writtenFiles[name] = data
+			return nil
+		},
+		readFileFunc:   func(string) ([]byte, error) { return []byte("binary"), nil },
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+	}
+	params.ServiceUsername = "DOMAIN\\svc_rewst"
+	params.ServicePassword = "super-secret-password"
+
+	if err := runConfig(params); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	for name, data := range writtenFiles {
+		if strings.Contains(string(data), "super-secret-password") {
+			t.Errorf("password leaked into file %q", name)
+		}
+	}
+}
+
 func TestRunConfig_HTTPTimeout(t *testing.T) {
 	done := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent_smith/main.go
+++ b/cmd/agent_smith/main.go
@@ -92,7 +92,7 @@ func main() {
 	// Show usage
 	loggingLevelsList := getAllowedConfigLevelsString("|")
 	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2]",
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2] [--service-username <USER>] [--service-password <PASS>]",
 		loggingLevelsList,
 	)
 	usages := []string{

--- a/cmd/agent_smith/main_test.go
+++ b/cmd/agent_smith/main_test.go
@@ -113,6 +113,8 @@ type mockServiceManager struct {
 	openService   service.Service
 	createErr     error
 	createService service.Service
+
+	createCalls []service.AgentParams
 }
 
 func (m *mockServiceManager) Open(name string) (service.Service, error) {
@@ -120,5 +122,6 @@ func (m *mockServiceManager) Open(name string) (service.Service, error) {
 }
 
 func (m *mockServiceManager) Create(params service.AgentParams) (service.Service, error) {
+	m.createCalls = append(m.createCalls, params)
 	return m.createService, m.createErr
 }

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -132,7 +132,13 @@ func runUpdate(params *updateContext) {
 	// new account takes effect. Otherwise just restart the existing
 	// registration.
 	if params.ServiceUsername != "" {
-		logger.Info("Re-registering service with new account", "service", name, "user", params.ServiceUsername)
+		logger.Info(
+			"Re-registering service with new account",
+			"service",
+			name,
+			"user",
+			params.ServiceUsername,
+		)
 
 		if err := svc.Delete(); err != nil {
 			logger.Error("Failed to delete service", "service", name, "error", err)

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/service"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 )
@@ -26,8 +27,10 @@ func runUpdate(params *updateContext) {
 		return
 	}
 	defer func() {
-		err = svc.Close()
-		if err != nil {
+		if svc == nil {
+			return
+		}
+		if err := svc.Close(); err != nil {
 			logger.Error("Failed to close service handle", "error", err)
 		}
 	}()
@@ -124,6 +127,41 @@ func runUpdate(params *updateContext) {
 	}
 
 	logger.Info("Agent installed to", "path", agentExecutablePath)
+
+	// If service credentials were provided, re-register the service so the
+	// new account takes effect. Otherwise just restart the existing
+	// registration.
+	if params.ServiceUsername != "" {
+		logger.Info("Re-registering service with new account", "service", name, "user", params.ServiceUsername)
+
+		if err := svc.Delete(); err != nil {
+			logger.Error("Failed to delete service", "service", name, "error", err)
+			return
+		}
+		if err := svc.Close(); err != nil {
+			logger.Error("Failed to close service handle", "error", err)
+		}
+		svc = nil
+
+		logger.Info("Waiting for service executable to stop")
+		time.Sleep(serviceExecutableTimeout)
+
+		newSvc, err := params.ServiceManager.Create(service.AgentParams{
+			Name:                name,
+			AgentExecutablePath: agentExecutablePath,
+			OrgId:               params.OrgId,
+			ConfigFilePath:      configFilePath,
+			LogFilePath:         agent.GetLogFilePath(params.OrgId),
+			ServiceUsername:     params.ServiceUsername,
+			ServicePassword:     params.ServicePassword,
+		})
+		if err != nil {
+			logger.Error("Failed to create service", "service", name, "error", err)
+			return
+		}
+		svc = newSvc
+		logger.Info("Service re-registered", "service", name)
+	}
 
 	// Starting the service
 	logger.Info("Starting service", "service", name)

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -19,6 +19,8 @@ type updateContext struct {
 	NoAutoUpdates        bool
 	GithubToken          string
 	MqttQos              int
+	ServiceUsername      string
+	ServicePassword      string
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -55,6 +57,18 @@ func newUpdateContext(
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.StringVar(
+		&params.ServiceUsername,
+		"service-username",
+		"",
+		"User account the service should run as (re-registers the service when set)",
+	)
+	fs.StringVar(
+		&params.ServicePassword,
+		"service-password",
+		"",
+		"Password for --service-username (Windows only; not persisted to disk)",
+	)
 	fs.SetOutput(bytes.NewBuffer([]byte{}))
 
 	err := fs.Parse(args)
@@ -76,6 +90,10 @@ func newUpdateContext(
 
 	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
 		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
+	}
+
+	if params.ServicePassword != "" && params.ServiceUsername == "" {
+		return nil, fmt.Errorf("service-password requires service-username")
 	}
 
 	params.Sys = sys

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -38,6 +38,31 @@ func TestNewUpdateContext(t *testing.T) {
 		t.Errorf("expected MqttQos 0, got %v", resultWithQos.MqttQos)
 	}
 
+	if result.ServiceUsername != "" {
+		t.Errorf("expected empty ServiceUsername by default, got %q", result.ServiceUsername)
+	}
+	if result.ServicePassword != "" {
+		t.Errorf("expected empty ServicePassword by default, got %q", result.ServicePassword)
+	}
+
+	resultWithCreds, err := newUpdateContext(
+		[]string{
+			"--org-id", orgId, "--update",
+			"--service-username", "rewst",
+			"--service-password", "p@ss",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error with service credentials, got %v", err)
+	}
+	if resultWithCreds.ServiceUsername != "rewst" {
+		t.Errorf("expected ServiceUsername %q, got %q", "rewst", resultWithCreds.ServiceUsername)
+	}
+	if resultWithCreds.ServicePassword != "p@ss" {
+		t.Errorf("expected ServicePassword %q, got %q", "p@ss", resultWithCreds.ServicePassword)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -52,6 +77,10 @@ func TestNewUpdateContext(t *testing.T) {
 		{
 			[]string{"--org-id", orgId, "--update", "--mqtt-qos", "3"},
 			"invalid mqtt-qos",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--service-password", "p@ss"},
+			"service-password requires service-username",
 		},
 	}
 

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -183,3 +183,60 @@ func TestRunUpdate_StartFails(t *testing.T) {
 
 	runUpdate(params)
 }
+
+func TestRunUpdate_NoServiceUsername_DoesNotRecreate(t *testing.T) {
+	params := newBaseUpdateParams()
+	mgr := &mockServiceManager{openService: &mockService{isActive: false}}
+	params.ServiceManager = mgr
+
+	runUpdate(params)
+
+	if len(mgr.createCalls) != 0 {
+		t.Errorf("expected no Create calls without ServiceUsername, got %d", len(mgr.createCalls))
+	}
+}
+
+func TestRunUpdate_WithServiceUsername_RecreatesService(t *testing.T) {
+	params := newBaseUpdateParams()
+	params.ServiceUsername = "rewst"
+	params.ServicePassword = "p@ss"
+	mgr := &mockServiceManager{
+		openService:   &mockService{isActive: false},
+		createService: &mockService{},
+	}
+	params.ServiceManager = mgr
+
+	runUpdate(params)
+
+	if len(mgr.createCalls) != 1 {
+		t.Fatalf("expected 1 Create call when ServiceUsername set, got %d", len(mgr.createCalls))
+	}
+	got := mgr.createCalls[0]
+	if got.ServiceUsername != "rewst" {
+		t.Errorf("expected ServiceUsername %q in Create params, got %q", "rewst", got.ServiceUsername)
+	}
+	if got.ServicePassword != "p@ss" {
+		t.Errorf("expected ServicePassword %q in Create params, got %q", "p@ss", got.ServicePassword)
+	}
+}
+
+func TestRunUpdate_WithServiceUsername_DeleteFails(t *testing.T) {
+	params := newBaseUpdateParams()
+	params.ServiceUsername = "rewst"
+	params.ServiceManager = &mockServiceManager{
+		openService: &mockService{isActive: false, deleteErr: errors.New("delete failed")},
+	}
+
+	runUpdate(params)
+}
+
+func TestRunUpdate_WithServiceUsername_CreateFails(t *testing.T) {
+	params := newBaseUpdateParams()
+	params.ServiceUsername = "rewst"
+	params.ServiceManager = &mockServiceManager{
+		openService: &mockService{isActive: false},
+		createErr:   errors.New("create failed"),
+	}
+
+	runUpdate(params)
+}

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -213,10 +213,18 @@ func TestRunUpdate_WithServiceUsername_RecreatesService(t *testing.T) {
 	}
 	got := mgr.createCalls[0]
 	if got.ServiceUsername != "rewst" {
-		t.Errorf("expected ServiceUsername %q in Create params, got %q", "rewst", got.ServiceUsername)
+		t.Errorf(
+			"expected ServiceUsername %q in Create params, got %q",
+			"rewst",
+			got.ServiceUsername,
+		)
 	}
 	if got.ServicePassword != "p@ss" {
-		t.Errorf("expected ServicePassword %q in Create params, got %q", "p@ss", got.ServicePassword)
+		t.Errorf(
+			"expected ServicePassword %q in Create params, got %q",
+			"p@ss",
+			got.ServicePassword,
+		)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,6 +6,14 @@ type AgentParams struct {
 	OrgId               string
 	ConfigFilePath      string
 	LogFilePath         string
+	// ServiceUsername, when non-empty, registers the service to run as the
+	// given account instead of the platform default (LocalSystem on Windows,
+	// root on Linux/macOS).
+	ServiceUsername string
+	// ServicePassword is the password for ServiceUsername on Windows. It is
+	// only consulted at service registration time and must never be persisted
+	// to disk. Linux and macOS service managers ignore it.
+	ServicePassword string
 }
 
 type Service interface {

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -125,6 +125,9 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.ConfigFilePath,
 		params.LogFilePath,
 	)
+	if params.ServiceUsername != "" {
+		fmt.Fprintf(&serviceConfig, "<key>UserName</key>\n<string>%s</string>\n", params.ServiceUsername)
+	}
 	fmt.Fprintf(&serviceConfig, "<key>RunAtLoad</key>\n<false/>\n")
 	fmt.Fprintf(
 		&serviceConfig,

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -126,7 +126,11 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.LogFilePath,
 	)
 	if params.ServiceUsername != "" {
-		fmt.Fprintf(&serviceConfig, "<key>UserName</key>\n<string>%s</string>\n", params.ServiceUsername)
+		fmt.Fprintf(
+			&serviceConfig,
+			"<key>UserName</key>\n<string>%s</string>\n",
+			params.ServiceUsername,
+		)
 	}
 	fmt.Fprintf(&serviceConfig, "<key>RunAtLoad</key>\n<false/>\n")
 	fmt.Fprintf(

--- a/internal/service/service_darwin_test.go
+++ b/internal/service/service_darwin_test.go
@@ -316,6 +316,45 @@ func TestDefaultServiceManager_Create_PlistContent(t *testing.T) {
 	}
 }
 
+func TestDefaultServiceManager_Create_PlistOmitsUserNameByDefault(t *testing.T) {
+	tmpFile := newTempPlistPath(t)
+	mock := &mockLaunchCtl{plistPath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+
+	if _, err := sm.Create(AgentParams{Name: "my-service"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read plist file: %v", err)
+	}
+	if strings.Contains(string(data), "<key>UserName</key>") {
+		t.Errorf("expected no UserName key when ServiceUsername unset, got:\n%s", data)
+	}
+}
+
+func TestDefaultServiceManager_Create_PlistIncludesUserName(t *testing.T) {
+	tmpFile := newTempPlistPath(t)
+	mock := &mockLaunchCtl{plistPath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+
+	if _, err := sm.Create(AgentParams{Name: "my-service", ServiceUsername: "rewst"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read plist file: %v", err)
+	}
+	content := string(data)
+	for _, check := range []string{"<key>UserName</key>", "<string>rewst</string>"} {
+		if !strings.Contains(content, check) {
+			t.Errorf("expected plist to contain %q, got:\n%s", check, content)
+		}
+	}
+}
+
 func TestDefaultServiceManager_Create_WriteFileError(t *testing.T) {
 	mock := &mockLaunchCtl{plistPath: "/nonexistent/dir/file.plist"}
 	sm := &defaultServiceManager{system: mock}

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -74,13 +74,16 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	fmt.Fprintf(&serviceConfig, "[Unit]\nDescription=%s\n\n", params.Name)
 	fmt.Fprintf(
 		&serviceConfig,
-		"[Service]\nExecStart=%s --org-id %s --config-file %s --log-file %s\nRestart=always\n\n",
+		"[Service]\nExecStart=%s --org-id %s --config-file %s --log-file %s\nRestart=always\n",
 		params.AgentExecutablePath,
 		params.OrgId,
 		params.ConfigFilePath,
 		params.LogFilePath,
 	)
-	fmt.Fprintf(&serviceConfig, "[Install]\nWantedBy=multi-user.target\n")
+	if params.ServiceUsername != "" {
+		fmt.Fprintf(&serviceConfig, "User=%s\nGroup=%s\n", params.ServiceUsername, params.ServiceUsername)
+	}
+	fmt.Fprintf(&serviceConfig, "\n[Install]\nWantedBy=multi-user.target\n")
 
 	serviceConfigFilePath := s.system.ServiceConfigFilePath(params.Name)
 	err := os.WriteFile(serviceConfigFilePath, []byte(serviceConfig.String()), utils.DefaultFileMod)

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -81,7 +81,12 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 		params.LogFilePath,
 	)
 	if params.ServiceUsername != "" {
-		fmt.Fprintf(&serviceConfig, "User=%s\nGroup=%s\n", params.ServiceUsername, params.ServiceUsername)
+		fmt.Fprintf(
+			&serviceConfig,
+			"User=%s\nGroup=%s\n",
+			params.ServiceUsername,
+			params.ServiceUsername,
+		)
 	}
 	fmt.Fprintf(&serviceConfig, "\n[Install]\nWantedBy=multi-user.target\n")
 

--- a/internal/service/service_linux_test.go
+++ b/internal/service/service_linux_test.go
@@ -229,6 +229,45 @@ func TestDefaultServiceManager_Create_ServiceConfigContent(t *testing.T) {
 	}
 }
 
+func TestDefaultServiceManager_Create_ServiceConfigOmitsUserByDefault(t *testing.T) {
+	tmpFile := newTempConfigPath(t)
+	mock := &mockSystemCtl{configFilePath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+
+	if _, err := sm.Create(AgentParams{Name: "my-service"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	if strings.Contains(string(data), "User=") {
+		t.Errorf("expected no User= directive when ServiceUsername unset, got:\n%s", data)
+	}
+}
+
+func TestDefaultServiceManager_Create_ServiceConfigIncludesUser(t *testing.T) {
+	tmpFile := newTempConfigPath(t)
+	mock := &mockSystemCtl{configFilePath: tmpFile}
+	sm := &defaultServiceManager{system: mock}
+
+	if _, err := sm.Create(AgentParams{Name: "my-service", ServiceUsername: "rewst"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	content := string(data)
+	for _, check := range []string{"User=rewst", "Group=rewst"} {
+		if !strings.Contains(content, check) {
+			t.Errorf("expected config to contain %q, got:\n%s", check, content)
+		}
+	}
+}
+
 func TestDefaultServiceManager_Create_WriteFileError(t *testing.T) {
 	mock := &mockSystemCtl{configFilePath: "/nonexistent/dir/file.service"}
 	sm := &defaultServiceManager{system: mock}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -97,11 +97,27 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 	}
 	defer func() { _ = svcMgr.Disconnect() }() // Cleanup - error can be ignored
 
-	svc, err := svcMgr.CreateService(params.Name, params.AgentExecutablePath, mgr.Config{
+	config := mgr.Config{
 		StartType:        mgr.StartAutomatic,
 		Description:      fmt.Sprintf("Rewst Remote Agent for Org %s", params.OrgId),
 		DelayedAutoStart: true,
-	}, "--org-id", params.OrgId, "--config-file", params.ConfigFilePath, "--log-file", params.LogFilePath)
+	}
+	if params.ServiceUsername != "" {
+		config.ServiceStartName = params.ServiceUsername
+		config.Password = params.ServicePassword
+	}
+
+	svc, err := svcMgr.CreateService(
+		params.Name,
+		params.AgentExecutablePath,
+		config,
+		"--org-id",
+		params.OrgId,
+		"--config-file",
+		params.ConfigFilePath,
+		"--log-file",
+		params.LogFilePath,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -67,6 +67,9 @@ type mockWindowsServiceManager struct {
 	createErr    error
 	openErr      error
 	disconnected bool
+
+	lastCreateConfig mgr.Config
+	createCalled     bool
 }
 
 func (m *mockWindowsServiceManager) Disconnect() error {
@@ -79,6 +82,8 @@ func (m *mockWindowsServiceManager) CreateService(
 	c mgr.Config,
 	args ...string,
 ) (*mgr.Service, error) {
+	m.createCalled = true
+	m.lastCreateConfig = c
 	return nil, m.createErr
 }
 
@@ -320,6 +325,57 @@ func TestDefaultServiceManager_Create_DisconnectsOnSuccess(t *testing.T) {
 
 	if !manager.disconnected {
 		t.Error("expected Disconnect to be called after success")
+	}
+}
+
+func TestDefaultServiceManager_Create_DefaultsToLocalSystem(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	sm := &defaultServiceManager{factory: factory}
+
+	_, err := sm.Create(AgentParams{Name: "test-svc"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !manager.createCalled {
+		t.Fatal("expected CreateService to be called")
+	}
+	if manager.lastCreateConfig.ServiceStartName != "" {
+		t.Errorf(
+			"expected empty ServiceStartName when ServiceUsername unset, got %q",
+			manager.lastCreateConfig.ServiceStartName,
+		)
+	}
+	if manager.lastCreateConfig.Password != "" {
+		t.Errorf(
+			"expected empty Password when ServiceUsername unset, got %q",
+			manager.lastCreateConfig.Password,
+		)
+	}
+}
+
+func TestDefaultServiceManager_Create_AppliesServiceCredentials(t *testing.T) {
+	manager := &mockWindowsServiceManager{}
+	factory := &mockWindowsServiceManagerFactory{manager: manager}
+	sm := &defaultServiceManager{factory: factory}
+
+	_, err := sm.Create(AgentParams{
+		Name:            "test-svc",
+		ServiceUsername: "DOMAIN\\svc_rewst",
+		ServicePassword: "p@ss",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manager.lastCreateConfig.ServiceStartName != "DOMAIN\\svc_rewst" {
+		t.Errorf(
+			"expected ServiceStartName %q, got %q",
+			"DOMAIN\\svc_rewst",
+			manager.lastCreateConfig.ServiceStartName,
+		)
+	}
+	if manager.lastCreateConfig.Password != "p@ss" {
+		t.Errorf("expected Password %q, got %q", "p@ss", manager.lastCreateConfig.Password)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `--service-username` and `--service-password` flags to **config** and **update** modes so the agent service can be registered under a specified user account instead of LocalSystem (Windows) / root (Linux/macOS).
- Enables Rewst workflows that need a domain identity to run cmdlets like `Get-ADUser`.
- Password is consumed only at service registration time and is never persisted to `config.json`.

## Changes
- `cmd/agent_smith/`: wire new flags through config/update modes with dedicated context structs + tests
- `internal/service/`: thread `ServiceUsername`/`ServicePassword` into per-OS service creation
  - Windows: pass credentials to SCM at create time
  - Linux: emit `User=`/`Group=` in the systemd unit
  - macOS: emit `<key>UserName</key>` in the launchd plist

## Test plan
- [ ] `go test ./...` passes
- [ ] Windows: install with `--service-username DOMAIN\\user --service-password ...` and verify service runs as that account in `services.msc`
- [ ] Linux: install with `--service-username rewst` and verify `systemctl show <svc> -p User` reflects the account
- [ ] macOS: install with `--service-username someuser` and confirm the plist contains the `UserName` key and the daemon launches under that account
- [ ] Confirm `config.json` does **not** contain the password after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)