### PR TITLE
test: [sc-95915] Add integration coverage for --service-username across install/update

### DIFF
--- a/.github/actions/assert-config-secret-absent/action.yml
+++ b/.github/actions/assert-config-secret-absent/action.yml
@@ -1,0 +1,46 @@
+name: Assert config secret absent
+description: Assert the service password was not persisted to config.json on disk. No-op when no secret is supplied.
+
+inputs:
+  config_dir:
+    description: "Directory containing the per-org agent config (without org id suffix)"
+    required: true
+  org_id:
+    description: "Org id used as the config subdirectory"
+    required: true
+  secret:
+    description: "Secret value that must not appear in config.json (e.g. the service password)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Assert secret absent from config.json
+      shell: pwsh
+      env:
+        CONFIG_DIR: ${{ inputs.config_dir }}
+        ORG_ID: ${{ inputs.org_id }}
+        SECRET: ${{ inputs.secret }}
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        if ([string]::IsNullOrEmpty($env:SECRET)) {
+          Write-Output "No secret supplied; skipping config.json secret check"
+          exit 0
+        }
+
+        $configPath = Join-Path $env:CONFIG_DIR (Join-Path $env:ORG_ID "config.json")
+        if (-not (Test-Path $configPath)) {
+          Write-Error "config.json not found at $configPath"
+          exit 1
+        }
+
+        $content = Get-Content $configPath -Raw
+        if ($content.Contains($env:SECRET)) {
+          # Avoid echoing the secret itself.
+          Write-Output "::error::Service password was persisted to config.json at $configPath"
+          exit 1
+        }
+
+        Write-Output "Confirmed service password is absent from config.json"

--- a/.github/actions/assert-service-identity/action.yml
+++ b/.github/actions/assert-service-identity/action.yml
@@ -1,0 +1,82 @@
+name: Assert service identity
+description: Assert the registered agent service runs under the expected account, querying the platform service manager. Fails (red) when the service runs under the platform default account instead of the requested one.
+
+inputs:
+  service:
+    description: "Service name"
+    required: true
+  expected_identity:
+    description: "Account the service is expected to run as (e.g. rewst-it-svc on Linux/macOS, .\\rewst-it-svc on Windows)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Assert identity (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        EXPECTED: ${{ inputs.expected_identity }}
+      run: |
+        set -euo pipefail
+        actual="$(systemctl show "$SERVICE" -p User --value)"
+        echo "systemctl reports User=$actual (expected $EXPECTED)"
+        if [ "$actual" != "$EXPECTED" ]; then
+          echo "::error::Service $SERVICE runs as '${actual:-<default/root>}', expected '$EXPECTED'"
+          exit 1
+        fi
+        echo "Service identity matches expected account"
+
+    - name: Assert identity (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        EXPECTED: ${{ inputs.expected_identity }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $svc = Get-CimInstance Win32_Service -Filter "Name='$($env:SERVICE)'"
+        if (-not $svc) {
+          Write-Error "Service $($env:SERVICE) not found"
+          exit 1
+        }
+        $actual = $svc.StartName
+        Write-Output "Win32_Service StartName=$actual (expected $($env:EXPECTED))"
+
+        # Compare on the leaf account name so a machine/domain prefix (e.g.
+        # MACHINE\rewst-it-svc vs .\rewst-it-svc) still matches, while the
+        # platform default (LocalSystem) correctly fails.
+        $actualLeaf = ($actual -split '\\')[-1]
+        $expectedLeaf = ($env:EXPECTED -split '\\')[-1]
+        if ($actualLeaf -ne $expectedLeaf) {
+          Write-Output "::error::Service $($env:SERVICE) runs as '$actual', expected '$($env:EXPECTED)'"
+          exit 1
+        }
+        Write-Output "Service identity matches expected account"
+
+    - name: Assert identity (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        EXPECTED: ${{ inputs.expected_identity }}
+      run: |
+        set -euo pipefail
+        out="$(sudo launchctl print "system/$SERVICE" 2>/dev/null || true)"
+        echo "$out"
+
+        # Prefer the authoritative plist UserName key; launchctl output is shown above for the logs.
+        plist="/Library/LaunchDaemons/$SERVICE.plist"
+        actual="$(/usr/libexec/PlistBuddy -c 'Print :UserName' "$plist" 2>/dev/null || true)"
+        echo "Plist UserName=${actual:-<default/root>} (expected $EXPECTED)"
+
+        if echo "$out" | grep -qiE "username[[:space:]]*=[[:space:]]*\"?$EXPECTED\"?"; then
+          echo "launchctl reports the expected UserName"
+        elif [ "$actual" = "$EXPECTED" ]; then
+          echo "plist confirms the expected UserName"
+        else
+          echo "::error::Service $SERVICE runs as '${actual:-<default/root>}', expected '$EXPECTED'"
+          exit 1
+        fi
+        echo "Service identity matches expected account"

--- a/.github/actions/install-agent/action.yml
+++ b/.github/actions/install-agent/action.yml
@@ -23,6 +23,14 @@ inputs:
   github_token:
     description: "GitHub token used by the agent installer"
     required: true
+  service_username:
+    description: "Optional account the service should run as (passed via --service-username)"
+    required: false
+    default: ""
+  service_password:
+    description: "Optional password for --service-username (Windows only; sourced from a secret)"
+    required: false
+    default: ""
 
 outputs:
   install_output_path:
@@ -55,22 +63,36 @@ runs:
       id: install-unix
       if: runner.os != 'Windows'
       shell: bash
+      env:
+        SERVICE_USERNAME: ${{ inputs.service_username }}
       run: |
+        extra_args=()
+        if [ -n "$SERVICE_USERNAME" ]; then
+          extra_args+=(--service-username "$SERVICE_USERNAME")
+        fi
         sudo "./dist/${{ inputs.binary }}" \
           --config-url "${{ inputs.config_url }}" \
           --config-secret "${{ inputs.config_secret }}" \
           --org-id "${{ inputs.org_id }}" \
-          --github-token "${{ inputs.github_token }}" 2>&1 | tee install_output.txt
+          --github-token "${{ inputs.github_token }}" \
+          "${extra_args[@]}" 2>&1 | tee install_output.txt
         echo "path=install_output.txt" >> "$GITHUB_OUTPUT"
 
     - name: Install agent (Windows)
       id: install-windows
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        SERVICE_USERNAME: ${{ inputs.service_username }}
+        SERVICE_PASSWORD: ${{ inputs.service_password }}
       run: |
+        $extra = @()
+        if ($env:SERVICE_USERNAME) { $extra += @("--service-username", $env:SERVICE_USERNAME) }
+        if ($env:SERVICE_PASSWORD) { $extra += @("--service-password", $env:SERVICE_PASSWORD) }
         ./dist/${{ inputs.binary }} `
           --config-url "${{ inputs.config_url }}" `
           --config-secret "${{ inputs.config_secret }}" `
           --org-id "${{ inputs.org_id }}" `
-          --github-token "${{ inputs.github_token }}" 2>&1 | Tee-Object -FilePath install_output.txt
+          --github-token "${{ inputs.github_token }}" `
+          @extra 2>&1 | Tee-Object -FilePath install_output.txt
         "path=install_output.txt" >> $env:GITHUB_OUTPUT

--- a/.github/actions/provision-service-user/action.yml
+++ b/.github/actions/provision-service-user/action.yml
@@ -5,10 +5,11 @@ inputs:
   username:
     description: "Bare account name to provision (e.g. rewst-it-svc)"
     required: true
+
+outputs:
   password:
-    description: "Password for the account (Windows only; sourced from a secret)"
-    required: false
-    default: ""
+    description: "Randomly generated account password (Windows only; masked in logs). Empty on Linux/macOS."
+    value: ${{ steps.windows.outputs.password }}
 
 runs:
   using: composite
@@ -51,20 +52,37 @@ runs:
         fi
 
     - name: Provision user (Windows)
+      id: windows
       if: runner.os == 'Windows'
       shell: pwsh
       env:
         SVC_USER: ${{ inputs.username }}
-        SVC_PASSWORD: ${{ inputs.password }}
       run: |
         $ErrorActionPreference = "Stop"
 
-        if (-not $env:SVC_PASSWORD) {
-          Write-Error "A password is required to provision the Windows service account"
-          exit 1
+        # Generate a random, complexity-compliant password (upper, lower, digit,
+        # special) and mask it so it never appears in the logs. It is exposed as a
+        # step output so the install/update steps can register the service under
+        # the same credentials, and is never persisted to a secret or to disk.
+        $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+        function Get-RandChar([string]$set) {
+          $bytes = New-Object 'System.Byte[]' 1
+          $rng.GetBytes($bytes)
+          return $set[$bytes[0] % $set.Length]
         }
+        $upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        $lower = 'abcdefghijklmnopqrstuvwxyz'
+        $digit = '0123456789'
+        $special = '!@#%^*-_=+'
+        $all = $upper + $lower + $digit + $special
+        $chars = @((Get-RandChar $upper), (Get-RandChar $lower), (Get-RandChar $digit), (Get-RandChar $special))
+        for ($i = 0; $i -lt 20; $i++) { $chars += (Get-RandChar $all) }
+        $password = -join ($chars | Sort-Object { Get-Random })
 
-        $securePassword = ConvertTo-SecureString $env:SVC_PASSWORD -AsPlainText -Force
+        Write-Output "::add-mask::$password"
+        "password=$password" >> $env:GITHUB_OUTPUT
+
+        $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
 
         if (Get-LocalUser -Name $env:SVC_USER -ErrorAction SilentlyContinue) {
           Write-Output "User $env:SVC_USER already exists; resetting password"

--- a/.github/actions/provision-service-user/action.yml
+++ b/.github/actions/provision-service-user/action.yml
@@ -1,0 +1,107 @@
+name: Provision service user
+description: Create a dedicated local/system account the agent service can run as, per platform. On Windows the account is granted the "Log on as a service" right.
+
+inputs:
+  username:
+    description: "Bare account name to provision (e.g. rewst-it-svc)"
+    required: true
+  password:
+    description: "Password for the account (Windows only; sourced from a secret)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Provision user (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        SVC_USER: ${{ inputs.username }}
+      run: |
+        set -euo pipefail
+        if id "$SVC_USER" >/dev/null 2>&1; then
+          echo "User $SVC_USER already exists; reusing"
+        else
+          sudo useradd --system --no-create-home --shell /usr/sbin/nologin "$SVC_USER"
+          echo "Created system user $SVC_USER"
+        fi
+
+    - name: Provision user (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        SVC_USER: ${{ inputs.username }}
+      run: |
+        set -euo pipefail
+        if dscl . -read "/Users/$SVC_USER" >/dev/null 2>&1; then
+          echo "User $SVC_USER already exists; reusing"
+        else
+          # Pick a UniqueID that is free and in the system range (< 500).
+          uid=499
+          while dscl . -search /Users UniqueID "$uid" 2>/dev/null | grep -q .; do
+            uid=$((uid - 1))
+          done
+          sudo dscl . -create "/Users/$SVC_USER"
+          sudo dscl . -create "/Users/$SVC_USER" UserShell /usr/bin/false
+          sudo dscl . -create "/Users/$SVC_USER" RealName "Rewst Integration Test Service"
+          sudo dscl . -create "/Users/$SVC_USER" UniqueID "$uid"
+          sudo dscl . -create "/Users/$SVC_USER" PrimaryGroupID 20
+          echo "Created local user $SVC_USER with UniqueID $uid"
+        fi
+
+    - name: Provision user (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SVC_USER: ${{ inputs.username }}
+        SVC_PASSWORD: ${{ inputs.password }}
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        if (-not $env:SVC_PASSWORD) {
+          Write-Error "A password is required to provision the Windows service account"
+          exit 1
+        }
+
+        $securePassword = ConvertTo-SecureString $env:SVC_PASSWORD -AsPlainText -Force
+
+        if (Get-LocalUser -Name $env:SVC_USER -ErrorAction SilentlyContinue) {
+          Write-Output "User $env:SVC_USER already exists; resetting password"
+          Set-LocalUser -Name $env:SVC_USER -Password $securePassword
+        } else {
+          New-LocalUser -Name $env:SVC_USER -Password $securePassword `
+            -FullName "Rewst Integration Test Service" `
+            -Description "Service account for integration tests" `
+            -PasswordNeverExpires -AccountNeverExpires | Out-Null
+          Write-Output "Created local user $env:SVC_USER"
+        }
+
+        # Grant the "Log on as a service" right (SeServiceLogonRight) via secedit.
+        $account = ".\$($env:SVC_USER)"
+        $sid = (New-Object System.Security.Principal.NTAccount($account)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+
+        $tmp = Join-Path $env:RUNNER_TEMP "secpol"
+        New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+        $infPath = Join-Path $tmp "secpol.inf"
+        $dbPath = Join-Path $tmp "secpol.sdb"
+
+        secedit /export /cfg $infPath /areas USER_RIGHTS | Out-Null
+
+        $content = Get-Content $infPath
+        $line = $content | Where-Object { $_ -match "^SeServiceLogonRight" }
+        if ($line) {
+          if ($line -notmatch [regex]::Escape($sid)) {
+            $content = $content -replace "^SeServiceLogonRight.*", "$line,*$sid"
+          } else {
+            Write-Output "SID already holds SeServiceLogonRight"
+          }
+        } else {
+          $content = $content -replace "(\[Privilege Rights\])", "`$1`r`nSeServiceLogonRight = *$sid"
+        }
+        # secedit expects the INF as Unicode (UTF-16LE).
+        Set-Content -Path $infPath -Value $content -Encoding Unicode
+
+        secedit /import /db $dbPath /cfg $infPath /areas USER_RIGHTS | Out-Null
+        secedit /configure /db $dbPath /areas USER_RIGHTS | Out-Null
+        Write-Output "Granted 'Log on as a service' to $account"

--- a/.github/actions/provision-service-user/action.yml
+++ b/.github/actions/provision-service-user/action.yml
@@ -96,8 +96,10 @@ runs:
         }
 
         # Grant the "Log on as a service" right (SeServiceLogonRight) via secedit.
+        # Read the SID straight from the local account; the ".\" SCM prefix is not
+        # resolvable via NTAccount.Translate().
         $account = ".\$($env:SVC_USER)"
-        $sid = (New-Object System.Security.Principal.NTAccount($account)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        $sid = (Get-LocalUser -Name $env:SVC_USER).SID.Value
 
         $tmp = Join-Path $env:RUNNER_TEMP "secpol"
         New-Item -ItemType Directory -Force -Path $tmp | Out-Null

--- a/.github/actions/remove-service-user/action.yml
+++ b/.github/actions/remove-service-user/action.yml
@@ -1,0 +1,49 @@
+name: Remove service user
+description: Tear down the dedicated service account provisioned for the test, per platform. Safe to run regardless of job outcome.
+
+inputs:
+  username:
+    description: "Bare account name to remove (e.g. rewst-it-svc)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Remove user (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        SVC_USER: ${{ inputs.username }}
+      run: |
+        if id "$SVC_USER" >/dev/null 2>&1; then
+          sudo userdel "$SVC_USER" || true
+          echo "Removed user $SVC_USER"
+        else
+          echo "User $SVC_USER not present; nothing to remove"
+        fi
+
+    - name: Remove user (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        SVC_USER: ${{ inputs.username }}
+      run: |
+        if dscl . -read "/Users/$SVC_USER" >/dev/null 2>&1; then
+          sudo dscl . -delete "/Users/$SVC_USER" || true
+          echo "Removed user $SVC_USER"
+        else
+          echo "User $SVC_USER not present; nothing to remove"
+        fi
+
+    - name: Remove user (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SVC_USER: ${{ inputs.username }}
+      run: |
+        if (Get-LocalUser -Name $env:SVC_USER -ErrorAction SilentlyContinue) {
+          Remove-LocalUser -Name $env:SVC_USER
+          Write-Output "Removed user $env:SVC_USER"
+        } else {
+          Write-Output "User $env:SVC_USER not present; nothing to remove"
+        }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -377,10 +377,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Provision service account
+        id: provision
         uses: ./.github/actions/provision-service-user
         with:
           username: ${{ matrix.service_user }}
-          password: ${{ secrets.IT_SERVICE_PASSWORD }}
 
       - name: Install agent as service account
         uses: ./.github/actions/install-agent
@@ -393,7 +393,7 @@ jobs:
           org_id: ${{ vars.IT_ORG_ID }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           service_username: ${{ matrix.service_username_arg }}
-          service_password: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+          service_password: ${{ steps.provision.outputs.password }}
 
       - name: Assert service runs as account (config flow)
         uses: ./.github/actions/assert-service-identity
@@ -412,7 +412,7 @@ jobs:
         with:
           config_dir: ${{ matrix.config_dir }}
           org_id: ${{ vars.IT_ORG_ID }}
-          secret: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+          secret: ${{ steps.provision.outputs.password }}
 
       - name: Re-register service via update flow (Unix)
         if: runner.os != 'Windows'
@@ -435,7 +435,7 @@ jobs:
           ORG_ID: ${{ vars.IT_ORG_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SERVICE_USERNAME: ${{ matrix.service_username_arg }}
-          SERVICE_PASSWORD: ${{ secrets.IT_SERVICE_PASSWORD }}
+          SERVICE_PASSWORD: ${{ steps.provision.outputs.password }}
         run: |
           & "./dist/${{ matrix.binary }}" `
             --update `
@@ -455,7 +455,7 @@ jobs:
         with:
           config_dir: ${{ matrix.config_dir }}
           org_id: ${{ vars.IT_ORG_ID }}
-          secret: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+          secret: ${{ steps.provision.outputs.password }}
 
       - name: Uninstall agent
         uses: ./.github/actions/run-agent

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -119,6 +119,9 @@ jobs:
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/etc/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n/tmp/rewst_remote_agent/scripts/$orgId"
+              service_user = 'rewst-it-svc'
+              service_username_arg = 'rewst-it-svc'
+              service_identity = 'rewst-it-svc'
             },
             [ordered]@{
               os = 'windows-latest'
@@ -132,6 +135,9 @@ jobs:
               success_patterns = "Command completed`nSending postback`nPostback already sent"
               no_auto_updates_extra = '--disable-agent-postback'
               uninstall_paths = "C:\ProgramData\RewstRemoteAgent\$orgId`nC:\Program Files\RewstRemoteAgent\$orgId`nC:\RewstRemoteAgent\scripts\$orgId"
+              service_user = 'rewst-it-svc'
+              service_username_arg = '.\rewst-it-svc'
+              service_identity = '.\rewst-it-svc'
             },
             [ordered]@{
               os = 'macos-latest'
@@ -145,6 +151,9 @@ jobs:
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/Library/Application Support/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n`$env:TMPDIR/rewst_remote_agent/scripts/$orgId"
+              service_user = 'rewst-it-svc'
+              service_username_arg = 'rewst-it-svc'
+              service_identity = 'rewst-it-svc'
             }
           )
 
@@ -352,3 +361,115 @@ jobs:
         uses: ./.github/actions/assert-uninstalled
         with:
           paths: ${{ matrix.uninstall_paths }}
+
+  test-service-user:
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    needs: [build, build-integration-test, set-matrix]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Provision service account
+        uses: ./.github/actions/provision-service-user
+        with:
+          username: ${{ matrix.service_user }}
+          password: ${{ secrets.IT_SERVICE_PASSWORD }}
+
+      - name: Install agent as service account
+        uses: ./.github/actions/install-agent
+        with:
+          os: ${{ matrix.os }}
+          binary: ${{ matrix.binary }}
+          it_binary: ${{ matrix.it_binary }}
+          config_url: ${{ vars.IT_CONFIG_URL }}
+          config_secret: ${{ secrets.IT_CONFIG_SECRET }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          service_username: ${{ matrix.service_username_arg }}
+          service_password: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+
+      - name: Assert service runs as account (config flow)
+        uses: ./.github/actions/assert-service-identity
+        with:
+          service: ${{ matrix.service }}
+          expected_identity: ${{ matrix.service_identity }}
+
+      - name: Validate config and get device id
+        uses: ./.github/actions/validate-config
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+
+      - name: Assert password absent from config (config flow)
+        uses: ./.github/actions/assert-config-secret-absent
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          secret: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+
+      - name: Re-register service via update flow (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVICE_USERNAME: ${{ matrix.service_username_arg }}
+        run: |
+          sudo "./dist/${{ matrix.binary }}" \
+            --update \
+            --org-id "$ORG_ID" \
+            --github-token "$GH_TOKEN" \
+            --service-username "$SERVICE_USERNAME"
+
+      - name: Re-register service via update flow (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVICE_USERNAME: ${{ matrix.service_username_arg }}
+          SERVICE_PASSWORD: ${{ secrets.IT_SERVICE_PASSWORD }}
+        run: |
+          & "./dist/${{ matrix.binary }}" `
+            --update `
+            --org-id $env:ORG_ID `
+            --github-token $env:GH_TOKEN `
+            --service-username $env:SERVICE_USERNAME `
+            --service-password $env:SERVICE_PASSWORD
+
+      - name: Assert service runs as account (update flow)
+        uses: ./.github/actions/assert-service-identity
+        with:
+          service: ${{ matrix.service }}
+          expected_identity: ${{ matrix.service_identity }}
+
+      - name: Assert password absent from config (update flow)
+        uses: ./.github/actions/assert-config-secret-absent
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          secret: ${{ matrix.os == 'windows-latest' && secrets.IT_SERVICE_PASSWORD || '' }}
+
+      - name: Uninstall agent
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --uninstall --org-id ${{ vars.IT_ORG_ID }}
+
+      - name: Check deleted directories
+        uses: ./.github/actions/assert-uninstalled
+        with:
+          paths: ${{ matrix.uninstall_paths }}
+
+      - name: Remove service account
+        if: always()
+        uses: ./.github/actions/remove-service-user
+        with:
+          username: ${{ matrix.service_user }}


### PR DESCRIPTION
## Summary

Adds end-to-end integration coverage proving the agent service actually runs under the account passed to `--service-username`, and that the identity survives the update re-registration path — closing sc-95915. Previously only unit tests covered the flag wiring up to the service-manager boundary.

A new `test-service-user` job (matrixed over Windows, Linux, macOS) provisions a dedicated `rewst-it-svc` account, installs the agent under it, asserts the registered run-as identity, runs the `--update` re-registration flow, re-asserts the identity, and tears the account down — failing red if the service lands on the platform default account.

## What's included

**New composite actions**
- `provision-service-user` — creates `rewst-it-svc` per OS (`useradd --system` / `dscl` / `New-LocalUser`). On Windows it generates a random, complexity-compliant password at runtime, masks it (`::add-mask::`), exposes it as a step output, and grants `SeServiceLogonRight` via `secedit`. No stored secret required.
- `assert-service-identity` — asserts run-as identity and fails on mismatch: `systemctl show -p User` (Linux), `Win32_Service.StartName` leaf-compare (Windows), `launchctl print` + authoritative plist `UserName` fallback (macOS).
- `remove-service-user` — tears down the account per OS.
- `assert-config-secret-absent` — greps `config.json` for the password value and fails if present (never echoing it).

**Changed**
- `install-agent` — optional `service_username` / `service_password` inputs, appended safely via env vars (defaults preserve existing behavior).
- `integration-test.yml` — new matrix fields (`service_user`, `service_username_arg`, `service_identity`) and the `test-service-user` job covering provision → install → assert identity → assert no password in config → update re-register → re-assert identity → assert no password → uninstall → `always()` account teardown.

## Acceptance criteria
- [x] Config flow runs with `--service-username` (+`--service-password` on Windows) on all three platforms
- [x] Run-as identity asserted on all three platforms
- [x] Update flow runs with `--service-username` and re-asserts identity after re-registration
- [x] Account created before / removed after (including on failure); password never persisted to `config.json`
- [x] Assertion fails red when the service is registered under the default account

## Notes
- Per follow-up direction, the Windows password is **generated at runtime and masked** rather than sourced from a `IT_SERVICE_PASSWORD` secret (AC #4's wording said "from a GitHub secret"). The security intent — never in logs, never in `config.json` — is preserved. Worth flagging to QA so they expect the runtime-generated approach.
- The job asserts the registered run-as identity (which is the credential-plumbing this ticket targets) rather than requiring the service to be fully online under a non-privileged account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)