### PR TITLE
fix: [sc-96140] Set explicit MQTT ConnectTimeout instead of relying on paho default

### DIFF
--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -1,6 +1,10 @@
 package agent
 
-import "github.com/RewstApp/agent-smith-go/internal/utils"
+import (
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+)
 
 type Device struct {
 	DeviceId             string             `json:"device_id"`
@@ -16,6 +20,20 @@ type Device struct {
 	DisableAutoUpdates   bool               `json:"disable_auto_updates"`
 	GithubToken          string             `json:"github_token,omitempty"`
 	MqttQos              *byte              `json:"mqtt_qos,omitempty"`
+	// MqttConnectTimeoutSeconds optionally overrides the per-attempt MQTT
+	// connect timeout. When unset (or non-positive) the agent falls back to
+	// utils.DefaultMqttConnectTimeout. Useful for endpoints with slow TLS
+	// handshakes that need more than the default.
+	MqttConnectTimeoutSeconds *int `json:"mqtt_connect_timeout_seconds,omitempty"`
+}
+
+// MqttConnectTimeout returns the per-attempt MQTT connect timeout, honoring the
+// per-device override when set and falling back to the documented default.
+func (d Device) MqttConnectTimeout() time.Duration {
+	if d.MqttConnectTimeoutSeconds != nil && *d.MqttConnectTimeoutSeconds > 0 {
+		return time.Duration(*d.MqttConnectTimeoutSeconds) * time.Second
+	}
+	return utils.DefaultMqttConnectTimeout
 }
 
 type Plugin struct {

--- a/internal/mqtt/common.go
+++ b/internal/mqtt/common.go
@@ -19,14 +19,30 @@ var NewClient = mqtt.NewClient
 const DefaultDisconnectQuiesce time.Duration = 250 * time.Millisecond
 
 func NewClientOptions(device agent.Device) (*mqtt.ClientOptions, error) {
+	var (
+		opts *mqtt.ClientOptions
+		err  error
+	)
+
 	switch device.Broker {
 	default:
-		return newAzureIotHubClientOptions(azureIotHubDevice{
+		opts, err = newAzureIotHubClientOptions(azureIotHubDevice{
 			DeviceId:        device.DeviceId,
 			Host:            device.AzureIotHubHost,
 			SharedAccessKey: device.SharedAccessKey,
 		})
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Explicitly own the connect timeout instead of relying on paho's implicit
+	// 30s default, so reconnect timing stays predictable across paho upgrades.
+	// See utils.DefaultMqttConnectTimeout for the value and rationale.
+	opts.SetConnectTimeout(device.MqttConnectTimeout())
+
+	return opts, nil
 }
 
 type ReportedProperties struct {

--- a/internal/mqtt/common_test.go
+++ b/internal/mqtt/common_test.go
@@ -66,6 +66,9 @@ func TestNewClientOptions_ConnectTimeoutOverride(t *testing.T) {
 	}
 
 	if opts.ConnectTimeout != 12*time.Second {
-		t.Errorf("expected ConnectTimeout to honor per-device override (12s), got %v", opts.ConnectTimeout)
+		t.Errorf(
+			"expected ConnectTimeout to honor per-device override (12s), got %v",
+			opts.ConnectTimeout,
+		)
 	}
 }

--- a/internal/mqtt/common_test.go
+++ b/internal/mqtt/common_test.go
@@ -2,8 +2,10 @@ package mqtt
 
 import (
 	"testing"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
 
 func TestNewClientOptions_DefaultAzureIotHub(t *testing.T) {
@@ -35,5 +37,35 @@ func TestNewClientOptions_DefaultAzureIotHub(t *testing.T) {
 
 	if len(opts.Servers) == 0 {
 		t.Error("expected at least one mqtt broker to be configured")
+	}
+
+	// ConnectTimeout must be explicitly owned by us, not paho's implicit 30s
+	// default, and default to the documented value.
+	if opts.ConnectTimeout != utils.DefaultMqttConnectTimeout {
+		t.Errorf(
+			"expected ConnectTimeout to default to %v, got %v",
+			utils.DefaultMqttConnectTimeout,
+			opts.ConnectTimeout,
+		)
+	}
+}
+
+func TestNewClientOptions_ConnectTimeoutOverride(t *testing.T) {
+	override := 12
+	device := agent.Device{
+		DeviceId:                  "test-device",
+		AzureIotHubHost:           "myhub.azure-devices.net",
+		SharedAccessKey:           "c2VjcmV0a2V5",
+		Broker:                    "",
+		MqttConnectTimeoutSeconds: &override,
+	}
+
+	opts, err := NewClientOptions(device)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if opts.ConnectTimeout != 12*time.Second {
+		t.Errorf("expected ConnectTimeout to honor per-device override (12s), got %v", opts.ConnectTimeout)
 	}
 }

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -7,6 +7,22 @@ import (
 
 const maxTimeout time.Duration = 64 * time.Second
 
+// InitialReconnectInterval is the base interval the reconnect backoff seeds
+// from. The first reconnect slot produced by ReconnectTimeoutGenerator is
+// therefore ~2x this value (doubled) with up to ±25% jitter, i.e. it is never
+// shorter than 1.5 * InitialReconnectInterval.
+const InitialReconnectInterval time.Duration = time.Second
+
+// DefaultMqttConnectTimeout bounds a single MQTT connect attempt.
+//
+// paho.mqtt.golang defaults ConnectTimeout to an implicit 30s. We set our own
+// value so reconnect timing is fully owned by this codebase and stays stable
+// across paho upgrades. The value is intentionally <= the shortest reconnect
+// backoff slot (1.5 * InitialReconnectInterval) so a connect attempt can never
+// outlive the next backoff slot. Endpoints with slow TLS handshakes can raise
+// it per-device via the device config (mqtt_connect_timeout_seconds).
+const DefaultMqttConnectTimeout time.Duration = InitialReconnectInterval
+
 type ReconnectTimeoutGenerator struct {
 	base    time.Duration
 	timeout time.Duration
@@ -18,7 +34,7 @@ func (g *ReconnectTimeoutGenerator) Timeout() time.Duration {
 
 func (g *ReconnectTimeoutGenerator) Next() {
 	if g.base == 0 {
-		g.base = time.Second
+		g.base = InitialReconnectInterval
 	}
 
 	g.base *= 2

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -45,6 +45,23 @@ func TestReconnectTimeoutGenerator(t *testing.T) {
 	}
 }
 
+// TestDefaultMqttConnectTimeoutFitsBackoff records the chosen connect timeout
+// and its rationale: a single connect attempt must never outlive the shortest
+// reconnect backoff slot, otherwise a connect attempt could still be blocking
+// when the next reconnect would already be due. The shortest slot is the first
+// one: base doubled to 2 * InitialReconnectInterval, minus up to 25% jitter,
+// i.e. 1.5 * InitialReconnectInterval.
+func TestDefaultMqttConnectTimeoutFitsBackoff(t *testing.T) {
+	shortestSlot := time.Duration(float64(2*InitialReconnectInterval) * (1 - 0.25))
+	if DefaultMqttConnectTimeout > shortestSlot {
+		t.Errorf(
+			"DefaultMqttConnectTimeout (%v) must not exceed the shortest backoff slot (%v)",
+			DefaultMqttConnectTimeout,
+			shortestSlot,
+		)
+	}
+}
+
 func TestReconnectTimeoutGeneratorJitterDiffers(t *testing.T) {
 	// Two independent generators must produce different sequences
 	g1 := ReconnectTimeoutGenerator{}


### PR DESCRIPTION
## Summary

The MQTT client options assembled in `runCycle` set `AutoReconnect=false` and an `OnConnectionLost` callback, but never called `SetConnectTimeout` — so initial-connect/subscribe operations silently relied on paho.mqtt.golang's implicit 30s default. This coupled our reconnect behaviour to an undeclared library default that could drift across pinned paho versions without any signal in our code.

This PR makes the connect timeout fully owned by our code so reconnect behaviour stays predictable across paho upgrades.

## Changes

- **`internal/utils/time.go`** — Added `InitialReconnectInterval` (1s), now the seed for the reconnect backoff, plus `DefaultMqttConnectTimeout` as a documented constant alongside the backoff parameters. The default is `<=` the shortest possible backoff slot (`1.5 × InitialReconnectInterval` after worst-case jitter), so a connect attempt can never outlive the next backoff slot.
- **`internal/agent/device.go`** — Added optional per-device override `mqtt_connect_timeout_seconds` (mirroring the existing `mqtt_qos` tunable) and a `Device.MqttConnectTimeout()` helper.
- **`internal/mqtt/common.go`** — `NewClientOptions` now calls `opts.SetConnectTimeout(...)` centrally for all broker paths.
- **Tests** — Assert the default and per-device override in `common_test.go`; record the chosen timeout/rationale and prove it fits within the backoff in `time_test.go`.

## Acceptance criteria

- ✅ ConnectTimeout explicitly set to a documented value (constant + rationale comment).
- ✅ Overridable per-device via the existing device config struct.
- ✅ Value consistent with the initial backoff interval — connect attempt never outlives the next backoff slot.
- ✅ Unit tests + comments record the chosen timeout and rationale.

## Notes

The default is **1s**, a behavioural reduction from paho's old 30s, chosen to strictly satisfy the "never outlives the next backoff slot" criterion. Tenants with occasionally slow TLS handshakes are covered by the new per-device `mqtt_connect_timeout_seconds` override rather than a looser default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)