### PR TITLE
fix: [sc-96142] Prevent stop signal from blocking the monitor goroutine

### DIFF
--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -167,18 +167,20 @@ func (svc *serviceContext) Execute(
 		logger.Info("Plugins loaded", "plugins", plugins)
 	}
 
-	// Create a channel for stopped signal
+	// Create a channel for stopped signal. It is closed (never sent to) when a
+	// stop is requested so that closing can never block the monitor goroutine.
+	// A closed channel makes every select on <-stopped return immediately and
+	// permanently, decoupling teardown timing from the reconnect backoff
+	// schedule: a stop arriving while no runCycle is draining stopped (e.g.
+	// during the time.After reconnect wait) is still honored at once.
 	stopped := make(chan struct{})
 
 	// Monitor the request for the stopped signal
 	go func() {
-		for {
-			select {
-			case <-stop:
-				stopped <- struct{}{}
-			case <-ctx.Done():
-				return
-			}
+		select {
+		case <-stop:
+			close(stopped)
+		case <-ctx.Done():
 		}
 	}()
 

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -691,6 +692,127 @@ type blockingPublishClient struct {
 
 func (m *blockingPublishClient) Publish(_ string, _ byte, _ bool, _ interface{}) pahomqtt.Token {
 	return m.publishToken
+}
+
+// connectSignalClient embeds mockMQTTClient and always fails Connect, sending a
+// signal on connectCalled each time Connect is invoked. It is used to drive
+// Execute into the reconnect backoff loop deterministically.
+type connectSignalClient struct {
+	mockMQTTClient
+	connectCalled chan struct{}
+}
+
+func (m *connectSignalClient) Connect() pahomqtt.Token {
+	select {
+	case m.connectCalled <- struct{}{}:
+	default:
+	}
+	return &mockMQTTToken{err: errors.New("connection refused")}
+}
+
+// TestExecute_StopHonoredPromptlyDuringReconnectBackoff is the regression test
+// for sc-96142: a stop issued while Execute is waiting on the reconnect backoff
+// must return promptly (well within the backoff interval), and the stop-signal
+// monitor goroutine must never get stuck. Connect always fails, so after the
+// first cycle Execute enters a ~1.5-2.5s backoff wait; closing stop during that
+// wait must return Execute in well under a second.
+func TestExecute_StopHonoredPromptlyDuringReconnectBackoff(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	device := agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		LoggingLevel:         "error",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+	configBytes, _ := json.Marshal(device)
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	connectCalled := make(chan struct{}, 10)
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &connectSignalClient{connectCalled: connectCalled}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+
+	baselineGoroutines := runtime.NumGoroutine()
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	// Wait for the first connect attempt to fail; Execute then computes the
+	// next backoff and enters the reconnect-wait select.
+	select {
+	case <-connectCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not attempt to connect within timeout")
+	}
+
+	// Give Execute a moment to settle into the backoff wait. This is shorter
+	// than the minimum backoff (1.5 * InitialReconnectInterval) so the stop is
+	// genuinely issued mid-backoff, not after it has elapsed.
+	time.Sleep(150 * time.Millisecond)
+
+	start := time.Now()
+	close(stop)
+
+	select {
+	case code := <-done:
+		elapsed := time.Since(start)
+		if elapsed > time.Second {
+			t.Fatalf(
+				"stop during reconnect backoff not honored promptly: returned after %v",
+				elapsed,
+			)
+		}
+		if code != 0 {
+			t.Errorf("expected exit code 0 on stop, got %d", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not exit after stop during reconnect backoff")
+	}
+
+	// The stop-signal monitor goroutine must not be left blocked on a send into
+	// stopped after Execute returns. Poll until the goroutine count settles back
+	// to the pre-Execute baseline; a persistently higher count indicates a
+	// leaked/stuck monitor goroutine (the original sc-96142 failure mode).
+	leaked := true
+	for i := 0; i < 50; i++ {
+		if runtime.NumGoroutine() <= baselineGoroutines {
+			leaked = false
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if leaked {
+		t.Fatalf(
+			"goroutine count did not settle after stop (baseline=%d, current=%d): "+
+				"monitor goroutine may be stuck on a blocked send",
+			baselineGoroutines,
+			runtime.NumGoroutine(),
+		)
+	}
 }
 
 // TestExecute_SubscribeFailure verifies that when MQTT subscription fails,


### PR DESCRIPTION
## Summary

The service's stop-signal monitor goroutine forwarded the platform `stop` signal into an **unbuffered** `stopped` channel via a blocking send (`stopped <- struct{}{}`) inside a `for` loop ([service.go](cmd/agent_smith/service.go)). If a stop arrived while no `runCycle` was actively selecting on `stopped` (e.g. during the reconnect backoff `time.After` wait), the send blocked the monitor goroutine, coupling teardown timing to the backoff schedule rather than the operator's intent. Worse, once a stop was delivered the loop circled back and could block permanently on a second send after `Execute` had already returned, **leaking the goroutine**.

## Fix

Collapse the monitor into a single closeable-channel pattern — `close(stopped)` on stop:

```go
go func() {
    select {
    case <-stop:
        close(stopped)
    case <-ctx.Done():
    }
}()
```

Closing never blocks, and a closed channel makes every `select` on `<-stopped` (the reconnect-backoff wait and `runCycle`'s final select) return **immediately and permanently**. A stop is honored the instant it arrives, independent of the backoff schedule, and the goroutine can never get stuck.

## Tests

Added `TestExecute_StopHonoredPromptlyDuringReconnectBackoff`: drives `Execute` into the reconnect backoff (Connect always fails), closes `stop` mid-backoff, and asserts:
1. `Execute` returns in well under a second (vs. the ~1.5–2.5s backoff) with exit code 0.
2. The monitor goroutine count settles back to baseline (no leak).

Verified as a genuine regression guard: with the old `for`/send code it **fails every run** (leaked goroutine, baseline climbing across runs); with the fix it passes consistently under `-race`.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (no regressions; existing graceful-shutdown ordering tests still pass)

## Acceptance criteria

- [x] Stop signaling cannot block the monitor goroutine (closeable-channel pattern).
- [x] A stop issued during reconnect backoff is honored within ~1s, not at the end of the backoff interval.
- [x] Unit test covers stop during reconnect backoff returning from `Execute` promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)