### PR TITLE
fix: [sc-96141] Bound AgentReceivedMessage notification payload size

### DIFF
--- a/cmd/agent_smith/process_message_test.go
+++ b/cmd/agent_smith/process_message_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -437,3 +438,87 @@ func (t *failingThenPassTransport) RoundTrip(req *http.Request) (*http.Response,
 type simulatedNetError struct{ msg string }
 
 func (e *simulatedNetError) Error() string { return e.msg }
+
+const receivedMessagePrefix = "AgentReceivedMessage:"
+
+// TestBuildReceivedMessageNotification_SmallPayloadVerbatim verifies that a
+// payload at or below the threshold is embedded verbatim, preserving the
+// existing notification format for normal-sized messages.
+func TestBuildReceivedMessageNotification_SmallPayloadVerbatim(t *testing.T) {
+	payload := []byte(`{"commands":"echo hi"}`)
+
+	got := buildReceivedMessageNotification(payload)
+
+	want := receivedMessagePrefix + string(payload)
+	if got != want {
+		t.Errorf("expected verbatim notification %q, got %q", want, got)
+	}
+}
+
+// TestBuildReceivedMessageNotification_BoundaryVerbatim verifies that a payload
+// exactly at the threshold is still sent verbatim (the boundary is inclusive).
+func TestBuildReceivedMessageNotification_BoundaryVerbatim(t *testing.T) {
+	payload := []byte(strings.Repeat("a", maxNotificationPayloadBytes))
+
+	got := buildReceivedMessageNotification(payload)
+
+	want := receivedMessagePrefix + string(payload)
+	if got != want {
+		t.Errorf("expected payload at threshold to be sent verbatim")
+	}
+	if strings.Contains(got, "truncated") {
+		t.Errorf("payload at threshold must not be summarised, got %q", got)
+	}
+}
+
+// TestBuildReceivedMessageNotification_LargePayloadBounded verifies that the
+// notification size stays bounded for arbitrarily large payloads: the full
+// payload is never embedded, and the result reports the true byte length plus a
+// truncated prefix.
+func TestBuildReceivedMessageNotification_LargePayloadBounded(t *testing.T) {
+	// A payload well beyond the threshold (8 MiB) — the kind of multi-MB
+	// workflow body that previously inflated agent memory.
+	const payloadSize = 8 << 20
+	payload := []byte(strings.Repeat("x", payloadSize))
+
+	got := buildReceivedMessageNotification(payload)
+
+	// The notification must be bounded by the prefix + summary text + the
+	// truncated payload window, regardless of how large the payload is.
+	maxLen := len(receivedMessagePrefix) + 64 + maxNotificationPayloadBytes
+	if len(got) > maxLen {
+		t.Errorf("notification length %d exceeds bound %d", len(got), maxLen)
+	}
+	// It must never embed the full payload.
+	if len(got) >= payloadSize {
+		t.Errorf("notification embeds full payload: len=%d, payload=%d", len(got), payloadSize)
+	}
+	if !strings.HasPrefix(got, receivedMessagePrefix) {
+		t.Errorf("notification missing prefix: %q", got[:len(receivedMessagePrefix)])
+	}
+	// The true byte length must be reported so consumers can detect truncation.
+	if !strings.Contains(got, "8388608") {
+		t.Errorf("expected total byte length in summary, got %q", got[:128])
+	}
+}
+
+// TestBuildReceivedMessageNotification_BoundedAcrossSizes asserts the bound
+// holds for a range of payload sizes straddling the threshold.
+func TestBuildReceivedMessageNotification_BoundedAcrossSizes(t *testing.T) {
+	maxLen := len(receivedMessagePrefix) + 64 + maxNotificationPayloadBytes
+
+	for _, size := range []int{0, 1, maxNotificationPayloadBytes - 1, maxNotificationPayloadBytes, maxNotificationPayloadBytes + 1, 1 << 20} {
+		payload := []byte(strings.Repeat("z", size))
+		got := buildReceivedMessageNotification(payload)
+
+		if size <= maxNotificationPayloadBytes {
+			if got != receivedMessagePrefix+string(payload) {
+				t.Errorf("size %d: expected verbatim notification", size)
+			}
+			continue
+		}
+		if len(got) > maxLen {
+			t.Errorf("size %d: notification length %d exceeds bound %d", size, len(got), maxLen)
+		}
+	}
+}

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -30,6 +30,14 @@ const (
 	postbackHTTPTimeout      = 30 * time.Second
 	postbackMaxAttempts      = 3
 	postbackBaseRetryBackoff = 1 * time.Second
+
+	// maxNotificationPayloadBytes bounds how many bytes of a received message
+	// payload are embedded in the AgentReceivedMessage notification forwarded to
+	// plugins. Payloads at or below this size are sent verbatim (preserving the
+	// existing behaviour for normal-sized messages); larger payloads are
+	// summarised so a single oversized workflow message cannot inflate agent
+	// memory or overflow the plugin RPC pipe.
+	maxNotificationPayloadBytes = 4096
 )
 
 type errorResponse struct {
@@ -356,6 +364,28 @@ func (svc *serviceContext) runCycle(
 	}
 }
 
+// buildReceivedMessageNotification builds the bounded "AgentReceivedMessage"
+// notification string forwarded to plugins for a received payload. Payloads at
+// or below maxNotificationPayloadBytes are embedded verbatim. Larger payloads
+// are summarised as their total byte length plus a truncated prefix, so the
+// resulting notification stays a fixed maximum size regardless of payload size —
+// avoiding extra full-payload copies and the risk of overflowing the plugin RPC
+// pipe.
+func buildReceivedMessageNotification(payload []byte) string {
+	const prefix = "AgentReceivedMessage:"
+
+	if len(payload) <= maxNotificationPayloadBytes {
+		return prefix + string(payload)
+	}
+
+	return fmt.Sprintf(
+		"%s[truncated %d bytes] %s",
+		prefix,
+		len(payload),
+		payload[:maxNotificationPayloadBytes],
+	)
+}
+
 func (svc *serviceContext) processMessage(
 	payload []byte,
 	ctx context.Context,
@@ -371,7 +401,7 @@ func (svc *serviceContext) processMessage(
 	}
 
 	_ = notifier.Notify(
-		"AgentReceivedMessage:" + string(payload),
+		buildReceivedMessageNotification(payload),
 	) // Best effort notification
 
 	// Execute the message


### PR DESCRIPTION
## Summary

`processMessage` built the `AgentReceivedMessage` notification as `"AgentReceivedMessage:" + string(payload)` unconditionally for every received message. For large workflow payloads this copied the whole payload into a string and again into the concatenated notification before pushing it across the go-plugin RPC pipe — multiplying memory pressure and risking dropped notifications or OOM on resource-constrained endpoints.

## Changes

- Add `maxNotificationPayloadBytes = 4096` constant in `cmd/agent_smith/service.go`.
- Add `buildReceivedMessageNotification(payload []byte) string`:
  - Payloads **≤ 4096 bytes** are embedded verbatim (no change for normal-sized messages → no notification ordering/delivery regression).
  - Payloads **> 4096 bytes** become a fixed-max-size summary: `AgentReceivedMessage:[truncated <N> bytes] <first 4096 bytes>`, reporting the true total byte length plus a truncated prefix.
- `processMessage` now calls the builder instead of inline concatenation.

The notification size is now bounded by `prefix + summary + 4096` regardless of payload size, so a multi-MB message can no longer balloon agent memory or overflow the plugin RPC pipe.

## Tests

Added four unit tests in `cmd/agent_smith/process_message_test.go`:
- `SmallPayloadVerbatim` — normal messages keep the exact existing format.
- `BoundaryVerbatim` — payload exactly at threshold is sent whole (inclusive boundary).
- `LargePayloadBounded` — an 8 MiB payload yields a bounded string that never embeds the full payload and reports the true byte length.
- `BoundedAcrossSizes` — bound holds across sizes straddling the threshold (0, 1, threshold±1, 1 MiB).

`go vet ./...` and `go test ./...` pass.

## Acceptance criteria

- [x] Notification no longer embeds the full raw payload (fixed-size summary above threshold).
- [x] Bounded allocation/string size covered by unit test for arbitrary payload sizes.
- [x] No regression in plugin-notification ordering or delivery for normal-sized payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)