### PR TITLE
test: [sc-97773] Add MQTT reconnection coverage to integration workflow

### DIFF
--- a/.github/actions/disrupt-connection/action.yml
+++ b/.github/actions/disrupt-connection/action.yml
@@ -1,0 +1,118 @@
+name: Disrupt connection
+description: >
+  Simulate a transient Azure IoT Hub broker outage by blocking (mode=block) and
+  later restoring (mode=restore) the agent's outbound MQTT egress to the broker
+  host on its TLS port (8883). The agent reaches the broker only on this port, so
+  cutting it severs the live connection and forces the reconnect/teardown path.
+  Restore is idempotent and tolerant of a missing rule, so an always() cleanup
+  step can run it even if the block never applied - guaranteeing a runner is
+  never left firewalled. Gated per platform: iptables on Linux, pf on macOS,
+  Windows Firewall on Windows.
+
+inputs:
+  mode:
+    description: "block to sever broker egress, restore to remove the rule"
+    required: true
+  host:
+    description: "Azure IoT Hub host to disrupt (read from the validated agent config)"
+    required: true
+  port:
+    description: "Broker TCP port to block (MQTT over TLS)"
+    required: false
+    default: "8883"
+
+runs:
+  using: composite
+  steps:
+    - name: Block egress (Linux)
+      if: inputs.mode == 'block' && runner.os == 'Linux'
+      shell: bash
+      env:
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+        echo "Blocking egress to $HOST:$PORT"
+        # iptables resolves $HOST at rule-add time and installs a DROP rule per
+        # resolved address; the comment tag lets restore find and remove them.
+        sudo iptables -A OUTPUT -p tcp -d "$HOST" --dport "$PORT" \
+          -m comment --comment "rewst-it-disrupt" -j DROP
+        sudo iptables -L OUTPUT -n --line-numbers | grep "rewst-it-disrupt" || true
+
+    - name: Restore egress (Linux)
+      if: inputs.mode == 'restore' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "Restoring egress (removing rewst-it-disrupt rules)"
+        # Delete every tagged OUTPUT rule. Line numbers shift after each delete,
+        # so re-query the chain on each pass until none remain.
+        while true; do
+          line=$(sudo iptables -L OUTPUT --line-numbers -n | awk '/rewst-it-disrupt/{print $1; exit}')
+          if [ -z "$line" ]; then break; fi
+          sudo iptables -D OUTPUT "$line"
+        done
+        sudo iptables -L OUTPUT -n || true
+
+    - name: Block egress (macOS)
+      if: inputs.mode == 'block' && runner.os == 'macOS'
+      shell: bash
+      env:
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+        echo "Blocking egress to $HOST:$PORT"
+        # pf is disabled by default on the runner, so enabling it with a ruleset
+        # that only drops broker egress leaves all other traffic passing. pf has
+        # no state for the already-established connection, so the rule applies to
+        # it immediately.
+        printf 'block drop out quick proto tcp to %s port %s\n' "$HOST" "$PORT" \
+          | sudo pfctl -ef - 2>&1 || true
+        sudo pfctl -sr 2>/dev/null || true
+
+    - name: Restore egress (macOS)
+      if: inputs.mode == 'restore' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "Restoring egress (flushing pf rules and disabling pf)"
+        sudo pfctl -F all 2>/dev/null || true
+        sudo pfctl -d 2>/dev/null || true
+
+    - name: Block egress (Windows)
+      if: inputs.mode == 'block' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+      run: |
+        Write-Output "Blocking egress to $($env:HOST):$($env:PORT)"
+        $addrs = @()
+        try {
+          $addrs = [System.Net.Dns]::GetHostAddresses($env:HOST) |
+            Where-Object { $_.AddressFamily -eq 'InterNetwork' } |
+            ForEach-Object { $_.IPAddressToString } |
+            Select-Object -Unique
+        } catch {
+          Write-Output "DNS resolution failed for $($env:HOST): $_"
+        }
+        $params = @{
+          DisplayName = 'rewst-it-disrupt'
+          Direction   = 'Outbound'
+          Action      = 'Block'
+          Protocol    = 'TCP'
+          RemotePort  = $env:PORT
+        }
+        if ($addrs.Count -gt 0) {
+          Write-Output "Resolved $($env:HOST) -> $($addrs -join ', ')"
+          $params.RemoteAddress = $addrs
+        } else {
+          Write-Output "No addresses resolved; blocking port $($env:PORT) to all remote hosts"
+        }
+        New-NetFirewallRule @params | Out-Null
+
+    - name: Restore egress (Windows)
+      if: inputs.mode == 'restore' && runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Write-Output "Restoring egress (removing rewst-it-disrupt rule)"
+        Remove-NetFirewallRule -DisplayName 'rewst-it-disrupt' -ErrorAction SilentlyContinue

--- a/.github/actions/validate-config/action.yml
+++ b/.github/actions/validate-config/action.yml
@@ -13,6 +13,9 @@ outputs:
   device_id:
     description: "device_id read from config.json"
     value: ${{ steps.parse.outputs.device_id }}
+  azure_iot_hub_host:
+    description: "azure_iot_hub_host read from config.json (the MQTT broker host)"
+    value: ${{ steps.parse.outputs.azure_iot_hub_host }}
 
 runs:
   using: composite
@@ -48,4 +51,5 @@ runs:
         if ($failed) { exit 1 }
 
         "device_id=$($config.device_id)" >> $env:GITHUB_OUTPUT
+        "azure_iot_hub_host=$($config.azure_iot_hub_host)" >> $env:GITHUB_OUTPUT
         Write-Output "All config.json fields validated"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -351,6 +351,116 @@ jobs:
           service: ${{ matrix.service }}
           pattern: Command completed
 
+      # ---- MQTT reconnection scenario ----
+      # Force a transient broker outage and verify the agent tears down, backs
+      # off, resubscribes, and resumes command delivery exactly once. Counts are
+      # captured up front and compared as deltas because the log already contains
+      # "Subscribed to messages"/"Command completed" lines from earlier cycles
+      # (the service has restarted several times by now and the log is not reset
+      # while the service holds it open).
+      - name: Capture reconnect baseline counts
+        id: reconnect_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw
+          $subscribed = ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count
+          $completed  = ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "completed=$completed"   >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed completed=$completed"
+
+      - name: Disrupt broker connection
+        uses: ./.github/actions/disrupt-connection
+        with:
+          mode: block
+          host: ${{ steps.config.outputs.azure_iot_hub_host }}
+
+      - name: Wait for connection lost detection
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Connection lost
+          max_attempts: "60"
+          interval_seconds: "2"
+
+      - name: Assert connection lost and reconnect/backoff activity
+        uses: ./.github/actions/assert-log-contains
+        with:
+          log_file: ${{ matrix.log_file }}
+          patterns: |
+            Connection lost
+            Reconnecting in
+            Reconnecting...
+          wait_seconds: "10"
+
+      - name: Restore broker connection
+        if: always()
+        uses: ./.github/actions/disrupt-connection
+        with:
+          mode: restore
+          host: ${{ steps.config.outputs.azure_iot_hub_host }}
+
+      - name: Wait for fresh subscription after reconnect
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.reconnect_baseline.outputs.subscribed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent resubscribed after reconnect (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent did not resubscribe after reconnect (subscribed count stayed at $baseline)"
+          exit 1
+
+      - name: Send command after reconnect
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Assert command executed exactly once after reconnect
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.reconnect_baseline.outputs.completed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          $observed = $baseline
+          # Wait for the post-reconnect command to complete.
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $observed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($observed -gt $baseline) { break }
+          }
+          if (($observed - $baseline) -lt 1) {
+            Write-Error "Post-reconnect command never completed (count stayed at $baseline)"
+            exit 1
+          }
+          # Allow a brief window for any duplicate delivery to surface, then
+          # require the delta to be exactly one - guarding against re-delivery of
+          # the buffered message on a non-clean reconnected session.
+          Start-Sleep -Seconds 10
+          $content = Get-Content $env:LOG_FILE -Raw
+          $final = ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count
+          $delta = $final - $baseline
+          Write-Output "Post-reconnect 'Command completed' delta: $delta (baseline $baseline, final $final)"
+          if ($delta -ne 1) {
+            Write-Error "Expected exactly one post-reconnect 'Command completed', got $delta (duplicate delivery?)"
+            exit 1
+          }
+          Write-Output "Confirmed exactly one post-reconnect command execution"
+
       - name: Uninstall agent
         uses: ./.github/actions/run-agent
         with:


### PR DESCRIPTION
## Summary

Adds MQTT reconnection coverage to the integration test workflow — the most failure-prone runtime behavior of the agent and previously only covered by unit tests. This exercises the reconnect/teardown/resubscribe path end-to-end on real `windows-latest`, `ubuntu-latest`, and `macos-latest` runners against the live broker, protecting the recently hardened reconnect logic (sc-96140/96141/96142) from regressions.

## Changes

- **New composite action `.github/actions/disrupt-connection`** — simulates a transient broker outage by blocking then restoring the agent's outbound MQTT egress to the IoT Hub host on TCP 8883 (its only broker port). Per-OS: `iptables` (Linux), `pf` (macOS), Windows Firewall (Windows). Restore is **idempotent and tolerant of a missing rule**, so an `always()` cleanup never leaves a runner firewalled.
- **`validate-config`** — now exposes `azure_iot_hub_host` as an output so the disruption targets the correct broker per matrix entry, read from the config the agent itself wrote.
- **`integration-test.yml`** — reconnection scenario added to the `test` job (after the syslog check, before uninstall), inheriting the existing `fail-fast: false` matrix:
  - Capture baseline counts (the log isn't reset while the service holds it, so assertions use deltas).
  - Block → assert `Connection lost`, `Reconnecting in`, `Reconnecting...`.
  - **Restore with `if: always()`** so connectivity is restored even if assertions fail.
  - Wait for a fresh `Subscribed to messages` (count > baseline) to prove resubscription.
  - Send a command post-reconnect, assert it completes, then assert the `Command completed` delta is **exactly 1** (duplicate-delivery guard).

## Acceptance criteria

- [x] Reconnection scenario runs on all three OSes within the existing `fail-fast: false` matrix
- [x] Forces a disconnect and asserts `Connection lost` → reconnect/backoff → `Subscribed to messages`
- [x] Post-reconnect command executes exactly once; no duplicate
- [x] Connectivity always restored (cleanup runs even on failure)
- [x] New action lives under `.github/actions/` per convention
- [ ] Workflow passes on all three platforms via `workflow_dispatch` (run after merge/dispatch)

## QA testing steps

1. Run **Integration Test** via `workflow_dispatch` with `os = all`.
2. For each OS, confirm the disrupt step applies a firewall rule, then `Connection lost` + reconnect/backoff lines appear, then a fresh `Subscribed to messages` after restore.
3. Confirm "Assert command executed exactly once after reconnect" passes (delta = 1).
4. Optionally force an assertion failure and confirm the `always()` restore still runs (runner not left firewalled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)