### PR TITLE
fix: [sc-97777] Show specific validation errors and add --help for CLI usage

### DIFF
--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -35,15 +35,10 @@ type configContext struct {
 	HTTPClient     *http.Client
 }
 
-func newConfigContext(
-	args []string,
-	sys agent.SystemInfoProvider,
-	domain agent.DomainInfoProvider,
-	fsys utils.FileSystem,
-	svcMgr service.ServiceManager,
-) (*configContext, error) {
-	var params configContext
-
+// newConfigFlagSet builds the flag set for config mode, binding flags to the
+// provided params. It is shared between argument parsing and usage rendering so
+// that the per-flag descriptions stay in a single place.
+func newConfigFlagSet(params *configContext) *flag.FlagSet {
 	fs := flag.NewFlagSet("config", flag.ContinueOnError)
 	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
 	fs.StringVar(&params.ConfigUrl, "config-url", "", "Configuration URL")
@@ -76,7 +71,20 @@ func newConfigContext(
 		"",
 		"Password for --service-username (Windows only; not persisted to disk)",
 	)
-	fs.SetOutput(bytes.NewBuffer([]byte{}))
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+func newConfigContext(
+	args []string,
+	sys agent.SystemInfoProvider,
+	domain agent.DomainInfoProvider,
+	fsys utils.FileSystem,
+	svcMgr service.ServiceManager,
+) (*configContext, error) {
+	var params configContext
+
+	fs := newConfigFlagSet(&params)
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cmd/agent_smith/diagnostic_context.go
+++ b/cmd/agent_smith/diagnostic_context.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
+	"io"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
@@ -21,6 +21,17 @@ type diagnosticContext struct {
 	FS             utils.FileSystem
 }
 
+// newDiagnosticFlagSet builds the flag set for diagnostic mode, binding flags
+// to the provided params. It is shared between argument parsing and usage
+// rendering so that the per-flag descriptions stay in a single place.
+func newDiagnosticFlagSet(params *diagnosticContext) *flag.FlagSet {
+	fs := flag.NewFlagSet("diagnostic", flag.ContinueOnError)
+	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
+	fs.BoolVar(&params.Diagnostic, "diagnostic", false, "Run diagnostic mode")
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
 func newDiagnosticContext(
 	args []string,
 	sys agent.SystemInfoProvider,
@@ -30,10 +41,7 @@ func newDiagnosticContext(
 ) (*diagnosticContext, error) {
 	var params diagnosticContext
 
-	fs := flag.NewFlagSet("diagnostic", flag.ContinueOnError)
-	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
-	fs.BoolVar(&params.Diagnostic, "diagnostic", false, "Run diagnostic mode")
-	fs.SetOutput(bytes.NewBuffer([]byte{}))
+	fs := newDiagnosticFlagSet(&params)
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cmd/agent_smith/main.go
+++ b/cmd/agent_smith/main.go
@@ -51,7 +51,14 @@ func main() {
 	fs := utils.NewFileSystem()
 	svcMgr := service.NewServiceManager()
 
+	// Attempt each operational mode in dispatch order. The first whose context
+	// constructor succeeds wins. Each mode's validation error is retained so a
+	// failed invocation can surface the specific reason for the mode the
+	// operator most likely intended (see reportUsage).
+	modeErrs := map[string]error{}
+
 	diagnosticCtx, err := newDiagnosticContext(os.Args[1:], sys, domain, svcMgr, fs)
+	modeErrs["diagnostic"] = err
 	if err == nil {
 		// Run diagnostic routine
 		runDiagnostic(diagnosticCtx)
@@ -59,6 +66,7 @@ func main() {
 	}
 
 	uninstallContext, err := newUninstallContext(os.Args[1:], svcMgr, fs)
+	modeErrs["uninstall"] = err
 	if err == nil {
 		// Run uninstall routine
 		runUninstall(uninstallContext)
@@ -66,6 +74,7 @@ func main() {
 	}
 
 	configContext, err := newConfigContext(os.Args[1:], sys, domain, fs, svcMgr)
+	modeErrs["config"] = err
 	if err == nil {
 		// Run config routine
 		if err := runConfig(configContext); err != nil {
@@ -76,6 +85,7 @@ func main() {
 	}
 
 	serviceContext, err := newServiceContext(os.Args[1:], sys, domain, executor)
+	modeErrs["service"] = err
 	if err == nil {
 		// Run service routine
 		runService(serviceContext)
@@ -83,28 +93,14 @@ func main() {
 	}
 
 	updateContext, err := newUpdateContext(os.Args[1:], sys, domain, svcMgr, fs)
+	modeErrs["update"] = err
 	if err == nil {
 		// Run update routine
 		runUpdate(updateContext)
 		return
 	}
 
-	// Show usage
-	loggingLevelsList := getAllowedConfigLevelsString("|")
-	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2] [--service-username <USER>] [--service-password <PASS>]",
-		loggingLevelsList,
-	)
-	usages := []string{
-		"--diagnostic",
-		"--uninstall",
-		fmt.Sprintf(
-			"--config-url <CONFIG URL> --config-secret <CONFIG SECRET> %s",
-			configFlagsList,
-		),
-		"--config-file <CONFIG FILE> --log-file <LOG FILE>",
-		fmt.Sprintf("--update %s", configFlagsList),
-	}
-	fmt.Printf("Usage: --org-id <ORG_ID> {%s}\n", strings.Join(usages, " | "))
-	os.Exit(1)
+	// No mode matched: surface help, the relevant mode's validation error, or
+	// the full multi-mode usage as appropriate.
+	os.Exit(reportUsage(os.Args[1:], modeErrs, os.Stdout, os.Stderr))
 }

--- a/cmd/agent_smith/service_context.go
+++ b/cmd/agent_smith/service_context.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -30,6 +30,18 @@ type serviceContext struct {
 	PostbackBaseRetryBackoff time.Duration
 }
 
+// newServiceFlagSet builds the flag set for service mode, binding flags to the
+// provided params. It is shared between argument parsing and usage rendering so
+// that the per-flag descriptions stay in a single place.
+func newServiceFlagSet(params *serviceContext) *flag.FlagSet {
+	fs := flag.NewFlagSet("service", flag.ContinueOnError)
+	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
+	fs.StringVar(&params.ConfigFile, "config-file", "", "Configuration File")
+	fs.StringVar(&params.LogFile, "log-file", "", "Log file")
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
 func newServiceContext(
 	args []string,
 	sys agent.SystemInfoProvider,
@@ -38,11 +50,7 @@ func newServiceContext(
 ) (*serviceContext, error) {
 	var params serviceContext
 
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
-	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
-	fs.StringVar(&params.ConfigFile, "config-file", "", "Configuration File")
-	fs.StringVar(&params.LogFile, "log-file", "", "Log file")
-	fs.SetOutput(bytes.NewBuffer([]byte{}))
+	fs := newServiceFlagSet(&params)
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cmd/agent_smith/uninstall_context.go
+++ b/cmd/agent_smith/uninstall_context.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
+	"io"
 
 	"github.com/RewstApp/agent-smith-go/internal/service"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -17,6 +17,17 @@ type uninstallContext struct {
 	FS             utils.FileSystem
 }
 
+// newUninstallFlagSet builds the flag set for uninstall mode, binding flags to
+// the provided params. It is shared between argument parsing and usage
+// rendering so that the per-flag descriptions stay in a single place.
+func newUninstallFlagSet(params *uninstallContext) *flag.FlagSet {
+	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
+	fs.BoolVar(&params.Uninstall, "uninstall", false, "Uninstall the agent")
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
 func newUninstallContext(
 	args []string,
 	svcMgr service.ServiceManager,
@@ -24,10 +35,7 @@ func newUninstallContext(
 ) (*uninstallContext, error) {
 	var params uninstallContext
 
-	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
-	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
-	fs.BoolVar(&params.Uninstall, "uninstall", false, "Uninstall the agent")
-	fs.SetOutput(bytes.NewBuffer([]byte{}))
+	fs := newUninstallFlagSet(&params)
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
+	"io"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
@@ -29,16 +29,11 @@ type updateContext struct {
 	FS             utils.FileSystem
 }
 
-func newUpdateContext(
-	args []string,
-	sys agent.SystemInfoProvider,
-	domain agent.DomainInfoProvider,
-	svcMgr service.ServiceManager,
-	fsys utils.FileSystem,
-) (*updateContext, error) {
-	var params updateContext
-
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+// newUpdateFlagSet builds the flag set for update mode, binding flags to the
+// provided params. It is shared between argument parsing and usage rendering so
+// that the per-flag descriptions stay in a single place.
+func newUpdateFlagSet(params *updateContext) *flag.FlagSet {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
 	fs.StringVar(&params.OrgId, "org-id", "", "Organization ID")
 	fs.BoolVar(&params.Update, "update", false, "Update the agent")
 	fs.StringVar(
@@ -69,7 +64,20 @@ func newUpdateContext(
 		"",
 		"Password for --service-username (Windows only; not persisted to disk)",
 	)
-	fs.SetOutput(bytes.NewBuffer([]byte{}))
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+func newUpdateContext(
+	args []string,
+	sys agent.SystemInfoProvider,
+	domain agent.DomainInfoProvider,
+	svcMgr service.ServiceManager,
+	fsys utils.FileSystem,
+) (*updateContext, error) {
+	var params updateContext
+
+	fs := newUpdateFlagSet(&params)
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -1,11 +1,28 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
+
+// flagHeaderPrefix matches the single-dash flag header that flag.PrintDefaults
+// emits at the start of each flag line (two spaces followed by one dash). The
+// agent documents flags with a double dash everywhere else, so the rendered
+// flag list is rewritten to match (e.g. "-diagnostic" -> "--diagnostic").
+var flagHeaderPrefix = regexp.MustCompile(`(?m)^  -`)
+
+// printFlagDefaults renders a flag set's per-flag descriptions using the
+// double-dash form so the help output matches how the flags are invoked.
+func printFlagDefaults(w io.Writer, fs *flag.FlagSet) {
+	var buf bytes.Buffer
+	fs.SetOutput(&buf)
+	fs.PrintDefaults()
+	w.Write(flagHeaderPrefix.ReplaceAll(buf.Bytes(), []byte("  --")))
+}
 
 // operationalMode describes a single command-line mode for the purposes of
 // argument detection and usage rendering. The modes are listed in the same
@@ -120,9 +137,7 @@ func detectMode(args []string) (operationalMode, bool) {
 // single mode.
 func printModeUsage(w io.Writer, mode operationalMode) {
 	fmt.Fprintf(w, "Usage (%s mode):\n  rewst_agent_config %s\n\nFlags:\n", mode.name, mode.summary)
-	fs := mode.flagSet()
-	fs.SetOutput(w)
-	fs.PrintDefaults()
+	printFlagDefaults(w, mode.flagSet())
 }
 
 // printFullUsage writes the one-line summary followed by per-flag descriptions
@@ -138,9 +153,7 @@ func printFullUsage(w io.Writer) {
 
 	for _, mode := range modes {
 		fmt.Fprintf(w, "\n%s mode:\n", capitalize(mode.name))
-		fs := mode.flagSet()
-		fs.SetOutput(w)
-		fs.PrintDefaults()
+		printFlagDefaults(w, mode.flagSet())
 	}
 }
 

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// operationalMode describes a single command-line mode for the purposes of
+// argument detection and usage rendering. The modes are listed in the same
+// order main attempts their context constructors.
+type operationalMode struct {
+	// name is the human-readable mode name (e.g. "config").
+	name string
+	// selector is the primary flag (without leading dashes) that signals the
+	// operator's intent to use this mode (e.g. "config-url").
+	selector string
+	// summary is the one-line invocation fragment shown in the usage summary.
+	summary string
+	// flagSet returns a fresh flag set whose flags carry this mode's per-flag
+	// usage descriptions. The bound params are discarded; only the flag
+	// definitions are used for rendering.
+	flagSet func() *flag.FlagSet
+}
+
+// operationalModes lists every mode in dispatch order. The summaries mirror the
+// historical one-line usage string so existing behavior is preserved.
+func operationalModes() []operationalMode {
+	configFlagsList := fmt.Sprintf(
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2] [--service-username <USER>] [--service-password <PASS>]",
+		getAllowedConfigLevelsString("|"),
+	)
+
+	return []operationalMode{
+		{
+			name:     "diagnostic",
+			selector: "diagnostic",
+			summary:  "--org-id <ORG_ID> --diagnostic",
+			flagSet:  func() *flag.FlagSet { return newDiagnosticFlagSet(&diagnosticContext{}) },
+		},
+		{
+			name:     "uninstall",
+			selector: "uninstall",
+			summary:  "--org-id <ORG_ID> --uninstall",
+			flagSet:  func() *flag.FlagSet { return newUninstallFlagSet(&uninstallContext{}) },
+		},
+		{
+			name:     "config",
+			selector: "config-url",
+			summary: fmt.Sprintf(
+				"--org-id <ORG_ID> --config-url <CONFIG URL> --config-secret <CONFIG SECRET> %s",
+				configFlagsList,
+			),
+			flagSet: func() *flag.FlagSet { return newConfigFlagSet(&configContext{}) },
+		},
+		{
+			name:     "service",
+			selector: "config-file",
+			summary:  "--org-id <ORG_ID> --config-file <CONFIG FILE> --log-file <LOG FILE>",
+			flagSet:  func() *flag.FlagSet { return newServiceFlagSet(&serviceContext{}) },
+		},
+		{
+			name:     "update",
+			selector: "update",
+			summary:  fmt.Sprintf("--org-id <ORG_ID> --update %s", configFlagsList),
+			flagSet:  func() *flag.FlagSet { return newUpdateFlagSet(&updateContext{}) },
+		},
+	}
+}
+
+// flagNameFromArg extracts the flag name from a single command-line token,
+// stripping leading dashes and any "=value" suffix. It returns ("", false) for
+// tokens that are not flags (e.g. positional arguments or a bare "-").
+func flagNameFromArg(arg string) (string, bool) {
+	if len(arg) < 2 || arg[0] != '-' {
+		return "", false
+	}
+
+	name := strings.TrimLeft(arg, "-")
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		name = name[:eq]
+	}
+
+	if name == "" {
+		return "", false
+	}
+
+	return name, true
+}
+
+// hasFlag reports whether the given flag name appears anywhere in args.
+func hasFlag(args []string, name string) bool {
+	for _, arg := range args {
+		if flagName, ok := flagNameFromArg(arg); ok && flagName == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasHelpFlag reports whether the operator requested help via --help or -h.
+func hasHelpFlag(args []string) bool {
+	return hasFlag(args, "help") || hasFlag(args, "h")
+}
+
+// detectMode returns the operational mode whose primary selector flag is
+// present in args. Modes are checked in dispatch order, so the first matching
+// selector wins. The boolean is false when no selector is present.
+func detectMode(args []string) (operationalMode, bool) {
+	for _, mode := range operationalModes() {
+		if hasFlag(args, mode.selector) {
+			return mode, true
+		}
+	}
+	return operationalMode{}, false
+}
+
+// printModeUsage writes the invocation summary and per-flag descriptions for a
+// single mode.
+func printModeUsage(w io.Writer, mode operationalMode) {
+	fmt.Fprintf(w, "Usage (%s mode):\n  rewst_agent_config %s\n\nFlags:\n", mode.name, mode.summary)
+	fs := mode.flagSet()
+	fs.SetOutput(w)
+	fs.PrintDefaults()
+}
+
+// printFullUsage writes the one-line summary followed by per-flag descriptions
+// for every mode.
+func printFullUsage(w io.Writer) {
+	modes := operationalModes()
+
+	summaries := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		summaries = append(summaries, mode.summary)
+	}
+	fmt.Fprintf(w, "Usage: rewst_agent_config {%s}\n", strings.Join(summaries, " | "))
+
+	for _, mode := range modes {
+		fmt.Fprintf(w, "\n%s mode:\n", capitalize(mode.name))
+		fs := mode.flagSet()
+		fs.SetOutput(w)
+		fs.PrintDefaults()
+	}
+}
+
+// capitalize upper-cases the first letter of a mode name for section headings.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// reportUsage renders the appropriate usage/help output for an invocation that
+// did not match any mode and returns the process exit code.
+//
+//   - --help/-h prints the full multi-mode usage to stdout and exits 0.
+//   - When a mode selector is present, the specific validation error for that
+//     mode is printed to stderr followed by that mode's usage; exit code 1.
+//   - When no selector is present, the full usage plus a hint to run --help is
+//     printed to stderr; exit code 1.
+//
+// modeErrs maps each mode name to the error its context constructor returned.
+func reportUsage(args []string, modeErrs map[string]error, stdout, stderr io.Writer) int {
+	if hasHelpFlag(args) {
+		printFullUsage(stdout)
+		return 0
+	}
+
+	if mode, ok := detectMode(args); ok {
+		if err := modeErrs[mode.name]; err != nil {
+			fmt.Fprintf(stderr, "error: %v\n\n", err)
+		}
+		printModeUsage(stderr, mode)
+		return 1
+	}
+
+	printFullUsage(stderr)
+	fmt.Fprintln(stderr, "\nRun with --help for detailed usage.")
+	return 1
+}

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -15,13 +15,13 @@ import (
 // flag list is rewritten to match (e.g. "-diagnostic" -> "--diagnostic").
 var flagHeaderPrefix = regexp.MustCompile(`(?m)^  -`)
 
-// printFlagDefaults renders a flag set's per-flag descriptions using the
+// renderFlagDefaults returns a flag set's per-flag descriptions using the
 // double-dash form so the help output matches how the flags are invoked.
-func printFlagDefaults(w io.Writer, fs *flag.FlagSet) {
+func renderFlagDefaults(fs *flag.FlagSet) string {
 	var buf bytes.Buffer
 	fs.SetOutput(&buf)
 	fs.PrintDefaults()
-	w.Write(flagHeaderPrefix.ReplaceAll(buf.Bytes(), []byte("  --")))
+	return string(flagHeaderPrefix.ReplaceAll(buf.Bytes(), []byte("  --")))
 }
 
 // operationalMode describes a single command-line mode for the purposes of
@@ -133,27 +133,40 @@ func detectMode(args []string) (operationalMode, bool) {
 	return operationalMode{}, false
 }
 
-// printModeUsage writes the invocation summary and per-flag descriptions for a
+// modeUsage returns the invocation summary and per-flag descriptions for a
 // single mode.
-func printModeUsage(w io.Writer, mode operationalMode) {
-	fmt.Fprintf(w, "Usage (%s mode):\n  rewst_agent_config %s\n\nFlags:\n", mode.name, mode.summary)
-	printFlagDefaults(w, mode.flagSet())
+func modeUsage(mode operationalMode) string {
+	var b strings.Builder
+	b.WriteString("Usage (")
+	b.WriteString(mode.name)
+	b.WriteString(" mode):\n  rewst_agent_config ")
+	b.WriteString(mode.summary)
+	b.WriteString("\n\nFlags:\n")
+	b.WriteString(renderFlagDefaults(mode.flagSet()))
+	return b.String()
 }
 
-// printFullUsage writes the multi-line invocation summary followed by per-flag
+// fullUsage returns the multi-line invocation summary followed by per-flag
 // descriptions for every mode.
-func printFullUsage(w io.Writer) {
+func fullUsage() string {
 	modes := operationalModes()
 
-	fmt.Fprintln(w, "Usage:")
+	var b strings.Builder
+	b.WriteString("Usage:\n")
 	for _, mode := range modes {
-		fmt.Fprintf(w, "  rewst_agent_config %s\n", mode.summary)
+		b.WriteString("  rewst_agent_config ")
+		b.WriteString(mode.summary)
+		b.WriteString("\n")
 	}
 
 	for _, mode := range modes {
-		fmt.Fprintf(w, "\n%s mode:\n", capitalize(mode.name))
-		printFlagDefaults(w, mode.flagSet())
+		b.WriteString("\n")
+		b.WriteString(capitalize(mode.name))
+		b.WriteString(" mode:\n")
+		b.WriteString(renderFlagDefaults(mode.flagSet()))
 	}
+
+	return b.String()
 }
 
 // capitalize upper-cases the first letter of a mode name for section headings.
@@ -176,19 +189,22 @@ func capitalize(s string) string {
 // modeErrs maps each mode name to the error its context constructor returned.
 func reportUsage(args []string, modeErrs map[string]error, stdout, stderr io.Writer) int {
 	if hasHelpFlag(args) {
-		printFullUsage(stdout)
+		_, _ = io.WriteString(stdout, fullUsage())
 		return 0
 	}
 
 	if mode, ok := detectMode(args); ok {
+		var b strings.Builder
 		if err := modeErrs[mode.name]; err != nil {
-			fmt.Fprintf(stderr, "error: %v\n\n", err)
+			b.WriteString("error: ")
+			b.WriteString(err.Error())
+			b.WriteString("\n\n")
 		}
-		printModeUsage(stderr, mode)
+		b.WriteString(modeUsage(mode))
+		_, _ = io.WriteString(stderr, b.String())
 		return 1
 	}
 
-	printFullUsage(stderr)
-	fmt.Fprintln(stderr, "\nRun with --help for detailed usage.")
+	_, _ = io.WriteString(stderr, fullUsage()+"\nRun with --help for detailed usage.\n")
 	return 1
 }

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -140,16 +140,15 @@ func printModeUsage(w io.Writer, mode operationalMode) {
 	printFlagDefaults(w, mode.flagSet())
 }
 
-// printFullUsage writes the one-line summary followed by per-flag descriptions
-// for every mode.
+// printFullUsage writes the multi-line invocation summary followed by per-flag
+// descriptions for every mode.
 func printFullUsage(w io.Writer) {
 	modes := operationalModes()
 
-	summaries := make([]string, 0, len(modes))
+	fmt.Fprintln(w, "Usage:")
 	for _, mode := range modes {
-		summaries = append(summaries, mode.summary)
+		fmt.Fprintf(w, "  rewst_agent_config %s\n", mode.summary)
 	}
-	fmt.Fprintf(w, "Usage: rewst_agent_config {%s}\n", strings.Join(summaries, " | "))
 
 	for _, mode := range modes {
 		fmt.Fprintf(w, "\n%s mode:\n", capitalize(mode.name))

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -129,15 +130,21 @@ func TestReportUsageHelp(t *testing.T) {
 				"Config mode:",
 				"Service mode:",
 				"Update mode:",
-				"-config-url",
-				"-config-file",
-				"-mqtt-qos",
-				"-logging-level",
+				"--config-url",
+				"--config-file",
+				"--mqtt-qos",
+				"--logging-level",
 				"Organization ID",
 			} {
 				if !strings.Contains(out, want) {
 					t.Errorf("expected help output to contain %q, got:\n%s", want, out)
 				}
+			}
+
+			// Flag headers must use the double-dash form to match how flags are
+			// invoked; no header should start with a single dash.
+			if singleDashHeader := regexp.MustCompile(`(?m)^  -[a-z]`); singleDashHeader.MatchString(out) {
+				t.Errorf("expected flag headers to use --, found single-dash header in:\n%s", out)
 			}
 
 			if stderr.Len() != 0 {

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -143,7 +143,8 @@ func TestReportUsageHelp(t *testing.T) {
 
 			// Flag headers must use the double-dash form to match how flags are
 			// invoked; no header should start with a single dash.
-			if singleDashHeader := regexp.MustCompile(`(?m)^  -[a-z]`); singleDashHeader.MatchString(out) {
+			singleDashHeader := regexp.MustCompile(`(?m)^  -[a-z]`)
+			if singleDashHeader.MatchString(out) {
 				t.Errorf("expected flag headers to use --, found single-dash header in:\n%s", out)
 			}
 
@@ -190,14 +191,32 @@ func TestReportUsageModeErrors(t *testing.T) {
 			wantErr: "missing config-secret",
 		},
 		{
-			name:    "config invalid mqtt-qos",
-			args:    []string{"--org-id", "x", "--config-url", "https://x", "--config-secret", "s", "--mqtt-qos", "5"},
+			name: "config invalid mqtt-qos",
+			args: []string{
+				"--org-id",
+				"x",
+				"--config-url",
+				"https://x",
+				"--config-secret",
+				"s",
+				"--mqtt-qos",
+				"5",
+			},
 			mode:    "config",
 			wantErr: "invalid mqtt-qos: must be 0, 1, or 2",
 		},
 		{
-			name:    "config invalid logging-level",
-			args:    []string{"--org-id", "x", "--config-url", "https://x", "--config-secret", "s", "--logging-level", "bogus"},
+			name: "config invalid logging-level",
+			args: []string{
+				"--org-id",
+				"x",
+				"--config-url",
+				"https://x",
+				"--config-secret",
+				"s",
+				"--logging-level",
+				"bogus",
+			},
 			mode:    "config",
 			wantErr: "invalid logging-level",
 		},

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildModeErrs runs every mode's context constructor against args and returns
+// the resulting error map, mirroring how main collects them. Providers are nil
+// because the failure paths under test never reach provider usage.
+func buildModeErrs(args []string) map[string]error {
+	modeErrs := map[string]error{}
+
+	_, err := newDiagnosticContext(args, nil, nil, nil, nil)
+	modeErrs["diagnostic"] = err
+
+	_, err = newUninstallContext(args, nil, nil)
+	modeErrs["uninstall"] = err
+
+	_, err = newConfigContext(args, nil, nil, nil, nil)
+	modeErrs["config"] = err
+
+	_, err = newServiceContext(args, nil, nil, nil)
+	modeErrs["service"] = err
+
+	_, err = newUpdateContext(args, nil, nil, nil, nil)
+	modeErrs["update"] = err
+
+	return modeErrs
+}
+
+func TestFlagNameFromArg(t *testing.T) {
+	tests := []struct {
+		arg    string
+		want   string
+		wantOk bool
+	}{
+		{"--config-url", "config-url", true},
+		{"-h", "h", true},
+		{"--mqtt-qos=2", "mqtt-qos", true},
+		{"--help", "help", true},
+		{"positional", "", false},
+		{"-", "", false},
+		{"--", "", false},
+		{"", "", false},
+	}
+
+	for _, test := range tests {
+		got, ok := flagNameFromArg(test.arg)
+		if got != test.want || ok != test.wantOk {
+			t.Errorf("flagNameFromArg(%q) = (%q, %v), want (%q, %v)",
+				test.arg, got, ok, test.want, test.wantOk)
+		}
+	}
+}
+
+func TestDetectMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantMode string
+		wantOk   bool
+	}{
+		{"diagnostic", []string{"--diagnostic"}, "diagnostic", true},
+		{"uninstall", []string{"--org-id", "x", "--uninstall"}, "uninstall", true},
+		{"config", []string{"--config-url", "https://x"}, "config", true},
+		{"service", []string{"--config-file", "/etc/x"}, "service", true},
+		{"update", []string{"--update"}, "update", true},
+		{"qos value form", []string{"--config-url=https://x"}, "config", true},
+		{"no selector", []string{"--org-id", "x"}, "", false},
+		{"empty", []string{}, "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mode, ok := detectMode(test.args)
+			if ok != test.wantOk {
+				t.Fatalf("detectMode(%v) ok = %v, want %v", test.args, ok, test.wantOk)
+			}
+			if ok && mode.name != test.wantMode {
+				t.Errorf("detectMode(%v) mode = %q, want %q", test.args, mode.name, test.wantMode)
+			}
+		})
+	}
+}
+
+func TestHasHelpFlag(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"--help"}, true},
+		{[]string{"-h"}, true},
+		{[]string{"--config-url", "x", "--help"}, true},
+		{[]string{"--diagnostic"}, false},
+		{[]string{}, false},
+	}
+
+	for _, test := range tests {
+		if got := hasHelpFlag(test.args); got != test.want {
+			t.Errorf("hasHelpFlag(%v) = %v, want %v", test.args, got, test.want)
+		}
+	}
+}
+
+func TestReportUsageHelp(t *testing.T) {
+	for _, flag := range []string{"--help", "-h"} {
+		t.Run(flag, func(t *testing.T) {
+			args := []string{flag}
+			var stdout, stderr bytes.Buffer
+
+			code := reportUsage(args, buildModeErrs(args), &stdout, &stderr)
+
+			if code != 0 {
+				t.Errorf("expected exit code 0 for %s, got %d", flag, code)
+			}
+
+			out := stdout.String()
+			if !strings.Contains(out, "Usage:") {
+				t.Errorf("expected usage summary in help output, got:\n%s", out)
+			}
+
+			// The full help must include per-flag descriptions for every mode.
+			for _, want := range []string{
+				"Diagnostic mode:",
+				"Uninstall mode:",
+				"Config mode:",
+				"Service mode:",
+				"Update mode:",
+				"-config-url",
+				"-config-file",
+				"-mqtt-qos",
+				"-logging-level",
+				"Organization ID",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected help output to contain %q, got:\n%s", want, out)
+				}
+			}
+
+			if stderr.Len() != 0 {
+				t.Errorf("expected nothing on stderr for help, got:\n%s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestReportUsageNoArgs(t *testing.T) {
+	args := []string{}
+	var stdout, stderr bytes.Buffer
+
+	code := reportUsage(args, buildModeErrs(args), &stdout, &stderr)
+
+	if code != 1 {
+		t.Errorf("expected exit code 1 for no args, got %d", code)
+	}
+
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "Usage:") {
+		t.Errorf("expected full usage on stderr, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "--help") {
+		t.Errorf("expected hint to run --help on stderr, got:\n%s", errOut)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected nothing on stdout for no-args path, got:\n%s", stdout.String())
+	}
+}
+
+func TestReportUsageModeErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		mode    string
+		wantErr string
+	}{
+		{
+			name:    "config missing secret",
+			args:    []string{"--org-id", "x", "--config-url", "https://x"},
+			mode:    "config",
+			wantErr: "missing config-secret",
+		},
+		{
+			name:    "config invalid mqtt-qos",
+			args:    []string{"--org-id", "x", "--config-url", "https://x", "--config-secret", "s", "--mqtt-qos", "5"},
+			mode:    "config",
+			wantErr: "invalid mqtt-qos: must be 0, 1, or 2",
+		},
+		{
+			name:    "config invalid logging-level",
+			args:    []string{"--org-id", "x", "--config-url", "https://x", "--config-secret", "s", "--logging-level", "bogus"},
+			mode:    "config",
+			wantErr: "invalid logging-level",
+		},
+		{
+			name:    "service missing log-file",
+			args:    []string{"--org-id", "x", "--config-file", "/etc/x"},
+			mode:    "service",
+			wantErr: "missing log-file",
+		},
+		{
+			name:    "update invalid mqtt-qos",
+			args:    []string{"--org-id", "x", "--update", "--mqtt-qos", "5"},
+			mode:    "update",
+			wantErr: "invalid mqtt-qos: must be 0, 1, or 2",
+		},
+		{
+			name:    "update missing org-id",
+			args:    []string{"--update"},
+			mode:    "update",
+			wantErr: "missing org-id",
+		},
+		{
+			name:    "uninstall missing org-id",
+			args:    []string{"--uninstall"},
+			mode:    "uninstall",
+			wantErr: "missing org-id",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			code := reportUsage(test.args, buildModeErrs(test.args), &stdout, &stderr)
+
+			if code != 1 {
+				t.Errorf("expected exit code 1, got %d", code)
+			}
+
+			errOut := stderr.String()
+			if !strings.Contains(errOut, test.wantErr) {
+				t.Errorf("expected error %q on stderr, got:\n%s", test.wantErr, errOut)
+			}
+
+			// The relevant mode's usage block must follow the error.
+			wantUsage := fmt.Sprintf("Usage (%s mode):", test.mode)
+			if !strings.Contains(errOut, wantUsage) {
+				t.Errorf("expected %q on stderr, got:\n%s", wantUsage, errOut)
+			}
+
+			if stdout.Len() != 0 {
+				t.Errorf("expected nothing on stdout for error path, got:\n%s", stdout.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When the agent was run with missing or invalid command-line arguments, it printed a single terse one-line usage and exited 1, silently discarding the specific validation error each mode's context constructor produced. There was also no `--help`/`-h` flag.

This PR makes the failure path actionable:

- **Detects the operator's intended mode** from its primary selector flag (`--diagnostic`, `--uninstall`, `--config-url`, `--config-file`, `--update`) and reports that mode's specific validation error (e.g. `error: invalid mqtt-qos: must be 0, 1, or 2`, `missing config-secret`) plus that mode's per-flag usage, then exits non-zero.
- **Adds `--help` / `-h`** which prints the full multi-mode usage with per-flag descriptions and exits 0.
- **No selector present** → prints the full usage plus a hint to run `--help`, exits non-zero.
- **Flag headers render with `--`** (e.g. `--diagnostic`) to match how flags are actually invoked, instead of the single-dash form `flag.PrintDefaults` emits.
- **Usage summary is multi-line**, one invocation per line, instead of one long brace-delimited line.

Each mode's flag definitions were extracted into a shared `new*FlagSet` builder so argument parsing and usage rendering reuse the same per-flag descriptions. Valid invocations for every mode behave exactly as before.

## Testing

- `go test ./...` passes; new `usage_test.go` covers help output (both flags), the no-args path, flag/mode detection, the double-dash rendering guard, and missing-flag + invalid-value paths across config, service, update, and uninstall modes.
- `gofmt` and `go vet` clean.

### Manual verification
- `rewst_agent_config --help` / `-h` → full per-mode usage, exit 0
- `rewst_agent_config` (no args) → full usage + "Run with --help" hint, exit 1
- `rewst_agent_config --org-id x --config-url https://x` → `error: missing config-secret` + config usage, exit 1
- `rewst_agent_config --org-id x --config-url https://x --config-secret s --mqtt-qos 5` → `error: invalid mqtt-qos: must be 0, 1, or 2`, exit 1

## QA Testing Steps
1. `rewst_agent_config --help` (and `-h`) → full per-mode usage, exit 0.
2. `rewst_agent_config` (no args) → full usage + hint to run `--help`, exit 1.
3. `rewst_agent_config --org-id x --config-url https://x` → names missing `config-secret` + config usage, exit 1.
4. `rewst_agent_config --org-id x --config-url https://x --config-secret s --mqtt-qos 5` → `invalid mqtt-qos: must be 0, 1, or 2`, exit 1.
5. `rewst_agent_config --org-id x --update --logging-level bogus` → `invalid logging-level`, exit 1.
6. A valid invocation for each mode → unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)