### PR TITLE
fix: [sc-97774] Cache shell version and whoami diagnostics per process

### DIFF
--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -27,6 +28,55 @@ type baseExecutor struct {
 	BuildExecuteCommandArgs  BuildExecuteCommandArgsFunc
 	BuildExecuteFileArgs     BuildExecuteFileArgsFunc
 	FS                       utils.FileSystem
+
+	// Diagnostic values (shell version and the service account reported by
+	// whoami) are static for the lifetime of an agent process: the shell binary
+	// and the account it runs as do not change between commands. They are
+	// therefore computed at most once via diagOnce and reused on every
+	// subsequent command instead of spawning two extra subprocesses per
+	// command. diagOnce makes the computation safe under the concurrent worker
+	// pool, and the cached fields are only read after Do returns (so the
+	// once-guaranteed happens-before relationship protects them from races).
+	diagOnce      sync.Once
+	cachedVersion string
+	cachedWhoami  string
+}
+
+// diagnostics returns the shell version and current-user strings used for debug
+// logging, computing them via two subprocesses the first time it is called and
+// returning the memoized values thereafter. It is only invoked when debug
+// logging is enabled, so info-level operation never spawns these subprocesses.
+func (e *baseExecutor) diagnostics(ctx context.Context, logger hclog.Logger) (string, string) {
+	e.diagOnce.Do(func() {
+		// #nosec G204
+		versionCmd := exec.CommandContext(
+			ctx,
+			e.Shell,
+			e.BuildExecuteCommandArgs(e.ShellVersionCheckCommand)...)
+		versionOutputBytes, err := versionCmd.CombinedOutput()
+		versionOutput := string(versionOutputBytes)
+		if err != nil {
+			logger.Error(
+				"Shell version check failed",
+				"error",
+				err,
+				"combined_output",
+				versionOutput,
+			)
+		}
+		e.cachedVersion = strings.TrimSpace(versionOutput)
+
+		// #nosec G204
+		whoamiCmd := exec.CommandContext(ctx, e.Shell, e.BuildExecuteCommandArgs("whoami")...)
+		whoamiOutputBytes, err := whoamiCmd.CombinedOutput()
+		whoamiOutput := string(whoamiOutputBytes)
+		if err != nil {
+			logger.Error("Whoami check failed", "error", err, "combined_output", whoamiOutput)
+		}
+		e.cachedWhoami = whoamiOutput
+	})
+
+	return e.cachedVersion, e.cachedWhoami
 }
 
 // SECURITY: Agent Smith is a command execution agent. The shell executable is configured
@@ -53,41 +103,15 @@ func (e *baseExecutor) Execute(
 		return errorResultBytes(logger, err)
 	}
 
-	// Run the command in the system using powershell
+	// Log diagnostics in debug mode. The shell version and whoami values are
+	// computed once per agent process and reused; only the per-command output
+	// (the commands themselves) varies between calls.
 	if logger.IsDebug() {
-		// #nosec G204
-		cmd := exec.CommandContext(
-			ctx,
-			e.Shell,
-			e.BuildExecuteCommandArgs(e.ShellVersionCheckCommand)...)
-		combinedOutputBytes, err := cmd.CombinedOutput()
-		combinedOutput := string(combinedOutputBytes)
-		if err != nil {
-			logger.Error(
-				"Shell version check failed",
-				"error",
-				err,
-				"combined_output",
-				combinedOutput,
-			)
-		}
-
-		version := strings.TrimSpace(combinedOutput)
+		version, user := e.diagnostics(ctx, logger)
 
 		logger.Debug("Shell version", "shell", e.Shell, "version", version)
 		logger.Debug("Commands to execute", "commands", commands)
-	}
-
-	if logger.IsDebug() {
-		// #nosec G204
-		cmd := exec.CommandContext(ctx, e.Shell, e.BuildExecuteCommandArgs("whoami")...)
-		combinedOutputBytes, err := cmd.CombinedOutput()
-		combinedOutput := string(combinedOutputBytes)
-		if err != nil {
-			logger.Error("Whoami check failed", "error", err, "combined_output", combinedOutput)
-		}
-
-		logger.Debug("Whoami", "user", combinedOutput)
+		logger.Debug("Whoami", "user", user)
 	}
 
 	// Save commands to temporary file

--- a/internal/interpreter/base_executor_unix_test.go
+++ b/internal/interpreter/base_executor_unix_test.go
@@ -108,6 +108,9 @@ func TestBaseExecutor_Diagnostics_ConcurrentCachedOnce(t *testing.T) {
 	wg.Wait()
 
 	if runs := countSubprocessRuns(t, counterFile); runs != 1 {
-		t.Errorf("expected version-check subprocess to run once under concurrency, ran %d times", runs)
+		t.Errorf(
+			"expected version-check subprocess to run once under concurrency, ran %d times",
+			runs,
+		)
 	}
 }

--- a/internal/interpreter/base_executor_unix_test.go
+++ b/internal/interpreter/base_executor_unix_test.go
@@ -1,0 +1,113 @@
+//go:build darwin || linux
+
+package interpreter
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
+)
+
+// newCountingExecutor returns a bash-backed executor whose shell-version check
+// appends a byte to counterFile each time it actually runs as a subprocess.
+// Counting the version check is sufficient to prove how many times the cached
+// diagnostics were computed, because the version check and whoami share a single
+// sync.Once. The real script execution writes the user commands to a temp file
+// and never touches counterFile, so it does not interfere with the count.
+func newCountingExecutor(counterFile string) *baseExecutor {
+	return &baseExecutor{
+		Shell:                    "bash",
+		ShellVersionCheckCommand: "printf x >> " + counterFile + "; echo 1.0",
+		WriteUtf8BOM:             false,
+		BuildExecuteCommandArgs:  func(command string) []string { return []string{"-c", command} },
+		BuildExecuteFileArgs:     func(path string) []string { return []string{path} },
+		FS:                       utils.NewFileSystem(),
+	}
+}
+
+func countSubprocessRuns(t *testing.T, counterFile string) int {
+	t.Helper()
+	data, err := os.ReadFile(counterFile)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("failed to read counter file: %v", err)
+	}
+	return len(data)
+}
+
+func TestBaseExecutor_Diagnostics_CachedAcrossCommands(t *testing.T) {
+	counterFile := filepath.Join(t.TempDir(), "version-runs")
+	executor := newCountingExecutor(counterFile)
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Debug})
+	device := agent.Device{RewstOrgId: "test-org-cache"}
+
+	const commandCount = 3
+	for i := 0; i < commandCount; i++ {
+		msg := Message{PostId: "test:cache", Commands: encodeCommand("echo hello")}
+		executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+	}
+
+	if runs := countSubprocessRuns(t, counterFile); runs != 1 {
+		t.Errorf("expected version-check subprocess to run once, ran %d times", runs)
+	}
+
+	logs := strings.ToLower(buf.String())
+	// Each command still logs the (cached) diagnostics, so debug output is unchanged.
+	if got := strings.Count(logs, "[debug] shell version"); got != commandCount {
+		t.Errorf("expected %d shell version log lines, got %d", commandCount, got)
+	}
+	if got := strings.Count(logs, "[debug] whoami"); got != commandCount {
+		t.Errorf("expected %d whoami log lines, got %d", commandCount, got)
+	}
+}
+
+func TestBaseExecutor_Diagnostics_DisabledAtInfoLevel(t *testing.T) {
+	counterFile := filepath.Join(t.TempDir(), "version-runs")
+	executor := newCountingExecutor(counterFile)
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Info})
+	device := agent.Device{RewstOrgId: "test-org-info"}
+
+	msg := Message{PostId: "test:info", Commands: encodeCommand("echo hello")}
+	executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	if runs := countSubprocessRuns(t, counterFile); runs != 0 {
+		t.Errorf("expected no diagnostic subprocess at info level, ran %d times", runs)
+	}
+}
+
+func TestBaseExecutor_Diagnostics_ConcurrentCachedOnce(t *testing.T) {
+	counterFile := filepath.Join(t.TempDir(), "version-runs")
+	executor := newCountingExecutor(counterFile)
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Debug})
+	device := agent.Device{RewstOrgId: "test-org-concurrent"}
+
+	const workers = 10
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			msg := Message{PostId: "test:concurrent", Commands: encodeCommand("echo hello")}
+			executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+		}()
+	}
+	wg.Wait()
+
+	if runs := countSubprocessRuns(t, counterFile); runs != 1 {
+		t.Errorf("expected version-check subprocess to run once under concurrency, ran %d times", runs)
+	}
+}


### PR DESCRIPTION
## Summary

When the agent runs at debug logging level, `baseExecutor.Execute` spawned **two extra subprocesses per command** — a shell-version check and a `whoami` check — before running the actual command. On Windows these launch PowerShell, which is expensive (hundreds of ms each, plus profile loading), so a debug-mode agent did roughly 3× the process launches per command, adding latency and CPU/memory churn.

These values are static for the lifetime of an agent process (the shell binary and the service account don't change between commands), so they are now computed once and reused.

## Changes

- **`internal/interpreter/base_executor.go`**: Added `diagOnce sync.Once`, `cachedVersion`, and `cachedWhoami` fields to `baseExecutor`, plus a `diagnostics()` method that runs the two subprocesses inside `diagOnce.Do`. `Execute` now logs the cached values on every command. The per-command `"Commands to execute"` line stays dynamic; `"Shell version"` and `"Whoami"` are still logged per command from cache, so debug output content is unchanged.
- **`internal/interpreter/base_executor_unix_test.go`** (new): Coverage for the cached, info-level-disabled, and concurrent-worker-pool paths.

## Acceptance criteria

- ✅ In debug mode, diagnostic subprocesses execute at most once per agent process (`sync.Once`).
- ✅ Debug log output still contains shell version and current-user info.
- ✅ Info-level operation spawns no diagnostic subprocesses (unchanged).
- ✅ Concurrency-safe under the worker pool — `go test -race ./...` passes.
- ✅ Existing interpreter tests pass; coverage added for the cached/repeated/concurrent path.

## QA testing steps

1. Run an agent against a device config with `logging_level` set to `debug`.
2. Dispatch several commands and tail the log file — confirm `Shell version`, `Commands to execute`, and `Whoami` debug lines still appear for each command.
3. Observe process activity (e.g. Task Manager / `ps`): the shell-version and `whoami` subprocesses should fire only on the first command, not on every subsequent one.
4. Switch the device to `info` logging level, dispatch commands, and confirm no extra diagnostic subprocesses are launched.

## Test plan

- `go build ./...`
- `go test -race ./...` (all packages pass)
- `GOOS=windows go build ./...` + `go vet` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)