### PR TITLE
fix: [sc-97776] Use compact JSON for command result postbacks

### DIFF
--- a/internal/interpreter/result.go
+++ b/internal/interpreter/result.go
@@ -19,7 +19,7 @@ func errorResultBytes(logger hclog.Logger, err error) []byte {
 	r := &errorResult{
 		Error: err.Error(),
 	}
-	b, marshalErr := json.MarshalIndent(r, "", "  ")
+	b, marshalErr := json.Marshal(r)
 	if marshalErr != nil {
 		logger.Error("Failed to marshal error result", "error", marshalErr)
 		return []byte(`{"error":"failed to marshal error result"}`)
@@ -32,7 +32,7 @@ func resultBytes(logger hclog.Logger, err string, out string) []byte {
 		Error:  err,
 		Output: out,
 	}
-	b, marshalErr := json.MarshalIndent(r, "", "  ")
+	b, marshalErr := json.Marshal(r)
 	if marshalErr != nil {
 		logger.Error("Failed to marshal result", "error", marshalErr)
 		return []byte(`{"error":"failed to marshal result","output":""}`)

--- a/internal/interpreter/result_test.go
+++ b/internal/interpreter/result_test.go
@@ -1,12 +1,22 @@
 package interpreter
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
 )
+
+// assertCompactJSON fails if the bytes contain indentation whitespace
+// (newlines or tabs), ensuring postbacks are serialized compactly.
+func assertCompactJSON(t *testing.T, b []byte) {
+	t.Helper()
+	if bytes.ContainsAny(b, "\n\t") {
+		t.Errorf("expected compact JSON without indentation, got %s", b)
+	}
+}
 
 func TestErrorResultBytes(t *testing.T) {
 	logger := hclog.NewNullLogger()
@@ -16,6 +26,8 @@ func TestErrorResultBytes(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected non-nil bytes")
 	}
+
+	assertCompactJSON(t, b)
 
 	var out errorResult
 	if err = json.Unmarshal(b, &out); err != nil {
@@ -34,6 +46,8 @@ func TestResultBytes(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected non-nil bytes")
 	}
+
+	assertCompactJSON(t, b)
 
 	var out result
 	err := json.Unmarshal(b, &out)


### PR DESCRIPTION
## Summary
Command results sent back to the Rewst engine were serialized with `json.MarshalIndent`, which pretty-prints with two-space indentation and newlines. Since this payload is machine-to-machine (agent → Rewst webhook), the indentation provides no value and costs extra CPU and bytes on the wire on every command postback — overhead that scales with command output size.

This switches both `errorResultBytes` and `resultBytes` in [internal/interpreter/result.go](internal/interpreter/result.go) to `json.Marshal`, producing compact JSON. The JSON structure and field names (`error`, `output`) are unchanged.

## Changes
- Replace `json.MarshalIndent(r, "", "  ")` with `json.Marshal(r)` in `errorResultBytes` and `resultBytes`. Hardcoded fallback JSON strings are unchanged.
- Add an `assertCompactJSON` helper to the unit tests and assert that both result serializers emit compact output (no newlines/tabs). Existing unmarshal-based assertions confirm the structure/fields are unchanged.

## Testing
- `go test ./internal/interpreter/` passes.

## Acceptance Criteria
- [x] Command result and error-result postbacks serialized as compact JSON.
- [x] JSON structure and field names (`error`, `output`) unchanged.
- [x] Unit tests updated to expect compact output and pass.
- [x] No regression in postback success across the integration test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)