### PR TITLE
fix: [sc-97778] Add panic recovery to long-lived agent goroutines

### DIFF
--- a/cmd/agent_smith/panic_recovery_test.go
+++ b/cmd/agent_smith/panic_recovery_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/interpreter"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
+)
+
+// panicOnceExecutor panics on its first Execute call and counts successful
+// (non-panicking) calls thereafter, so a test can assert the worker survived a
+// panic and continued processing subsequent messages.
+type panicOnceExecutor struct {
+	calls   atomic.Int32
+	survive atomic.Int32
+}
+
+func (e *panicOnceExecutor) AlwaysPostback() bool { return false }
+
+func (e *panicOnceExecutor) Execute(
+	_ context.Context,
+	_ *interpreter.Message,
+	_ agent.Device,
+	_ hclog.Logger,
+	_ agent.SystemInfoProvider,
+	_ agent.DomainInfoProvider,
+) []byte {
+	if e.calls.Add(1) == 1 {
+		panic("simulated handler panic")
+	}
+	e.survive.Add(1)
+	return nil
+}
+
+// TestProcessMessageGuarded_RecoversAndLogs verifies a panic while handling a
+// single message is recovered (the call returns normally), logged at Error
+// level with a stack trace, and never propagates to crash the process.
+func TestProcessMessageGuarded_RecoversAndLogs(t *testing.T) {
+	exec := &panicOnceExecutor{}
+	svc := newTestSvc(exec)
+
+	buf := bytes.Buffer{}
+	logger := utils.ConfigureLogger("test", &buf, utils.Error)
+	notifier := &mockNotifierWrapper{}
+	device := agent.Device{}
+
+	// Must not panic — if recovery were missing, this call would crash the test
+	// process (and the agent in production).
+	svc.processMessageGuarded(7, validPayload("echo boom"), context.Background(), device, logger, notifier)
+
+	output := buf.String()
+	if !strings.Contains(output, "Recovered from panic") {
+		t.Errorf("expected recovery log, got %q", output)
+	}
+	if !strings.Contains(output, "simulated handler panic") {
+		t.Errorf("expected recovered value in log, got %q", output)
+	}
+	if !strings.Contains(output, "stack=") {
+		t.Errorf("expected stack trace in log, got %q", output)
+	}
+	if !strings.Contains(output, "worker=7") {
+		t.Errorf("expected worker id in log, got %q", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "[error]") {
+		t.Errorf("expected error-level log, got %q", output)
+	}
+}
+
+// TestWorkerPool_SurvivesPanickingHandler verifies the worker pool keeps
+// processing subsequent messages after a handler panics — i.e. a panicking
+// message does not permanently kill a worker. It drives the same guarded
+// worker loop used by runCycle.
+func TestWorkerPool_SurvivesPanickingHandler(t *testing.T) {
+	exec := &panicOnceExecutor{}
+	svc := newTestSvc(exec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := hclog.NewNullLogger()
+	notifier := &mockNotifierWrapper{}
+	device := agent.Device{}
+
+	msgQueue := make(chan []byte, messageQueueSize)
+
+	var wg sync.WaitGroup
+	for i := range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case payload, ok := <-msgQueue:
+					if !ok {
+						return
+					}
+					svc.processMessageGuarded(i, payload, ctx, device, logger, notifier)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	const total = 20
+	for range total {
+		msgQueue <- validPayload("echo hi")
+	}
+
+	// All messages must be consumed (the first triggers the panic; the rest are
+	// processed normally), proving no worker died permanently.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if int(exec.calls.Load()) >= total {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	close(msgQueue)
+	wg.Wait()
+
+	if got := int(exec.calls.Load()); got != total {
+		t.Errorf("expected all %d messages handled, got %d", total, got)
+	}
+	if got := int(exec.survive.Load()); got != total-1 {
+		t.Errorf("expected %d messages processed after the panic, got %d", total-1, got)
+	}
+}

--- a/cmd/agent_smith/panic_recovery_test.go
+++ b/cmd/agent_smith/panic_recovery_test.go
@@ -54,7 +54,14 @@ func TestProcessMessageGuarded_RecoversAndLogs(t *testing.T) {
 
 	// Must not panic — if recovery were missing, this call would crash the test
 	// process (and the agent in production).
-	svc.processMessageGuarded(7, validPayload("echo boom"), context.Background(), device, logger, notifier)
+	svc.processMessageGuarded(
+		7,
+		validPayload("echo boom"),
+		context.Background(),
+		device,
+		logger,
+		notifier,
+	)
 
 	output := buf.String()
 	if !strings.Contains(output, "Recovered from panic") {

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -184,13 +184,13 @@ func (svc *serviceContext) Execute(
 	stopped := make(chan struct{})
 
 	// Monitor the request for the stopped signal
-	go func() {
+	utils.SafeGo(logger, func() {
 		select {
 		case <-stop:
 			close(stopped)
 		case <-ctx.Done():
 		}
-	}()
+	}, "scope", "stop_monitor")
 
 	running <- struct{}{}
 	_ = notifier.Notify("AgentStarted") // Best effort notification
@@ -270,7 +270,7 @@ func (svc *serviceContext) runCycle(
 						"worker", i,
 						"queue_length", len(msgQueue),
 					)
-					svc.processMessage(payload, cycleCtx, device, logger, notifier)
+					svc.processMessageGuarded(i, payload, cycleCtx, device, logger, notifier)
 				case <-cycleCtx.Done():
 					logger.Debug("Message worker stopped: context cancelled", "worker", i)
 					return
@@ -384,6 +384,26 @@ func buildReceivedMessageNotification(payload []byte) string {
 		len(payload),
 		payload[:maxNotificationPayloadBytes],
 	)
+}
+
+// processMessageGuarded runs processMessage with per-message panic recovery.
+// Because the payload is untrusted (received over MQTT), a malformed message,
+// an unexpected nil, a plugin RPC fault, or any library panic on this path must
+// not crash the process. Recovering per-message — rather than per-worker-loop —
+// contains the fault to the single offending message and keeps the worker alive
+// to process the next item, so the pool stays at full strength. The recovered
+// value and a stack trace are logged at Error level (with the worker id) to aid
+// diagnosis. Normal error returns from processMessage are unaffected.
+func (svc *serviceContext) processMessageGuarded(
+	workerId int,
+	payload []byte,
+	ctx context.Context,
+	device agent.Device,
+	logger hclog.Logger,
+	notifier plugins.NotifierWrapper,
+) {
+	defer utils.Recover(logger, "worker", workerId, "scope", "processMessage")
+	svc.processMessage(payload, ctx, device, logger, notifier)
 }
 
 func (svc *serviceContext) processMessage(

--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 	"github.com/hashicorp/go-hclog"
 )
@@ -324,7 +325,7 @@ func (r *AutoUpdateRunner) Start() {
 				r.logger.Info("Auto updater stopped")
 				return
 			case <-timer.C:
-				if err := r.updater.Run(r.ctx); err != nil {
+				if err := r.runUpdate(); err != nil {
 					r.logger.Error("Update failed, starting retry backoff", "error", err)
 					if r.retryWithBackoff() {
 						return
@@ -334,6 +335,21 @@ func (r *AutoUpdateRunner) Start() {
 			}
 		}
 	}()
+}
+
+// runUpdate invokes the updater's Run with panic recovery so a fault on the
+// update path (malformed release JSON, a library or RPC panic, an unexpected
+// nil) is recovered and logged with a stack trace instead of crashing the
+// agent. A recovered panic is surfaced as an error so the normal failure path
+// (retry backoff, then resume on schedule) continues unchanged.
+func (r *AutoUpdateRunner) runUpdate() (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = utils.LogRecoveredPanic(r.logger, rec, "scope", "auto_update_tick")
+		}
+	}()
+
+	return r.updater.Run(r.ctx)
 }
 
 func (r *AutoUpdateRunner) Stop() {
@@ -356,7 +372,7 @@ func (r *AutoUpdateRunner) retryWithBackoff() bool {
 		case <-time.After(backoff):
 		}
 
-		if err := r.updater.Run(r.ctx); err != nil {
+		if err := r.runUpdate(); err != nil {
 			r.logger.Error("Retry failed", "attempt", attempt+1, "error", err)
 			continue
 		}

--- a/internal/agent/updater_panic_test.go
+++ b/internal/agent/updater_panic_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+)
+
+// TestRunUpdate_RecoversPanic verifies that a panic on the update path is
+// recovered, logged at Error level with a stack trace, and surfaced as an error
+// so the normal failure-handling flow continues.
+func TestRunUpdate_RecoversPanic(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := utils.ConfigureLogger("test", &buf, utils.Error)
+	mock := &mockUpdater{
+		runFn: func(_ context.Context) error {
+			panic("update tick boom")
+		},
+	}
+
+	runner := NewAutoUpdateRunner(logger, mock, time.Hour, 3, time.Millisecond)
+
+	err := runner.runUpdate()
+	if err == nil {
+		t.Fatal("expected error from recovered panic, got nil")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Recovered from panic") {
+		t.Errorf("expected recovery log, got %q", output)
+	}
+	if !strings.Contains(output, "update tick boom") {
+		t.Errorf("expected recovered value in log, got %q", output)
+	}
+	if !strings.Contains(output, "stack=") {
+		t.Errorf("expected stack trace in log, got %q", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "[error]") {
+		t.Errorf("expected error-level log, got %q", output)
+	}
+}
+
+// TestAutoUpdateRunner_SurvivesPanickingTick verifies that when an update tick
+// panics, the runner does not crash and continues running on its schedule.
+func TestAutoUpdateRunner_SurvivesPanickingTick(t *testing.T) {
+	logger := utils.ConfigureLogger("test", &bytes.Buffer{}, utils.Off)
+
+	var calls atomic.Int32
+	mock := &mockUpdater{
+		runFn: func(_ context.Context) error {
+			// Panic on the first tick only; subsequent ticks succeed.
+			if calls.Add(1) == 1 {
+				panic("tick boom")
+			}
+			return nil
+		},
+	}
+
+	// Short interval and backoff so the panic tick, its retry, and at least one
+	// further successful tick all happen quickly.
+	runner := NewAutoUpdateRunner(logger, mock, 10*time.Millisecond, 3, time.Millisecond)
+	runner.Start()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls.Load() >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	runner.Stop()
+
+	if calls.Load() < 2 {
+		t.Errorf("expected runner to continue ticking after a panic, got %d calls", calls.Load())
+	}
+}

--- a/internal/service/service_unix.go
+++ b/internal/service/service_unix.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
 )
 
 func Run(runner Runner) (int, error) {
@@ -19,24 +22,24 @@ func Run(runner Runner) (int, error) {
 	ctxStop, cancelStop := context.WithCancel(context.Background())
 	defer cancelStop()
 
-	go func() {
+	utils.SafeGo(hclog.Default(), func() {
 		select {
 		case <-signalReceived:
 			stop <- struct{}{}
 		case <-ctxStop.Done():
 		}
-	}()
+	}, "scope", "signal_monitor")
 
 	running := make(chan struct{})
 	ctxRunning, cancelRunning := context.WithCancel(context.Background())
 	defer cancelRunning()
 
-	go func() {
+	utils.SafeGo(hclog.Default(), func() {
 		select {
 		case <-running:
 		case <-ctxRunning.Done():
 		}
-	}()
+	}, "scope", "running_monitor")
 
 	// Execute the runner
 	exitCode := runner.Execute(stop, running)

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -169,7 +171,7 @@ func (host *windowsRunner) Execute(
 	// Make go routines for the channels
 	ctxStop, cancelStop := context.WithCancel(context.Background())
 	defer cancelStop()
-	go func() {
+	utils.SafeGo(hclog.Default(), func() {
 		for {
 			select {
 			case change := <-request:
@@ -183,11 +185,11 @@ func (host *windowsRunner) Execute(
 				return
 			}
 		}
-	}()
+	}, "scope", "request_monitor")
 
 	ctxRunning, cancelRunning := context.WithCancel(context.Background())
 	defer cancelRunning()
-	go func() {
+	utils.SafeGo(hclog.Default(), func() {
 		select {
 		case <-running:
 			response <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
@@ -195,7 +197,7 @@ func (host *windowsRunner) Execute(
 			// Stop this routine
 			return
 		}
-	}()
+	}, "scope", "running_monitor")
 
 	// Execute the runner
 	host.exitCode = int(host.runner.Execute(stop, running))

--- a/internal/utils/recover.go
+++ b/internal/utils/recover.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// LogRecoveredPanic logs an already-recovered panic value at Error level along
+// with a stack trace, and returns an error describing it.
+//
+// Call it from inside a deferred closure that has itself called recover() when
+// the caller needs to react to the panic (for example, to set a named error
+// return so existing error-handling continues). When logging alone is enough,
+// prefer Recover. The keyvals are attached to the log entry to identify the
+// goroutine/context where the panic occurred (e.g. "worker", id).
+func LogRecoveredPanic(logger hclog.Logger, recovered any, keyvals ...any) error {
+	args := make([]any, 0, len(keyvals)+4)
+	args = append(args, keyvals...)
+	args = append(args, "panic", recovered, "stack", string(debug.Stack()))
+
+	if logger != nil {
+		logger.Error("Recovered from panic", args...)
+	}
+
+	return fmt.Errorf("recovered from panic: %v", recovered)
+}
+
+// Recover is a deferred panic handler: it recovers any in-flight panic in the
+// current goroutine and logs it at Error level with a stack trace. It is a
+// no-op when no panic is in flight, so deferring it unconditionally is safe and
+// it never changes normal (non-panic) control flow.
+//
+// It must be invoked directly via defer (defer utils.Recover(logger, ...)) so
+// the recover() runs in the panicking goroutine's deferred call.
+func Recover(logger hclog.Logger, keyvals ...any) {
+	if r := recover(); r != nil {
+		_ = LogRecoveredPanic(logger, r, keyvals...)
+	}
+}
+
+// SafeGo runs fn in a new goroutine guarded by Recover, so a panic in fn is
+// recovered and logged instead of crashing the process. keyvals are attached to
+// the log entry emitted if fn panics.
+func SafeGo(logger hclog.Logger, fn func(), keyvals ...any) {
+	go func() {
+		defer Recover(logger, keyvals...)
+		fn()
+	}()
+}

--- a/internal/utils/recover_test.go
+++ b/internal/utils/recover_test.go
@@ -1,0 +1,111 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRecoverContainsPanicAndStack(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := ConfigureLogger("test", &buf, Error)
+
+	func() {
+		defer Recover(logger, "worker", 3)
+		panic("boom")
+	}()
+
+	output := buf.String()
+	if !strings.Contains(output, "Recovered from panic") {
+		t.Errorf("expected recovery log message, got %q", output)
+	}
+	if !strings.Contains(output, "boom") {
+		t.Errorf("expected recovered value in log, got %q", output)
+	}
+	if !strings.Contains(output, "stack=") {
+		t.Errorf("expected stack trace in log, got %q", output)
+	}
+	if !strings.Contains(output, "worker=3") {
+		t.Errorf("expected keyvals in log, got %q", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "[error]") {
+		t.Errorf("expected error-level log, got %q", output)
+	}
+}
+
+func TestRecoverNoPanicIsNoOp(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := ConfigureLogger("test", &buf, Error)
+
+	func() {
+		defer Recover(logger)
+		// no panic
+	}()
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output when no panic, got %q", buf.String())
+	}
+}
+
+func TestRecoverNilLoggerDoesNotPanic(t *testing.T) {
+	// Must not itself panic when logger is nil.
+	func() {
+		defer Recover(nil)
+		panic("boom")
+	}()
+}
+
+func TestLogRecoveredPanicReturnsError(t *testing.T) {
+	buf := bytes.Buffer{}
+	logger := ConfigureLogger("test", &buf, Error)
+
+	err := LogRecoveredPanic(logger, "kapow")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), "kapow") {
+		t.Errorf("expected recovered value in error, got %q", err.Error())
+	}
+}
+
+// signalWriter is a concurrency-safe io.Writer that closes done after the
+// first write, letting a test wait until the logger has emitted output from a
+// SafeGo goroutine without racing on the underlying buffer.
+type signalWriter struct {
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	once sync.Once
+	done chan struct{}
+}
+
+func (w *signalWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.buf.Write(p)
+	w.once.Do(func() { close(w.done) })
+	return n, err
+}
+
+func (w *signalWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func TestSafeGoRecoversAndContinues(t *testing.T) {
+	w := &signalWriter{done: make(chan struct{})}
+	logger := ConfigureLogger("test", w, Error)
+
+	// A panic inside the SafeGo goroutine must be recovered (so the test
+	// process survives) and logged.
+	SafeGo(logger, func() {
+		panic("goroutine boom")
+	}, "scope", "test")
+
+	<-w.done
+
+	if !strings.Contains(w.String(), "goroutine boom") {
+		t.Errorf("expected recovered goroutine panic to be logged, got %q", w.String())
+	}
+}


### PR DESCRIPTION
## Summary

Agent Smith runs as a long-lived system service that executes remotely-supplied commands, but there was **no panic recovery anywhere in production code**. In Go an unrecovered panic in any goroutine kills the entire process — so a single fault while handling one untrusted MQTT message (or one update tick) would drop the MQTT connection and stop command execution for the device until the service restarts.

This change adds defense-in-depth: a fault on these paths is now logged and contained, not escalated to a full crash.

## Changes

- **Shared helper** (`internal/utils/recover.go`): `Recover`, `SafeGo`, and `LogRecoveredPanic`. They recover an in-flight panic, log it at **Error** level with the recovered value and a `debug.Stack()` trace, and never alter normal (non-panic) control flow.
- **Message worker pool** (`cmd/agent_smith/service.go`): extracted `processMessageGuarded`, which wraps `processMessage` with recovery **per-message**. A panic on the untrusted-payload path is contained to that one message (logged with worker id + stack); the worker continues, keeping the pool at full strength.
- **Auto-update runner** (`internal/agent/updater.go`): `runUpdate` recovers panics from `updater.Run` and surfaces them as an error, so the existing retry/backoff/reschedule flow continues unchanged.
- **Service-layer lifecycle goroutines** (`internal/service/service_unix.go`, `service_windows.go`) and the stop-monitor goroutine now run under `SafeGo`.

## Acceptance criteria

- [x] A panic while processing a single message is recovered and logged with a stack trace; the process stays alive and keeps processing subsequent messages.
- [x] The worker pool remains at full strength after a handler panics (no permanently dead workers).
- [x] A panic in an auto-update tick is recovered and logged without crashing the agent.
- [x] Recovery goes through a shared, unit-tested helper used consistently across the affected goroutines.
- [x] Normal error-handling behavior is unchanged; recovered panics are never silently discarded.
- [x] Unit tests assert a deliberately panicking message handler and update tick do not terminate the process and log at Error level. `go test -race ./...` passes.

## Testing

- `go test -race ./...` — pass
- `go vet ./...` — pass
- `GOOS=windows go build ./...` — pass

New tests: `internal/utils/recover_test.go`, `cmd/agent_smith/panic_recovery_test.go`, `internal/agent/updater_panic_test.go`.

## Notes

- The optional best-effort *notification* on panic (ticket marked "if appropriate") was left out to keep the shared helper free of plugin/notifier coupling — logging satisfies the criteria.
- Service-layer goroutines use `hclog.Default()` since `service.Run` has no logger in scope.
- `CHANGELOG.md` is intentionally untouched; this repo generates it via commitizen in a separate `docs:` commit at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)