### PR TITLE
fix: [sc-97779] Apply back-pressure so saturated queue stops dropping commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,46 @@ This will stop the service, remove configuration files, and clean up system serv
 4. Returns results back to the Rewst platform
 5. Supports system information collection and custom plugins
 
+### Message Delivery Guarantee
+
+Incoming messages are handed to a buffered queue drained by a pool of
+command-execution workers. When that queue fills (a burst of commands, or
+execution slow enough to keep every worker busy), the subscribe callback
+**applies back-pressure instead of dropping the message**: it blocks until a
+worker frees a slot. Because the agent subscribes at QoS 1 (at-least-once) by
+default and the MQTT client only acknowledges a message after the callback
+returns, a saturated agent stops acknowledging — so the broker holds and later
+redelivers the command rather than the agent silently discarding it. This trades
+a small amount of in-broker buffering for no silent command loss.
+
+The only case where a message is discarded is when it arrives while a connection
+cycle is tearing down (service stop or reconnect). The connection is going away
+regardless, so at QoS ≥ 1 the broker redelivers on the next connection. These
+drops are surfaced loudly — an `Error` log line, a cumulative dropped-message
+counter, and a best-effort `AgentMessageDropped` plugin notification — rather
+than a single warning, so they are observable in monitoring.
+
+#### Tuning queue capacity and concurrency
+
+Two optional fields in the device configuration file let high-volume deployments
+tune the queue without code changes:
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `worker_count` | `10` | Number of concurrent command-execution workers draining the queue. |
+| `message_queue_size` | `100` | Capacity of the buffered inbound message queue before back-pressure begins. |
+
+Both fall back to their defaults when omitted or set to a non-positive value.
+Raising `message_queue_size` absorbs larger bursts before back-pressure begins;
+raising `worker_count` widens execution parallelism. Example snippet:
+
+```json
+{
+  "worker_count": 25,
+  "message_queue_size": 500
+}
+```
+
 ## Build
 Required tools and packages:
 

--- a/cmd/agent_smith/message_queue_test.go
+++ b/cmd/agent_smith/message_queue_test.go
@@ -237,7 +237,15 @@ func TestEnqueueMessage_DropsLoudlyOnDrain(t *testing.T) {
 	msgQueue <- validPayload("echo full")
 	close(draining)
 
-	if ok := svc.enqueueMessage(validPayload("echo overflow"), msgQueue, draining, 1, logger, notifier); ok {
+	ok := svc.enqueueMessage(
+		validPayload("echo overflow"),
+		msgQueue,
+		draining,
+		1,
+		logger,
+		notifier,
+	)
+	if ok {
 		t.Fatal("expected enqueueMessage to drop when full and draining")
 	}
 

--- a/cmd/agent_smith/message_queue_test.go
+++ b/cmd/agent_smith/message_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,6 +21,28 @@ type mockNotifierWrapper struct{}
 func (m *mockNotifierWrapper) Kill()               {}
 func (m *mockNotifierWrapper) Plugins() []string   { return nil }
 func (m *mockNotifierWrapper) Notify(string) error { return nil }
+
+// recordingNotifierWrapper records every notification message it receives so
+// tests can assert that drops are surfaced to plugins.
+type recordingNotifierWrapper struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (m *recordingNotifierWrapper) Kill()             {}
+func (m *recordingNotifierWrapper) Plugins() []string { return nil }
+func (m *recordingNotifierWrapper) Notify(msg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, msg)
+	return nil
+}
+
+func (m *recordingNotifierWrapper) all() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.messages...)
+}
 
 // countingExecutor counts Execute calls and optionally blocks until released.
 type countingExecutor struct {
@@ -119,77 +142,158 @@ func TestMessageQueue_WorkersProcessAllMessages(t *testing.T) {
 	}
 }
 
-// TestMessageQueue_QueueFullDropsMessage verifies that when the queue is full
-// the callback drops the message rather than blocking.
-func TestMessageQueue_QueueFullDropsMessage(t *testing.T) {
-	// workerBlocked is incremented each time a worker enters Execute.
-	workerEntered := make(chan struct{}, workerCount)
-	block := make(chan struct{})
-
-	exec := &blockingConcurrencyExecutor{
-		block:   block,
-		onEnter: func() { workerEntered <- struct{}{} },
-		onExit:  func() {},
-	}
-	svc := newTestSvc(exec)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+// TestEnqueueMessage_EnqueuesWhenSlotAvailable verifies the normal path: a
+// payload is placed on the queue and reported as enqueued (not dropped).
+func TestEnqueueMessage_EnqueuesWhenSlotAvailable(t *testing.T) {
+	svc := newTestSvc(&countingExecutor{})
 	logger := hclog.NewNullLogger()
-	notifier := &mockNotifierWrapper{}
-	device := agent.Device{}
+	notifier := &recordingNotifierWrapper{}
 
-	msgQueue := make(chan []byte, messageQueueSize)
+	msgQueue := make(chan []byte, 1)
+	draining := make(chan struct{})
 
-	// Start workers.
-	for range workerCount {
-		go func() {
-			for {
-				select {
-				case payload, ok := <-msgQueue:
-					if !ok {
-						return
-					}
-					svc.processMessage(payload, ctx, device, logger, notifier)
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
+	payload := validPayload("echo hi")
+	if ok := svc.enqueueMessage(payload, msgQueue, draining, 1, logger, notifier); !ok {
+		t.Fatal("expected enqueueMessage to report success when a slot is free")
 	}
 
-	// Send exactly workerCount messages and wait until every worker is blocked
-	// inside Execute — at that point no worker can drain the queue further.
-	for range workerCount {
-		msgQueue <- validPayload("echo block")
-	}
-	for range workerCount {
-		select {
-		case <-workerEntered:
-		case <-time.After(2 * time.Second):
-			t.Fatal("workers did not enter Execute in time")
-		}
-	}
-
-	// Now fill the queue to its full capacity.
-	for range messageQueueSize {
-		msgQueue <- validPayload("echo fill")
-	}
-
-	// Queue is full. This select must take the default (drop) branch.
-	dropped := false
 	select {
-	case msgQueue <- validPayload("echo overflow"):
+	case got := <-msgQueue:
+		if string(got) != string(payload) {
+			t.Errorf("queued payload mismatch: got %q want %q", got, payload)
+		}
 	default:
-		dropped = true
+		t.Fatal("expected payload to be on the queue")
 	}
 
-	if !dropped {
-		t.Error("expected message to be dropped when queue is full, but it was enqueued")
+	if n := svc.droppedMessages.Load(); n != 0 {
+		t.Errorf("expected 0 drops, got %d", n)
+	}
+	if msgs := notifier.all(); len(msgs) != 0 {
+		t.Errorf("expected no notifications on success, got %v", msgs)
+	}
+}
+
+// TestEnqueueMessage_BackPressureBlocksThenSucceeds verifies that when the queue
+// is full enqueueMessage applies back-pressure (blocks) rather than dropping,
+// and succeeds once a worker frees a slot. This is the core anti-data-loss
+// behavior: a full queue must not silently discard the command.
+func TestEnqueueMessage_BackPressureBlocksThenSucceeds(t *testing.T) {
+	svc := newTestSvc(&countingExecutor{})
+	logger := hclog.NewNullLogger()
+	notifier := &recordingNotifierWrapper{}
+
+	msgQueue := make(chan []byte, 1)
+	draining := make(chan struct{})
+
+	// Pre-fill the queue so the next enqueue must wait.
+	msgQueue <- validPayload("echo first")
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- svc.enqueueMessage(validPayload("echo second"), msgQueue, draining, 1, logger, notifier)
+	}()
+
+	// The enqueue must not complete while the queue stays full.
+	select {
+	case <-done:
+		t.Fatal("enqueueMessage returned while queue was full; it should block (back-pressure)")
+	case <-time.After(100 * time.Millisecond):
 	}
 
-	close(block) // unblock workers so goroutines can exit
+	// Free a slot; the blocked enqueue should now succeed.
+	<-msgQueue
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Error("expected enqueueMessage to report success after a slot freed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("enqueueMessage did not complete after a slot freed")
+	}
+
+	if n := svc.droppedMessages.Load(); n != 0 {
+		t.Errorf("expected 0 drops under back-pressure, got %d", n)
+	}
+	if msgs := notifier.all(); len(msgs) != 0 {
+		t.Errorf("expected no drop notifications under back-pressure, got %v", msgs)
+	}
+}
+
+// TestEnqueueMessage_DropsLoudlyOnDrain verifies that a payload arriving while
+// the cycle is tearing down (draining closed) on a full queue is dropped, and
+// that the drop is surfaced loudly: the cumulative counter increments and a
+// best-effort plugin notification is emitted. This is the bounded escape that
+// keeps teardown from deadlocking on a full queue.
+func TestEnqueueMessage_DropsLoudlyOnDrain(t *testing.T) {
+	svc := newTestSvc(&countingExecutor{})
+	logger := hclog.NewNullLogger()
+	notifier := &recordingNotifierWrapper{}
+
+	msgQueue := make(chan []byte, 1)
+	draining := make(chan struct{})
+
+	// Fill the queue and signal teardown so the only available branch is drain.
+	msgQueue <- validPayload("echo full")
+	close(draining)
+
+	if ok := svc.enqueueMessage(validPayload("echo overflow"), msgQueue, draining, 1, logger, notifier); ok {
+		t.Fatal("expected enqueueMessage to drop when full and draining")
+	}
+
+	if n := svc.droppedMessages.Load(); n != 1 {
+		t.Errorf("expected dropped counter to be 1, got %d", n)
+	}
+
+	msgs := notifier.all()
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly one drop notification, got %v", msgs)
+	}
+	if !strings.HasPrefix(msgs[0], "AgentMessageDropped:") {
+		t.Errorf("unexpected notification message: %q", msgs[0])
+	}
+}
+
+// TestEnqueueMessage_DrainUnblocksBackPressure verifies that closing draining
+// releases a callback already blocked on a full queue, so teardown can proceed
+// without deadlock even when no worker frees a slot.
+func TestEnqueueMessage_DrainUnblocksBackPressure(t *testing.T) {
+	svc := newTestSvc(&countingExecutor{})
+	logger := hclog.NewNullLogger()
+	notifier := &recordingNotifierWrapper{}
+
+	msgQueue := make(chan []byte, 1)
+	draining := make(chan struct{})
+
+	// Fill the queue so the enqueue blocks.
+	msgQueue <- validPayload("echo full")
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- svc.enqueueMessage(validPayload("echo blocked"), msgQueue, draining, 1, logger, notifier)
+	}()
+
+	// Confirm it is blocked.
+	select {
+	case <-done:
+		t.Fatal("enqueueMessage returned before draining; expected it to block")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Teardown: closing draining must release the blocked enqueue as a drop.
+	close(draining)
+	select {
+	case ok := <-done:
+		if ok {
+			t.Error("expected blocked enqueue to be reported as dropped after draining closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked enqueueMessage was not released by draining (deadlock risk)")
+	}
+
+	if n := svc.droppedMessages.Load(); n != 1 {
+		t.Errorf("expected dropped counter to be 1, got %d", n)
+	}
 }
 
 // TestMessageQueue_WorkersCancelOnContextDone verifies that all workers exit

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -25,8 +25,12 @@ import (
 )
 
 const (
-	workerCount              = 10
-	messageQueueSize         = 100
+	// workerCount and messageQueueSize are the defaults applied when the device
+	// config does not override them via worker_count / message_queue_size. The
+	// effective values are resolved per cycle from the device config; see
+	// agent.Device.ResolvedWorkerCount / ResolvedMessageQueueSize.
+	workerCount              = agent.DefaultWorkerCount
+	messageQueueSize         = agent.DefaultMessageQueueSize
 	postbackHTTPTimeout      = 30 * time.Second
 	postbackMaxAttempts      = 3
 	postbackBaseRetryBackoff = 1 * time.Second
@@ -251,9 +255,21 @@ func (svc *serviceContext) runCycle(
 ) (bool, bool, service.ServiceExitCode) {
 	cycleCtx, cycleCancel := context.WithCancel(ctx)
 
-	msgQueue := make(chan []byte, messageQueueSize)
+	resolvedWorkerCount := device.ResolvedWorkerCount()
+	resolvedQueueSize := device.ResolvedMessageQueueSize()
+
+	msgQueue := make(chan []byte, resolvedQueueSize)
+
+	// draining is closed at the very start of teardown (its defer is registered
+	// last, so it runs first) to release the subscribe callback if it is blocked
+	// applying back-pressure on a full queue. Releasing the callback before the
+	// MQTT Unsubscribe/Disconnect is what keeps teardown deadlock-free: paho
+	// dispatches messages on a single ordered goroutine, so a permanently
+	// blocked callback would also stall the UNSUBACK/disconnect handling.
+	draining := make(chan struct{})
+
 	var wg sync.WaitGroup
-	for i := range workerCount {
+	for i := range resolvedWorkerCount {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -332,17 +348,14 @@ func (svc *serviceContext) runCycle(
 		logger.Info("Device twin reported properties updated", "agent_version", version.Version)
 	}
 
+	// Closed first during teardown (registered after the MQTT teardown defer so
+	// it runs before it under LIFO) to unblock a back-pressured callback.
+	defer close(draining)
+
+	// enqueueMessage applies back-pressure instead of dropping; see its doc for
+	// the delivery guarantee and the single (loudly surfaced) teardown drop path.
 	token = client.Subscribe(topic, qos, func(client mqtt.Client, msg mqtt.Message) {
-		payload := msg.Payload()
-		select {
-		case msgQueue <- payload:
-		default:
-			logger.Warn(
-				"Message dropped: queue full",
-				"queue_size",
-				messageQueueSize,
-			)
-		}
+		svc.enqueueMessage(msg.Payload(), msgQueue, draining, resolvedQueueSize, logger, notifier)
 	})
 
 	if token.Wait() && token.Error() != nil {
@@ -384,6 +397,48 @@ func buildReceivedMessageNotification(payload []byte) string {
 		len(payload),
 		payload[:maxNotificationPayloadBytes],
 	)
+}
+
+// enqueueMessage hands a received payload to the worker queue, applying
+// back-pressure rather than dropping. paho dispatches messages on a single
+// ordered goroutine and sends the QoS-1 PUBACK only after the subscribe callback
+// (and thus this function) returns, so blocking here stops the broker from
+// considering the message delivered: when the queue is full the call waits until
+// a worker frees a slot, and if the agent stays saturated paho's inbound buffer
+// fills so the broker holds and later redelivers messages instead of the agent
+// silently discarding them.
+//
+// The single drop path is a payload arriving while the cycle is tearing down
+// (draining closed). The connection is going away regardless, so at QoS >= 1 the
+// broker redelivers on the next connection; the drop is therefore surfaced
+// loudly — an Error log, a cumulative counter, and a best-effort plugin
+// notification — rather than buried in a single Warn. draining is selected as a
+// bounded escape so teardown can never deadlock on a full queue.
+//
+// Returns true when the payload was enqueued, false when it was dropped.
+func (svc *serviceContext) enqueueMessage(
+	payload []byte,
+	msgQueue chan<- []byte,
+	draining <-chan struct{},
+	queueSize int,
+	logger hclog.Logger,
+	notifier plugins.NotifierWrapper,
+) bool {
+	select {
+	case msgQueue <- payload:
+		return true
+	case <-draining:
+		dropped := svc.droppedMessages.Add(1)
+		logger.Error(
+			"Message dropped: received during shutdown, broker will redeliver at QoS>=1",
+			"queue_size", queueSize,
+			"dropped_total", dropped,
+		)
+		_ = notifier.Notify(
+			fmt.Sprintf("AgentMessageDropped:shutdown (dropped_total=%d)", dropped),
+		) // Best effort notification
+		return false
+	}
 }
 
 // processMessageGuarded runs processMessage with per-message panic recovery.

--- a/cmd/agent_smith/service_context.go
+++ b/cmd/agent_smith/service_context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
@@ -28,6 +29,13 @@ type serviceContext struct {
 	// PostbackBaseRetryBackoff is the base delay used for exponential backoff
 	// between postback attempts. Defaults to postbackBaseRetryBackoff.
 	PostbackBaseRetryBackoff time.Duration
+
+	// droppedMessages counts inbound messages the agent could not accept and had
+	// to discard. Under normal operation the subscribe callback applies
+	// back-pressure instead of dropping, so this only increments when a payload
+	// arrives during teardown (see runCycle). It is a cumulative, process-wide
+	// counter exposed for observability beyond the per-drop error log.
+	droppedMessages atomic.Int64
 }
 
 // newServiceFlagSet builds the flag set for service mode, binding flags to the

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -25,6 +25,47 @@ type Device struct {
 	// utils.DefaultMqttConnectTimeout. Useful for endpoints with slow TLS
 	// handshakes that need more than the default.
 	MqttConnectTimeoutSeconds *int `json:"mqtt_connect_timeout_seconds,omitempty"`
+	// WorkerCount optionally overrides how many concurrent command-execution
+	// workers drain the inbound message queue. When unset (or non-positive) the
+	// agent falls back to DefaultWorkerCount. Deployments that expect a high
+	// volume of concurrent commands can raise this to widen execution
+	// parallelism.
+	WorkerCount *int `json:"worker_count,omitempty"`
+	// MessageQueueSize optionally overrides the capacity of the buffered queue
+	// that holds received messages waiting for a worker. When unset (or
+	// non-positive) the agent falls back to DefaultMessageQueueSize. A larger
+	// queue absorbs bigger bursts before the agent starts applying back-pressure
+	// to the broker.
+	MessageQueueSize *int `json:"message_queue_size,omitempty"`
+}
+
+const (
+	// DefaultWorkerCount is the number of concurrent command-execution workers
+	// used when WorkerCount is not configured.
+	DefaultWorkerCount = 10
+	// DefaultMessageQueueSize is the buffered inbound message queue capacity used
+	// when MessageQueueSize is not configured.
+	DefaultMessageQueueSize = 100
+)
+
+// ResolvedWorkerCount returns the number of command-execution workers to start,
+// honoring the per-device override when set to a positive value and falling back
+// to DefaultWorkerCount otherwise.
+func (d Device) ResolvedWorkerCount() int {
+	if d.WorkerCount != nil && *d.WorkerCount > 0 {
+		return *d.WorkerCount
+	}
+	return DefaultWorkerCount
+}
+
+// ResolvedMessageQueueSize returns the inbound message queue capacity, honoring
+// the per-device override when set to a positive value and falling back to
+// DefaultMessageQueueSize otherwise.
+func (d Device) ResolvedMessageQueueSize() int {
+	if d.MessageQueueSize != nil && *d.MessageQueueSize > 0 {
+		return *d.MessageQueueSize
+	}
+	return DefaultMessageQueueSize
 }
 
 // MqttConnectTimeout returns the per-attempt MQTT connect timeout, honoring the

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -1,0 +1,49 @@
+package agent
+
+import "testing"
+
+func intPtr(v int) *int { return &v }
+
+func TestResolvedWorkerCount(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect int
+	}{
+		{"unset falls back to default", nil, DefaultWorkerCount},
+		{"zero falls back to default", intPtr(0), DefaultWorkerCount},
+		{"negative falls back to default", intPtr(-5), DefaultWorkerCount},
+		{"positive override honored", intPtr(25), 25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{WorkerCount: tt.value}
+			if got := d.ResolvedWorkerCount(); got != tt.expect {
+				t.Errorf("ResolvedWorkerCount() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestResolvedMessageQueueSize(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect int
+	}{
+		{"unset falls back to default", nil, DefaultMessageQueueSize},
+		{"zero falls back to default", intPtr(0), DefaultMessageQueueSize},
+		{"negative falls back to default", intPtr(-1), DefaultMessageQueueSize},
+		{"positive override honored", intPtr(500), 500},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{MessageQueueSize: tt.value}
+			if got := d.ResolvedMessageQueueSize(); got != tt.expect {
+				t.Errorf("ResolvedMessageQueueSize() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Incoming MQTT messages were handed to a buffered queue (`messageQueueSize = 100`) via a non-blocking `select`/`default` in the subscribe callback: when the queue was full the message was **dropped** with only a `Warn` log. Because the agent subscribes at QoS 1 (at-least-once), the broker considers a message delivered once the callback returns — so a dropped message was lost permanently. Under bursts or slow command execution the agent silently discarded work, with no error surfaced back to Rewst.

This PR replaces the silent drop with **back-pressure**, makes the rare teardown-time drop **loudly observable**, and makes the queue **tunable**.

## What changed

- **Back-pressure instead of loss** (`cmd/agent_smith/service.go`): the enqueue path was extracted into a testable `enqueueMessage` method that now **blocks** until a worker frees a slot. paho dispatches messages on a single ordered goroutine (`Order: true`) and sends the QoS-1 PUBACK only *after* the callback returns, so blocking stops the broker from considering the message delivered — under sustained saturation the broker holds and later redelivers rather than the agent discarding.
- **Deadlock-free teardown**: a `draining` channel is closed at the very start of teardown (its `defer` is registered after the MQTT-teardown defer, so it runs *first* under LIFO), releasing any back-pressured callback before `Unsubscribe`/`Disconnect`. This avoids the deadlock a permanently-blocked handler would otherwise cause in paho's ordered dispatch. Existing stop/reconnect ordering is otherwise preserved.
- **Observable drops**: the only remaining drop path (a payload arriving during teardown — broker redelivers at QoS ≥ 1) is surfaced via an `Error` log, a cumulative `droppedMessages` counter, and a best-effort `AgentMessageDropped` plugin notification.
- **Tunable capacity** (`internal/agent/device.go`): optional `worker_count` and `message_queue_size` device-config fields with `Resolved*` accessors that fall back to the defaults (10 / 100).
- **Docs** (`README.md`): new "Message Delivery Guarantee" section explaining the block-vs-drop trade-off and a tuning table; also documented in code comments.

## Testing

- New/updated unit tests in `cmd/agent_smith/message_queue_test.go`: normal enqueue, back-pressure-blocks-then-succeeds, loud drop-on-drain (counter + notification), drain-unblocks-blocked-callback.
- New `internal/agent/device_test.go`: config resolution (unset/zero/negative fall back, positive honored).
- `go test -race ./...` passes.

## Acceptance criteria

- [x] Under sustained load commands are not silently lost (back-pressure → broker redelivery; teardown drops surfaced loudly + counter + plugin notification)
- [x] Shutdown/teardown completes promptly and cannot deadlock on a full queue
- [x] New queue behavior covered by unit tests including the full-queue path; `go test -race ./...` passes
- [x] Delivery guarantee and tunable capacity settings documented

## QA testing steps

1. Configure an agent with a small queue (`"worker_count": 1, "message_queue_size": 2`) and a slow command (e.g. `sleep 30`).
2. Fire a burst of ~10 workflow commands; confirm **all** eventually execute and post back — none silently lost.
3. While the queue is saturated, stop the service; confirm shutdown completes promptly (no hang) and any teardown-time drops appear as `Error` logs / `AgentMessageDropped` notifications, then redeliver on next start.
4. Verify default behavior (omit both config keys) is unchanged at 10 workers / 100 queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)