### PR TITLE
fix: [sc-97780] Spool exhausted postbacks to disk instead of dropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,40 @@ raising `worker_count` widens execution parallelism. Example snippet:
 }
 ```
 
+### Command Result Delivery
+
+After a command runs, the agent posts its result back to the Rewst engine with
+retry and exponential backoff. If every in-line attempt fails (network error or
+`5xx` across the whole retry budget), the result is **not dropped**:
+
+- The failure is surfaced beyond the log with a best-effort `AgentPostbackFailed:<post_id>`
+  plugin notification so monitoring can observe it.
+- The result is written to a **bounded on-disk spool** (under the agent's data
+  directory) and re-attempted on the next successful connection cycle. A
+  transient engine outage therefore recovers automatically once connectivity
+  returns, instead of losing the result.
+
+The spool is bounded by count and age (the oldest/expired entries are evicted)
+so it cannot grow without limit, and the flush is bound to the connection cycle
+so it never blocks shutdown.
+
+The in-line retry budget is tunable per deployment:
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `postback_max_attempts` | `3` | Total postback attempts (including the first try) before the result is spooled. |
+| `postback_base_retry_backoff_seconds` | `1` | Base delay for exponential backoff between attempts (`base * 2^(n-2)`). |
+
+Both fall back to their defaults when omitted or set to a non-positive value, so
+existing configurations are unaffected. Example snippet:
+
+```json
+{
+  "postback_max_attempts": 6,
+  "postback_base_retry_backoff_seconds": 2
+}
+```
+
 ## Build
 Required tools and packages:
 

--- a/cmd/agent_smith/postback_spool.go
+++ b/cmd/agent_smith/postback_spool.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
+)
+
+const (
+	// defaultSpoolMaxEntries bounds how many undelivered postbacks the on-disk
+	// spool retains. Older entries are evicted once this many accumulate so a
+	// prolonged engine outage cannot grow the spool without limit.
+	defaultSpoolMaxEntries = 100
+	// defaultSpoolMaxAge bounds how long an undelivered postback is retained.
+	// Entries older than this are discarded on the next enqueue or flush; a stale
+	// result is unlikely to be useful to a workflow that has long since timed out.
+	defaultSpoolMaxAge = 24 * time.Hour
+	// spoolFileSuffix is the extension used for spool entry files so unrelated
+	// files in the directory are ignored.
+	spoolFileSuffix = ".json"
+)
+
+// spoolEntry is the durable record of a command result whose postback could not
+// be delivered in-line. It carries everything needed to rebuild and retry the
+// postback on a later connection cycle.
+type spoolEntry struct {
+	PostId    string    `json:"post_id"`
+	Result    []byte    `json:"result"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// postbackSpool is a bounded, file-backed queue of command results whose
+// postback exhausted its in-line retry budget. Persisting them survives a
+// transient engine outage (or an agent restart) so the result is re-attempted
+// on a later cycle rather than lost.
+//
+// It is safe for concurrent use: command workers enqueue while a single flush
+// goroutine drains. Disk mutations during enqueue (directory creation, capacity
+// pruning, atomic file write) are serialized by mu, but flush deliberately does
+// not hold mu while performing network delivery so a slow engine cannot stall
+// workers — enqueue only ever creates new files and flush only ever reads or
+// removes existing ones, so the two never corrupt a shared file.
+type postbackSpool struct {
+	dir        string
+	maxEntries int
+	maxAge     time.Duration
+	logger     hclog.Logger
+
+	mu  sync.Mutex
+	seq uint64
+
+	// droppedTotal counts spool entries discarded because the spool was at
+	// capacity or an entry exceeded maxAge. Exposed for observability beyond the
+	// per-drop log line.
+	droppedTotal atomic.Int64
+}
+
+func newPostbackSpool(dir string, maxEntries int, maxAge time.Duration, logger hclog.Logger) *postbackSpool {
+	if maxEntries <= 0 {
+		maxEntries = defaultSpoolMaxEntries
+	}
+	if maxAge <= 0 {
+		maxAge = defaultSpoolMaxAge
+	}
+	return &postbackSpool{
+		dir:        dir,
+		maxEntries: maxEntries,
+		maxAge:     maxAge,
+		logger:     logger,
+	}
+}
+
+// enqueue persists entry for later delivery. The spool is kept within its
+// configured size and age bounds: expired entries and, if necessary, the oldest
+// entries are evicted before the new one is written. The write is atomic (temp
+// file + rename) so a flush never observes a partially written entry.
+func (s *postbackSpool) enqueue(entry spoolEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.dir, utils.DefaultDirMod); err != nil {
+		return fmt.Errorf("create spool dir: %w", err)
+	}
+
+	// Drop expired entries first, then evict oldest until there is room for one
+	// more (target maxEntries-1 so the new write lands at the cap).
+	s.pruneLocked(s.maxEntries - 1)
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal spool entry: %w", err)
+	}
+
+	s.seq++
+	name := fmt.Sprintf("%020d-%06d%s", entry.CreatedAt.UnixNano(), s.seq, spoolFileSuffix)
+	final := filepath.Join(s.dir, name)
+	tmp := final + ".tmp"
+
+	if err := os.WriteFile(tmp, data, utils.DefaultFileMod); err != nil {
+		return fmt.Errorf("write spool entry: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("commit spool entry: %w", err)
+	}
+	return nil
+}
+
+// pruneLocked removes expired entries and then, if more than keep entries
+// remain, evicts the oldest until keep remain. Callers must hold mu.
+func (s *postbackSpool) pruneLocked(keep int) {
+	files := s.listLocked()
+	if len(files) == 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-s.maxAge)
+	survivors := files[:0]
+	for _, name := range files {
+		if ts, ok := spoolFileTime(name); ok && ts.Before(cutoff) {
+			s.removeLocked(name, "expired")
+			continue
+		}
+		survivors = append(survivors, name)
+	}
+
+	if keep < 0 {
+		keep = 0
+	}
+	for len(survivors) > keep {
+		s.removeLocked(survivors[0], "capacity")
+		survivors = survivors[1:]
+	}
+}
+
+// listLocked returns the spool entry file names sorted oldest-first. The
+// timestamp-prefixed names sort chronologically by lexical order. Callers must
+// hold mu.
+func (s *postbackSpool) listLocked() []string {
+	dirEntries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.Error("Failed to read postback spool dir", "dir", s.dir, "error", err)
+		}
+		return nil
+	}
+
+	names := make([]string, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		if de.IsDir() || filepath.Ext(de.Name()) != spoolFileSuffix {
+			continue
+		}
+		names = append(names, de.Name())
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *postbackSpool) removeLocked(name, reason string) {
+	if err := os.Remove(filepath.Join(s.dir, name)); err != nil && !os.IsNotExist(err) {
+		s.logger.Error("Failed to remove spool entry", "file", name, "reason", reason, "error", err)
+		return
+	}
+	dropped := s.droppedTotal.Add(1)
+	s.logger.Error(
+		"Postback spool entry dropped",
+		"file", name,
+		"reason", reason,
+		"dropped_total", dropped,
+	)
+}
+
+// flush attempts to deliver each spooled entry oldest-first. deliver reports
+// done=true when the entry is resolved (delivered or permanently rejected), in
+// which case it is removed from the spool. A done=false result is treated as a
+// transient failure (the engine is still unreachable): flushing stops so the
+// remaining entries are retried on a later cycle, preserving order. Flushing
+// also stops promptly when ctx is cancelled so it never delays teardown.
+func (s *postbackSpool) flush(ctx context.Context, deliver func(spoolEntry) (bool, error)) {
+	s.mu.Lock()
+	names := s.listLocked()
+	s.mu.Unlock()
+
+	if len(names) == 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-s.maxAge)
+	delivered := 0
+	for _, name := range names {
+		if ctx.Err() != nil {
+			return
+		}
+
+		path := filepath.Join(s.dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				s.logger.Error("Failed to read spool entry", "file", name, "error", err)
+			}
+			continue
+		}
+
+		var entry spoolEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			// A corrupt entry can never be delivered; drop it rather than wedging
+			// the flush on it forever.
+			s.logger.Error("Discarding corrupt spool entry", "file", name, "error", err)
+			s.remove(name)
+			continue
+		}
+
+		if entry.CreatedAt.Before(cutoff) {
+			s.remove(name)
+			continue
+		}
+
+		done, derr := deliver(entry)
+		if !done {
+			// Engine still unreachable — stop and retry the rest next cycle.
+			if derr != nil {
+				s.logger.Info(
+					"Postback spool flush paused: engine still unreachable",
+					"post_id", entry.PostId,
+					"delivered", delivered,
+					"error", derr,
+				)
+			}
+			return
+		}
+		s.remove(name)
+		delivered++
+	}
+
+	if delivered > 0 {
+		s.logger.Info("Postback spool flushed", "delivered", delivered)
+	}
+}
+
+// remove deletes a spool entry that has been resolved during flush.
+func (s *postbackSpool) remove(name string) {
+	if err := os.Remove(filepath.Join(s.dir, name)); err != nil && !os.IsNotExist(err) {
+		s.logger.Error("Failed to remove spool entry", "file", name, "error", err)
+	}
+}
+
+// spoolFileTime parses the creation timestamp encoded in a spool file name
+// (the leading zero-padded unix-nano field). It returns ok=false for names that
+// do not match the expected format.
+func spoolFileTime(name string) (time.Time, bool) {
+	base := name[:len(name)-len(spoolFileSuffix)]
+	var nano, seq uint64
+	if _, err := fmt.Sscanf(base, "%020d-%06d", &nano, &seq); err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(0, int64(nano)), true
+}

--- a/cmd/agent_smith/postback_spool.go
+++ b/cmd/agent_smith/postback_spool.go
@@ -64,7 +64,12 @@ type postbackSpool struct {
 	droppedTotal atomic.Int64
 }
 
-func newPostbackSpool(dir string, maxEntries int, maxAge time.Duration, logger hclog.Logger) *postbackSpool {
+func newPostbackSpool(
+	dir string,
+	maxEntries int,
+	maxAge time.Duration,
+	logger hclog.Logger,
+) *postbackSpool {
 	if maxEntries <= 0 {
 		maxEntries = defaultSpoolMaxEntries
 	}

--- a/cmd/agent_smith/postback_spool_test.go
+++ b/cmd/agent_smith/postback_spool_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func newTestSpool(t *testing.T, maxEntries int, maxAge time.Duration) *postbackSpool {
+	t.Helper()
+	return newPostbackSpool(t.TempDir(), maxEntries, maxAge, hclog.NewNullLogger())
+}
+
+func countSpoolFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read spool dir: %v", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == spoolFileSuffix {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSpool_EnqueueFlushRoundTrip verifies that spooled entries are delivered
+// oldest-first and removed from disk once delivered.
+func TestSpool_EnqueueFlushRoundTrip(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+
+	for _, id := range []string{"a", "b", "c"} {
+		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+	}
+
+	var delivered []string
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		delivered = append(delivered, e.PostId)
+		return true, nil
+	})
+
+	want := []string{"a", "b", "c"}
+	if len(delivered) != len(want) {
+		t.Fatalf("expected %d deliveries, got %v", len(want), delivered)
+	}
+	for i := range want {
+		if delivered[i] != want[i] {
+			t.Errorf("delivery order mismatch at %d: got %q want %q", i, delivered[i], want[i])
+		}
+	}
+	if n := countSpoolFiles(t, s.dir); n != 0 {
+		t.Errorf("expected spool emptied after delivery, %d files remain", n)
+	}
+}
+
+// TestSpool_FlushStopsOnTransientFailure verifies that a transient (done=false)
+// result halts the flush and leaves every remaining entry on disk for a later
+// cycle, preserving order.
+func TestSpool_FlushStopsOnTransientFailure(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+
+	for _, id := range []string{"a", "b", "c"} {
+		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+	}
+
+	var attempts int
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		attempts++
+		return false, context.DeadlineExceeded // transient
+	})
+
+	if attempts != 1 {
+		t.Errorf("expected flush to stop after first transient failure, got %d attempts", attempts)
+	}
+	if n := countSpoolFiles(t, s.dir); n != 3 {
+		t.Errorf("expected all 3 entries retained, %d remain", n)
+	}
+}
+
+// TestSpool_CapacityBound verifies that the spool never exceeds maxEntries: the
+// oldest entries are evicted as new ones arrive.
+func TestSpool_CapacityBound(t *testing.T) {
+	s := newTestSpool(t, 3, time.Hour)
+
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+		// Distinct timestamps keep filename ordering deterministic.
+		time.Sleep(time.Millisecond)
+	}
+
+	if n := countSpoolFiles(t, s.dir); n != 3 {
+		t.Fatalf("expected spool capped at 3, got %d", n)
+	}
+	if got := s.droppedTotal.Load(); got != 2 {
+		t.Errorf("expected 2 capacity drops, got %d", got)
+	}
+
+	var delivered []string
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		delivered = append(delivered, e.PostId)
+		return true, nil
+	})
+	want := []string{"c", "d", "e"}
+	if len(delivered) != 3 {
+		t.Fatalf("expected 3 survivors, got %v", delivered)
+	}
+	for i := range want {
+		if delivered[i] != want[i] {
+			t.Errorf("expected newest entries retained; at %d got %q want %q", i, delivered[i], want[i])
+		}
+	}
+}
+
+// TestSpool_AgeBoundOnFlush verifies that entries older than maxAge are
+// discarded during flush without being delivered.
+func TestSpool_AgeBoundOnFlush(t *testing.T) {
+	s := newTestSpool(t, 10, 10*time.Millisecond)
+
+	if err := s.enqueue(spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	var attempts int
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		attempts++
+		return true, nil
+	})
+
+	if attempts != 0 {
+		t.Errorf("expected expired entry not to be delivered, got %d attempts", attempts)
+	}
+	if n := countSpoolFiles(t, s.dir); n != 0 {
+		t.Errorf("expected expired entry removed, %d remain", n)
+	}
+}
+
+// TestSpool_AgeBoundOnEnqueue verifies that a later enqueue prunes entries that
+// have aged out, bounding growth even without a flush.
+func TestSpool_AgeBoundOnEnqueue(t *testing.T) {
+	s := newTestSpool(t, 10, 10*time.Millisecond)
+
+	if err := s.enqueue(spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("enqueue old: %v", err)
+	}
+	time.Sleep(30 * time.Millisecond)
+	if err := s.enqueue(spoolEntry{PostId: "new", Result: []byte("y"), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("enqueue new: %v", err)
+	}
+
+	if n := countSpoolFiles(t, s.dir); n != 1 {
+		t.Fatalf("expected expired entry pruned on enqueue, %d files remain", n)
+	}
+
+	var delivered []string
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		delivered = append(delivered, e.PostId)
+		return true, nil
+	})
+	if len(delivered) != 1 || delivered[0] != "new" {
+		t.Errorf("expected only the fresh entry to survive, got %v", delivered)
+	}
+}
+
+// TestSpool_CorruptEntryDropped verifies a non-parseable spool file is discarded
+// rather than wedging the flush.
+func TestSpool_CorruptEntryDropped(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A valid-looking name but garbage contents.
+	bad := filepath.Join(s.dir, "00000000000000000001-000001"+spoolFileSuffix)
+	if err := os.WriteFile(bad, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	var attempts int
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		attempts++
+		return true, nil
+	})
+
+	if attempts != 0 {
+		t.Errorf("expected corrupt entry not to be delivered, got %d attempts", attempts)
+	}
+	if n := countSpoolFiles(t, s.dir); n != 0 {
+		t.Errorf("expected corrupt entry removed, %d remain", n)
+	}
+}
+
+// TestSpool_FlushContextCancelled verifies that a cancelled context stops the
+// flush before any delivery, so teardown is never delayed.
+func TestSpool_FlushContextCancelled(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+	if err := s.enqueue(spoolEntry{PostId: "a", Result: []byte("a"), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var attempts int
+	s.flush(ctx, func(e spoolEntry) (bool, error) {
+		attempts++
+		return true, nil
+	})
+
+	if attempts != 0 {
+		t.Errorf("expected no delivery on cancelled context, got %d", attempts)
+	}
+	if n := countSpoolFiles(t, s.dir); n != 1 {
+		t.Errorf("expected entry retained for a later cycle, %d remain", n)
+	}
+}
+
+// TestSpool_FlushEmptyNoop verifies flushing an empty/absent spool is a no-op.
+func TestSpool_FlushEmptyNoop(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+	var attempts int
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		attempts++
+		return true, nil
+	})
+	if attempts != 0 {
+		t.Errorf("expected no deliveries from empty spool, got %d", attempts)
+	}
+}
+
+// TestSpool_ResultPreserved verifies the result payload round-trips intact.
+func TestSpool_ResultPreserved(t *testing.T) {
+	s := newTestSpool(t, 10, time.Hour)
+	payload := []byte(`{"status":"ok","data":[1,2,3]}`)
+	if err := s.enqueue(spoolEntry{PostId: "id:1", Result: payload, CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var got []byte
+	s.flush(context.Background(), func(e spoolEntry) (bool, error) {
+		got = e.Result
+		return true, nil
+	})
+	if string(got) != string(payload) {
+		t.Errorf("result payload corrupted: got %q want %q", got, payload)
+	}
+}

--- a/cmd/agent_smith/postback_spool_test.go
+++ b/cmd/agent_smith/postback_spool_test.go
@@ -39,7 +39,9 @@ func TestSpool_EnqueueFlushRoundTrip(t *testing.T) {
 	s := newTestSpool(t, 10, time.Hour)
 
 	for _, id := range []string{"a", "b", "c"} {
-		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+		if err := s.enqueue(
+			spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()},
+		); err != nil {
 			t.Fatalf("enqueue %s: %v", id, err)
 		}
 	}
@@ -71,7 +73,9 @@ func TestSpool_FlushStopsOnTransientFailure(t *testing.T) {
 	s := newTestSpool(t, 10, time.Hour)
 
 	for _, id := range []string{"a", "b", "c"} {
-		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+		if err := s.enqueue(
+			spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()},
+		); err != nil {
 			t.Fatalf("enqueue %s: %v", id, err)
 		}
 	}
@@ -96,7 +100,9 @@ func TestSpool_CapacityBound(t *testing.T) {
 	s := newTestSpool(t, 3, time.Hour)
 
 	for _, id := range []string{"a", "b", "c", "d", "e"} {
-		if err := s.enqueue(spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()}); err != nil {
+		if err := s.enqueue(
+			spoolEntry{PostId: id, Result: []byte(id), CreatedAt: time.Now()},
+		); err != nil {
 			t.Fatalf("enqueue %s: %v", id, err)
 		}
 		// Distinct timestamps keep filename ordering deterministic.
@@ -121,7 +127,12 @@ func TestSpool_CapacityBound(t *testing.T) {
 	}
 	for i := range want {
 		if delivered[i] != want[i] {
-			t.Errorf("expected newest entries retained; at %d got %q want %q", i, delivered[i], want[i])
+			t.Errorf(
+				"expected newest entries retained; at %d got %q want %q",
+				i,
+				delivered[i],
+				want[i],
+			)
 		}
 	}
 }
@@ -131,7 +142,9 @@ func TestSpool_CapacityBound(t *testing.T) {
 func TestSpool_AgeBoundOnFlush(t *testing.T) {
 	s := newTestSpool(t, 10, 10*time.Millisecond)
 
-	if err := s.enqueue(spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()}); err != nil {
+	if err := s.enqueue(
+		spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()},
+	); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 	time.Sleep(30 * time.Millisecond)
@@ -155,11 +168,15 @@ func TestSpool_AgeBoundOnFlush(t *testing.T) {
 func TestSpool_AgeBoundOnEnqueue(t *testing.T) {
 	s := newTestSpool(t, 10, 10*time.Millisecond)
 
-	if err := s.enqueue(spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()}); err != nil {
+	if err := s.enqueue(
+		spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()},
+	); err != nil {
 		t.Fatalf("enqueue old: %v", err)
 	}
 	time.Sleep(30 * time.Millisecond)
-	if err := s.enqueue(spoolEntry{PostId: "new", Result: []byte("y"), CreatedAt: time.Now()}); err != nil {
+	if err := s.enqueue(
+		spoolEntry{PostId: "new", Result: []byte("y"), CreatedAt: time.Now()},
+	); err != nil {
 		t.Fatalf("enqueue new: %v", err)
 	}
 
@@ -208,7 +225,9 @@ func TestSpool_CorruptEntryDropped(t *testing.T) {
 // flush before any delivery, so teardown is never delayed.
 func TestSpool_FlushContextCancelled(t *testing.T) {
 	s := newTestSpool(t, 10, time.Hour)
-	if err := s.enqueue(spoolEntry{PostId: "a", Result: []byte("a"), CreatedAt: time.Now()}); err != nil {
+	if err := s.enqueue(
+		spoolEntry{PostId: "a", Result: []byte("a"), CreatedAt: time.Now()},
+	); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 
@@ -246,7 +265,9 @@ func TestSpool_FlushEmptyNoop(t *testing.T) {
 func TestSpool_ResultPreserved(t *testing.T) {
 	s := newTestSpool(t, 10, time.Hour)
 	payload := []byte(`{"status":"ok","data":[1,2,3]}`)
-	if err := s.enqueue(spoolEntry{PostId: "id:1", Result: payload, CreatedAt: time.Now()}); err != nil {
+	if err := s.enqueue(
+		spoolEntry{PostId: "id:1", Result: payload, CreatedAt: time.Now()},
+	); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 

--- a/cmd/agent_smith/process_message_test.go
+++ b/cmd/agent_smith/process_message_test.go
@@ -227,7 +227,13 @@ func TestProcessMessage_PostbackExhaustionSpoolsAndNotifies(t *testing.T) {
 	notifier := &recordingNotifierWrapper{}
 	device := deviceWithEngine(srv.Listener.Addr().String())
 
-	svc.processMessage(postbackPayload("echo hi", "id:exhaust-spool"), ctx, device, logger, notifier)
+	svc.processMessage(
+		postbackPayload("echo hi", "id:exhaust-spool"),
+		ctx,
+		device,
+		logger,
+		notifier,
+	)
 
 	// The failure must be surfaced beyond the log.
 	var notified bool

--- a/cmd/agent_smith/process_message_test.go
+++ b/cmd/agent_smith/process_message_test.go
@@ -205,6 +205,113 @@ func TestProcessMessage_PostbackFulfilled(t *testing.T) {
 	svc.processMessage(postbackPayload("echo hi", "id:fulfilled"), ctx, device, logger, notifier)
 }
 
+// TestProcessMessage_PostbackExhaustionSpoolsAndNotifies verifies that when the
+// in-line retry budget is exhausted the result is (a) surfaced via an
+// AgentPostbackFailed plugin notification carrying the post_id and (b) persisted
+// to the on-disk spool for later delivery rather than dropped.
+func TestProcessMessage_PostbackExhaustionSpoolsAndNotifies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"down"}`))
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{"ok":true}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+	svc.spool = newPostbackSpool(t.TempDir(), 10, time.Hour, hclog.NewNullLogger())
+
+	ctx := context.Background()
+	logger := hclog.NewNullLogger()
+	notifier := &recordingNotifierWrapper{}
+	device := deviceWithEngine(srv.Listener.Addr().String())
+
+	svc.processMessage(postbackPayload("echo hi", "id:exhaust-spool"), ctx, device, logger, notifier)
+
+	// The failure must be surfaced beyond the log.
+	var notified bool
+	for _, m := range notifier.all() {
+		if m == "AgentPostbackFailed:id:exhaust-spool" {
+			notified = true
+		}
+	}
+	if !notified {
+		t.Errorf("expected AgentPostbackFailed notification, got %v", notifier.all())
+	}
+
+	// The result must be persisted, not dropped.
+	if n := countSpoolFiles(t, svc.spool.dir); n != 1 {
+		t.Errorf("expected exhausted result spooled, got %d files", n)
+	}
+}
+
+// TestFlushPostbackSpool_DeliversSpooledResult verifies that a spooled result is
+// re-delivered (and removed) once the engine is reachable again.
+func TestFlushPostbackSpool_DeliversSpooledResult(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+	svc.spool = newPostbackSpool(t.TempDir(), 10, time.Hour, hclog.NewNullLogger())
+
+	if err := svc.spool.enqueue(spoolEntry{
+		PostId:    "id:recover",
+		Result:    []byte(`{}`),
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	device := deviceWithEngine(srv.Listener.Addr().String())
+	svc.flushPostbackSpool(context.Background(), device, hclog.NewNullLogger())
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected exactly one re-delivery, got %d", got)
+	}
+	if n := countSpoolFiles(t, svc.spool.dir); n != 0 {
+		t.Errorf("expected spool emptied after delivery, %d remain", n)
+	}
+}
+
+// TestFlushPostbackSpool_RetainsOnEngineDown verifies that a spooled result is
+// kept (not lost) when the engine is still unreachable during a flush.
+func TestFlushPostbackSpool_RetainsOnEngineDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"still down"}`))
+	}))
+	defer srv.Close()
+
+	exec := &mockExecutor{result: []byte(`{}`)}
+	svc := newProcessMessageSvc(exec, &http.Client{
+		Transport: &schemeRewriteTransport{scheme: "http"},
+	})
+	svc.spool = newPostbackSpool(t.TempDir(), 10, time.Hour, hclog.NewNullLogger())
+
+	if err := svc.spool.enqueue(spoolEntry{
+		PostId:    "id:still-down",
+		Result:    []byte(`{}`),
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	device := deviceWithEngine(srv.Listener.Addr().String())
+	svc.flushPostbackSpool(context.Background(), device, hclog.NewNullLogger())
+
+	if n := countSpoolFiles(t, svc.spool.dir); n != 1 {
+		t.Errorf("expected spooled result retained while engine down, %d remain", n)
+	}
+}
+
 // schemeRewriteTransport rewrites the request scheme before forwarding,
 // allowing tests to hit plain-HTTP servers when processMessage builds https URLs.
 type schemeRewriteTransport struct {

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -32,8 +33,8 @@ const (
 	workerCount              = agent.DefaultWorkerCount
 	messageQueueSize         = agent.DefaultMessageQueueSize
 	postbackHTTPTimeout      = 30 * time.Second
-	postbackMaxAttempts      = 3
-	postbackBaseRetryBackoff = 1 * time.Second
+	postbackMaxAttempts      = agent.DefaultPostbackMaxAttempts
+	postbackBaseRetryBackoff = agent.DefaultPostbackBaseRetryBackoff
 
 	// maxNotificationPayloadBytes bounds how many bytes of a received message
 	// payload are embedded in the AgentReceivedMessage notification forwarded to
@@ -127,6 +128,22 @@ func (svc *serviceContext) Execute(
 
 		logger = utils.ConfigureLogger("agent_smith", sysLogger, device.LoggingLevel)
 	}
+
+	// Resolve the postback retry budget from the device config, falling back to
+	// the documented defaults when unset. Existing deployments that omit these
+	// keys keep the previous behaviour.
+	svc.PostbackMaxAttempts = device.ResolvedPostbackMaxAttempts()
+	svc.PostbackBaseRetryBackoff = device.ResolvedPostbackBaseRetryBackoff()
+
+	// Create the durable postback spool so results that exhaust their in-line
+	// retry budget are persisted and re-attempted on a later cycle instead of
+	// being dropped.
+	svc.spool = newPostbackSpool(
+		filepath.Join(agent.GetDataDirectory(svc.OrgId), "postback_spool"),
+		defaultSpoolMaxEntries,
+		defaultSpoolMaxAge,
+		logger,
+	)
 
 	if !device.DisableAutoUpdates {
 		updater := agent.NewUpdater(
@@ -367,6 +384,13 @@ func (svc *serviceContext) runCycle(
 	logger.Info("Subscribed to messages", "topic", topic, "qos", qos)
 	_ = notifier.Notify("AgentStatus:Online") // Best effort notification
 
+	// Now that connectivity is restored, re-attempt any postbacks that were
+	// spooled to disk when the engine was previously unreachable. Run it on a
+	// cycle-scoped goroutine so it cannot block the connection loop or teardown.
+	utils.SafeGo(logger, func() {
+		svc.flushPostbackSpool(cycleCtx, device, logger)
+	}, "scope", "postback_spool_flush")
+
 	select {
 	case <-stopped:
 		_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
@@ -499,20 +523,23 @@ func (svc *serviceContext) processMessage(
 		return
 	}
 
-	svc.sendPostbackWithRetry(ctx, &message, device, resultBytes, logger)
+	svc.sendPostbackWithRetry(ctx, &message, device, resultBytes, logger, notifier)
 }
 
 // sendPostbackWithRetry posts the command result to the Rewst engine, retrying
 // transient failures (network errors and 5xx responses) with exponential
 // backoff. Non-retryable responses (2xx success, 400 "already fulfilled", and
-// other 4xx errors) terminate the loop immediately. When all attempts fail the
-// final failure is surfaced clearly so the result is not silently dropped.
+// other 4xx errors) terminate the loop immediately. When all in-line attempts
+// fail the result is not silently dropped: the failure is surfaced via a
+// best-effort AgentPostbackFailed plugin notification and the result is spooled
+// to disk for re-attempt on a later cycle.
 func (svc *serviceContext) sendPostbackWithRetry(
 	ctx context.Context,
 	message *interpreter.Message,
 	device agent.Device,
 	resultBytes []byte,
 	logger hclog.Logger,
+	notifier plugins.NotifierWrapper,
 ) {
 	maxAttempts := svc.PostbackMaxAttempts
 	if maxAttempts < 1 {
@@ -554,12 +581,62 @@ func (svc *serviceContext) sendPostbackWithRetry(
 		lastErr = err
 	}
 
+	// All in-line attempts failed. Surface the failure beyond the log and, when a
+	// spool is configured, persist the result for re-attempt on a later cycle so
+	// a transient engine outage does not silently lose it.
 	logger.Error(
-		"Postback failed: all retries exhausted, result dropped",
+		"Postback failed: all in-line retries exhausted",
 		"post_id", message.PostId,
 		"attempts", maxAttempts,
 		"last_error", lastErr,
 	)
+	_ = notifier.Notify(
+		fmt.Sprintf("AgentPostbackFailed:%s", message.PostId),
+	) // Best effort notification
+
+	if svc.spool == nil {
+		logger.Error("Postback result dropped: no spool configured", "post_id", message.PostId)
+		return
+	}
+
+	if err := svc.spool.enqueue(spoolEntry{
+		PostId:    message.PostId,
+		Result:    resultBytes,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		logger.Error(
+			"Postback result dropped: failed to spool for later delivery",
+			"post_id", message.PostId,
+			"error", err,
+		)
+		return
+	}
+
+	logger.Warn(
+		"Postback result spooled for later delivery",
+		"post_id", message.PostId,
+	)
+}
+
+// flushPostbackSpool re-attempts delivery of any command results whose in-line
+// postback previously exhausted its retry budget and was spooled to disk. Each
+// entry is given a single attempt: a success or permanent (4xx) rejection
+// removes it from the spool, while a transient failure leaves it (and the rest)
+// for a later cycle. It is bound to the cycle context so it neither blocks the
+// connection loop nor delays teardown — cycle cancellation aborts any in-flight
+// request and stops the flush between entries.
+func (svc *serviceContext) flushPostbackSpool(
+	ctx context.Context,
+	device agent.Device,
+	logger hclog.Logger,
+) {
+	if svc.spool == nil {
+		return
+	}
+	svc.spool.flush(ctx, func(entry spoolEntry) (bool, error) {
+		msg := &interpreter.Message{PostId: entry.PostId}
+		return svc.attemptPostback(ctx, msg, device, entry.Result, logger, 1)
+	})
 }
 
 // attemptPostback performs a single postback attempt. It returns done=true

--- a/cmd/agent_smith/service_context.go
+++ b/cmd/agent_smith/service_context.go
@@ -30,6 +30,13 @@ type serviceContext struct {
 	// between postback attempts. Defaults to postbackBaseRetryBackoff.
 	PostbackBaseRetryBackoff time.Duration
 
+	// spool is the bounded on-disk fallback for command results whose postback
+	// exhausted its in-line retry budget. It survives transient engine outages so
+	// results are re-attempted on a later cycle rather than dropped. It may be nil
+	// (e.g. in unit tests that exercise postback logic in isolation), in which
+	// case exhausted results are surfaced via log and plugin notification only.
+	spool *postbackSpool
+
 	// droppedMessages counts inbound messages the agent could not accept and had
 	// to discard. Under normal operation the subscribe callback applies
 	// back-pressure instead of dropping, so this only increments when a payload

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -37,6 +37,16 @@ type Device struct {
 	// queue absorbs bigger bursts before the agent starts applying back-pressure
 	// to the broker.
 	MessageQueueSize *int `json:"message_queue_size,omitempty"`
+	// PostbackMaxAttempts optionally overrides the total number of postback
+	// attempts (including the initial try) before a command result is spooled to
+	// disk for later delivery. When unset (or non-positive) the agent falls back
+	// to DefaultPostbackMaxAttempts. Raising it widens the in-line retry window
+	// for transient engine outages.
+	PostbackMaxAttempts *int `json:"postback_max_attempts,omitempty"`
+	// PostbackBaseRetryBackoffSeconds optionally overrides the base delay used for
+	// exponential backoff between postback attempts, in seconds. When unset (or
+	// non-positive) the agent falls back to DefaultPostbackBaseRetryBackoff.
+	PostbackBaseRetryBackoffSeconds *int `json:"postback_base_retry_backoff_seconds,omitempty"`
 }
 
 const (
@@ -46,6 +56,13 @@ const (
 	// DefaultMessageQueueSize is the buffered inbound message queue capacity used
 	// when MessageQueueSize is not configured.
 	DefaultMessageQueueSize = 100
+	// DefaultPostbackMaxAttempts is the total number of postback attempts used
+	// when PostbackMaxAttempts is not configured.
+	DefaultPostbackMaxAttempts = 3
+	// DefaultPostbackBaseRetryBackoff is the base exponential-backoff delay used
+	// between postback attempts when PostbackBaseRetryBackoffSeconds is not
+	// configured.
+	DefaultPostbackBaseRetryBackoff = 1 * time.Second
 )
 
 // ResolvedWorkerCount returns the number of command-execution workers to start,
@@ -66,6 +83,26 @@ func (d Device) ResolvedMessageQueueSize() int {
 		return *d.MessageQueueSize
 	}
 	return DefaultMessageQueueSize
+}
+
+// ResolvedPostbackMaxAttempts returns the total number of postback attempts,
+// honoring the per-device override when set to a positive value and falling back
+// to DefaultPostbackMaxAttempts otherwise.
+func (d Device) ResolvedPostbackMaxAttempts() int {
+	if d.PostbackMaxAttempts != nil && *d.PostbackMaxAttempts > 0 {
+		return *d.PostbackMaxAttempts
+	}
+	return DefaultPostbackMaxAttempts
+}
+
+// ResolvedPostbackBaseRetryBackoff returns the base exponential-backoff delay
+// between postback attempts, honoring the per-device override when set to a
+// positive value and falling back to DefaultPostbackBaseRetryBackoff otherwise.
+func (d Device) ResolvedPostbackBaseRetryBackoff() time.Duration {
+	if d.PostbackBaseRetryBackoffSeconds != nil && *d.PostbackBaseRetryBackoffSeconds > 0 {
+		return time.Duration(*d.PostbackBaseRetryBackoffSeconds) * time.Second
+	}
+	return DefaultPostbackBaseRetryBackoff
 }
 
 // MqttConnectTimeout returns the per-attempt MQTT connect timeout, honoring the

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func intPtr(v int) *int { return &v }
 
@@ -43,6 +46,50 @@ func TestResolvedMessageQueueSize(t *testing.T) {
 			d := Device{MessageQueueSize: tt.value}
 			if got := d.ResolvedMessageQueueSize(); got != tt.expect {
 				t.Errorf("ResolvedMessageQueueSize() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestResolvedPostbackMaxAttempts(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect int
+	}{
+		{"unset falls back to default", nil, DefaultPostbackMaxAttempts},
+		{"zero falls back to default", intPtr(0), DefaultPostbackMaxAttempts},
+		{"negative falls back to default", intPtr(-3), DefaultPostbackMaxAttempts},
+		{"positive override honored", intPtr(10), 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{PostbackMaxAttempts: tt.value}
+			if got := d.ResolvedPostbackMaxAttempts(); got != tt.expect {
+				t.Errorf("ResolvedPostbackMaxAttempts() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestResolvedPostbackBaseRetryBackoff(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect time.Duration
+	}{
+		{"unset falls back to default", nil, DefaultPostbackBaseRetryBackoff},
+		{"zero falls back to default", intPtr(0), DefaultPostbackBaseRetryBackoff},
+		{"negative falls back to default", intPtr(-2), DefaultPostbackBaseRetryBackoff},
+		{"positive override honored", intPtr(5), 5 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{PostbackBaseRetryBackoffSeconds: tt.value}
+			if got := d.ResolvedPostbackBaseRetryBackoff(); got != tt.expect {
+				t.Errorf("ResolvedPostbackBaseRetryBackoff() = %v, want %v", got, tt.expect)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Command results are no longer silently dropped when the Rewst engine is temporarily unreachable. When in-line postback retries are exhausted, the result is surfaced via a plugin notification and persisted to a bounded on-disk spool, then re-attempted on the next successful connection cycle.

Fixes sc-97780.

## Changes

- **Durable spool** (`cmd/agent_smith/postback_spool.go`): bounded, file-backed queue of undelivered postbacks (atomic temp-file + rename). Bounded by count (100) and age (24h) — oldest/expired entries are evicted so it can't grow without limit. Concurrency-safe: workers enqueue under a mutex; flush snapshots then delivers without holding the lock so a slow engine never stalls workers. Corrupt entries are discarded rather than wedging the flush.
- **Surfaced beyond the log**: on exhaustion, a best-effort `AgentPostbackFailed:<post_id>` plugin notification is emitted and the result is spooled (logged at `Warn`, not "dropped").
- **Re-delivery on a later cycle**: after each successful connection, a cycle-scoped goroutine re-attempts spooled entries; success/terminal-4xx removes the entry, a transient failure stops and keeps the rest.
- **Configurable retry budget**: new config keys `postback_max_attempts` and `postback_base_retry_backoff_seconds` with `Resolved*` accessors falling back to the existing defaults (3 attempts / 1s) when unset — existing behavior preserved.
- **Shutdown safety**: the flush runs via `utils.SafeGo` bound to the cycle context (not in the worker WaitGroup), so teardown isn't blocked and context cancellation aborts in-flight retries promptly.
- Docs added to `README.md`.

## Acceptance criteria

- [x] Exhausted retries surfaced beyond a single error log (notification + durable record)
- [x] Transient-outage results recoverable from a bounded on-disk spool
- [x] Retry count and base backoff configurable with documented defaults; default behavior preserved when unset
- [x] Teardown not blocked; context cancellation still aborts in-flight retries
- [x] New behavior covered by unit tests including the all-retries-exhausted path; `go test -race ./...` passes

## Testing

`go test -race ./...`, `go vet ./...`, and `gofmt` all clean. New tests cover the spool (roundtrip/ordering, transient-stop, capacity & age bounds, corrupt-entry, context-cancel), the exhaustion→spool→notify path, flush re-delivery and retain-on-engine-down, and config resolution.

## QA steps

1. Run the agent against a workflow that posts a result with the engine **down**. Confirm logs show retries, then an `AgentPostbackFailed:<post_id>` notification, and a spool file appears under `<data-dir>/postback_spool/`.
2. Bring the engine back; on the next reconnect confirm the spooled result is delivered and the file is removed.
3. Set `postback_max_attempts` / `postback_base_retry_backoff_seconds`; confirm attempt count and backoff timing change, and omitting them preserves the 3-attempt / 1s default.
4. Stop the service mid-outage; confirm shutdown is prompt and the spool file persists for delivery after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)