### PR TITLE
fix: [sc-102471] Remove unsupported MQTT QoS 2 for Azure IoT Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rewst_agent_config.win.exe --org-id YOUR_ORG_ID --config-url CONFIG_URL --config
 - `--syslog`: Write logs to system log instead of file (Linux/macOS)
 - `--disable-agent-postback`: Disable agent postback
 - `--no-auto-updates`: Disable auto updates
-- `--mqtt-qos`: MQTT subscription QoS level (`0` = at-most-once, `1` = at-least-once, `2` = exactly-once). Defaults to `1` when omitted.
+- `--mqtt-qos`: MQTT subscription QoS level (`0` = at-most-once, `1` = at-least-once). Defaults to `1` when omitted. Azure IoT Hub does not support QoS 2.
 
 Example with optional parameters:
 ```bash

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -58,7 +58,7 @@ func newConfigFlagSet(params *configContext) *flag.FlagSet {
 	)
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
-	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0 or 1)")
 	fs.StringVar(
 		&params.ServiceUsername,
 		"service-username",
@@ -107,8 +107,8 @@ func newConfigContext(
 		return nil, fmt.Errorf("invalid logging-level")
 	}
 
-	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
-		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
+	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 1) {
+		return nil, fmt.Errorf("invalid mqtt-qos: must be 0 or 1")
 	}
 
 	if params.ServicePassword != "" && params.ServiceUsername == "" {

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -47,12 +47,12 @@ func TestNewConfigContext(t *testing.T) {
 			"--org-id", orgId,
 			"--config-url", configUrl,
 			"--config-secret", configSecret,
-			"--mqtt-qos", "2",
+			"--mqtt-qos", "1",
 		},
 		nil, nil, nil, nil,
 	)
-	if resultWithQos.MqttQos != 2 {
-		t.Errorf("expected MqttQos 2, got %v", resultWithQos.MqttQos)
+	if resultWithQos.MqttQos != 1 {
+		t.Errorf("expected MqttQos 1, got %v", resultWithQos.MqttQos)
 	}
 
 	if result.ServiceUsername != "" {
@@ -116,7 +116,7 @@ func TestNewConfigContext(t *testing.T) {
 				"--config-secret",
 				configSecret,
 				"--mqtt-qos",
-				"3",
+				"2",
 			},
 			"invalid mqtt-qos",
 		},

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -64,8 +64,8 @@ func (svc *serviceContext) loadConfig() (agent.Device, error) {
 		return device, err
 	}
 
-	if device.MqttQos != nil && *device.MqttQos > 2 {
-		return device, fmt.Errorf("mqtt_qos must be 0, 1, or 2; got %d", *device.MqttQos)
+	if device.MqttQos != nil && *device.MqttQos > 1 {
+		return device, fmt.Errorf("mqtt_qos must be 0 or 1; got %d", *device.MqttQos)
 	}
 
 	return device, nil

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -109,7 +109,7 @@ func TestLoadConfig_MqttQos(t *testing.T) {
 		{name: "qos_absent_defaults_to_1", mqttQos: nil, expectError: false},
 		{name: "qos_0_accepted", mqttQos: qos(0), expectError: false},
 		{name: "qos_1_accepted", mqttQos: qos(1), expectError: false},
-		{name: "qos_2_accepted", mqttQos: qos(2), expectError: false},
+		{name: "qos_2_rejected", mqttQos: qos(2), expectError: true},
 		{name: "qos_3_rejected", mqttQos: qos(3), expectError: true},
 	}
 
@@ -1120,9 +1120,9 @@ func TestExecute_SubscribedMessagesLogIncludesQoS(t *testing.T) {
 			expectedQoS: "qos=0",
 		},
 		{
-			name:        "explicit_qos_2",
-			mqttQos:     func() *byte { b := byte(2); return &b }(),
-			expectedQoS: "qos=2",
+			name:        "explicit_qos_1",
+			mqttQos:     func() *byte { b := byte(1); return &b }(),
+			expectedQoS: "qos=1",
 		},
 	}
 

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -51,7 +51,7 @@ func newUpdateFlagSet(params *updateContext) *flag.FlagSet {
 	)
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
-	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0, 1, or 2)")
+	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0 or 1)")
 	fs.StringVar(
 		&params.ServiceUsername,
 		"service-username",
@@ -96,8 +96,8 @@ func newUpdateContext(
 		return nil, fmt.Errorf("invalid logging-level")
 	}
 
-	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 2) {
-		return nil, fmt.Errorf("invalid mqtt-qos: must be 0, 1, or 2")
+	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 1) {
+		return nil, fmt.Errorf("invalid mqtt-qos: must be 0 or 1")
 	}
 
 	if params.ServicePassword != "" && params.ServiceUsername == "" {

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -75,7 +75,7 @@ func TestNewUpdateContext(t *testing.T) {
 			"invalid logging-level",
 		},
 		{
-			[]string{"--org-id", orgId, "--update", "--mqtt-qos", "3"},
+			[]string{"--org-id", orgId, "--update", "--mqtt-qos", "2"},
 			"invalid mqtt-qos",
 		},
 		{

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -45,7 +45,7 @@ type operationalMode struct {
 // historical one-line usage string so existing behavior is preserved.
 func operationalModes() []operationalMode {
 	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1|2] [--service-username <USER>] [--service-password <PASS>]",
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1] [--service-username <USER>] [--service-password <PASS>]",
 		getAllowedConfigLevelsString("|"),
 	)
 

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -203,7 +203,7 @@ func TestReportUsageModeErrors(t *testing.T) {
 				"5",
 			},
 			mode:    "config",
-			wantErr: "invalid mqtt-qos: must be 0, 1, or 2",
+			wantErr: "invalid mqtt-qos: must be 0 or 1",
 		},
 		{
 			name: "config invalid logging-level",
@@ -230,7 +230,7 @@ func TestReportUsageModeErrors(t *testing.T) {
 			name:    "update invalid mqtt-qos",
 			args:    []string{"--org-id", "x", "--update", "--mqtt-qos", "5"},
 			mode:    "update",
-			wantErr: "invalid mqtt-qos: must be 0, 1, or 2",
+			wantErr: "invalid mqtt-qos: must be 0 or 1",
 		},
 		{
 			name:    "update missing org-id",


### PR DESCRIPTION
## Summary

Azure IoT Hub does not support MQTT QoS 2, but the agent previously accepted `--mqtt-qos 2` and persisted it, later attempting to subscribe at QoS 2 — which IoT Hub rejects/downgrades or drops the connection for, silently breaking command delivery for that device. This restricts the accepted QoS values to `0` and `1`.

## Changes

- **Config mode** (`config_context.go`): `--mqtt-qos` accepts only 0 or 1; passing 2 fails validation (`invalid mqtt-qos: must be 0 or 1`) before any config file is written.
- **Update mode** (`update_context.go`): `--mqtt-qos` accepts only 0 or 1; passing 2 errors out and leaves the existing config unchanged.
- **Runtime validation** (`service.go`): a persisted `mqtt_qos` of 2 (e.g. hand-edited config) is now caught at startup with a clear error instead of attempting an unsupported subscription.
- **Usage/help text** (`usage.go`) and flag descriptions now advertise `0|1`.
- **README**: documents that Azure IoT Hub does not support QoS 2.
- Default behavior is unchanged: when `--mqtt-qos` is omitted, the agent still subscribes at QoS 1.

## Testing

- `go build ./...` and `go test ./cmd/agent_smith/` pass.
- Updated tests to assert QoS 2 is rejected in config mode, update mode, and runtime device validation, and that the new error message is surfaced.