### PR TITLE
feat: [sc-102474] Expose MQTT/worker/postback tuning parameters as flags

### DIFF
--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -120,11 +120,15 @@ func runConfig(params *configContext) error {
 	// Apply the optional tuning overrides. Each field is set only when the
 	// operator provided the flag, otherwise it stays nil so the agent falls
 	// back to its documented default.
-	response.Configuration.MqttConnectTimeoutSeconds = tuningPtr(params.Tuning.MqttConnectTimeoutSeconds)
+	response.Configuration.MqttConnectTimeoutSeconds = tuningPtr(
+		params.Tuning.MqttConnectTimeoutSeconds,
+	)
 	response.Configuration.WorkerCount = tuningPtr(params.Tuning.WorkerCount)
 	response.Configuration.MessageQueueSize = tuningPtr(params.Tuning.MessageQueueSize)
 	response.Configuration.PostbackMaxAttempts = tuningPtr(params.Tuning.PostbackMaxAttempts)
-	response.Configuration.PostbackBaseRetryBackoffSeconds = tuningPtr(params.Tuning.PostbackBaseRetryBackoffSeconds)
+	response.Configuration.PostbackBaseRetryBackoffSeconds = tuningPtr(
+		params.Tuning.PostbackBaseRetryBackoffSeconds,
+	)
 
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -117,6 +117,15 @@ func runConfig(params *configContext) error {
 		response.Configuration.MqttQos = &qos
 	}
 
+	// Apply the optional tuning overrides. Each field is set only when the
+	// operator provided the flag, otherwise it stays nil so the agent falls
+	// back to its documented default.
+	response.Configuration.MqttConnectTimeoutSeconds = tuningPtr(params.Tuning.MqttConnectTimeoutSeconds)
+	response.Configuration.WorkerCount = tuningPtr(params.Tuning.WorkerCount)
+	response.Configuration.MessageQueueSize = tuningPtr(params.Tuning.MessageQueueSize)
+	response.Configuration.PostbackMaxAttempts = tuningPtr(params.Tuning.PostbackMaxAttempts)
+	response.Configuration.PostbackBaseRetryBackoffSeconds = tuningPtr(params.Tuning.PostbackBaseRetryBackoffSeconds)
+
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)
 	err = params.FS.MkdirAll(dataDir)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -14,6 +14,121 @@ import (
 
 const configHTTPTimeout = 5 * time.Minute
 
+// tuningFlagUnset is the sentinel default for the optional integer tuning flags
+// (e.g. --worker-count). It mirrors the --mqtt-qos sentinel pattern: the value
+// is only applied to the configuration when the operator explicitly provides a
+// flag, otherwise the agent falls back to its documented default.
+const tuningFlagUnset = -1
+
+// tuningFlags groups the optional integer tuning parameters shared by config and
+// update modes. Each field defaults to tuningFlagUnset so an omitted flag leaves
+// the corresponding configuration field alone.
+type tuningFlags struct {
+	MqttConnectTimeoutSeconds       int
+	WorkerCount                     int
+	MessageQueueSize                int
+	PostbackMaxAttempts             int
+	PostbackBaseRetryBackoffSeconds int
+	// provided records which tuning flag names the operator explicitly set. It is
+	// populated from flag.FlagSet.Visit after parsing so validation can flag an
+	// explicitly-provided non-positive value (e.g. --worker-count -1) even when it
+	// collides with the unset sentinel.
+	provided map[string]bool
+}
+
+// tuningFlagNames lists the flag names bound by bindTuningFlags, in the order
+// they appear in usage output.
+var tuningFlagNames = []string{
+	"mqtt-connect-timeout-seconds",
+	"worker-count",
+	"message-queue-size",
+	"postback-max-attempts",
+	"postback-base-retry-backoff-seconds",
+}
+
+// captureProvided records which tuning flags were explicitly set on fs so that
+// validation can distinguish an omitted flag from one that was given a value
+// (including an invalid negative value that matches the unset sentinel).
+func (t *tuningFlags) captureProvided(fs *flag.FlagSet) {
+	names := map[string]bool{}
+	for _, name := range tuningFlagNames {
+		names[name] = true
+	}
+	t.provided = map[string]bool{}
+	fs.Visit(func(f *flag.Flag) {
+		if names[f.Name] {
+			t.provided[f.Name] = true
+		}
+	})
+}
+
+// bindTuningFlags registers the shared tuning flags on fs so config and update
+// modes expose an identical set of options with identical descriptions.
+func bindTuningFlags(fs *flag.FlagSet, t *tuningFlags) {
+	fs.IntVar(
+		&t.MqttConnectTimeoutSeconds,
+		"mqtt-connect-timeout-seconds",
+		tuningFlagUnset,
+		"MQTT connect timeout in seconds (positive integer)",
+	)
+	fs.IntVar(
+		&t.WorkerCount,
+		"worker-count",
+		tuningFlagUnset,
+		"Number of concurrent command-execution workers (positive integer)",
+	)
+	fs.IntVar(
+		&t.MessageQueueSize,
+		"message-queue-size",
+		tuningFlagUnset,
+		"Capacity of the inbound message queue (positive integer)",
+	)
+	fs.IntVar(
+		&t.PostbackMaxAttempts,
+		"postback-max-attempts",
+		tuningFlagUnset,
+		"Total postback attempts before spooling to disk (positive integer)",
+	)
+	fs.IntVar(
+		&t.PostbackBaseRetryBackoffSeconds,
+		"postback-base-retry-backoff-seconds",
+		tuningFlagUnset,
+		"Base exponential-backoff delay between postback attempts in seconds (positive integer)",
+	)
+}
+
+// validate rejects any tuning flag that was explicitly provided with a
+// non-positive value. Flags left unset are ignored so the agent falls back to
+// its documented default.
+func (t tuningFlags) validate() error {
+	checks := []struct {
+		name  string
+		value int
+	}{
+		{"mqtt-connect-timeout-seconds", t.MqttConnectTimeoutSeconds},
+		{"worker-count", t.WorkerCount},
+		{"message-queue-size", t.MessageQueueSize},
+		{"postback-max-attempts", t.PostbackMaxAttempts},
+		{"postback-base-retry-backoff-seconds", t.PostbackBaseRetryBackoffSeconds},
+	}
+	for _, c := range checks {
+		if t.provided[c.name] && c.value <= 0 {
+			return fmt.Errorf("invalid %s: must be a positive integer", c.name)
+		}
+	}
+	return nil
+}
+
+// tuningPtr returns a pointer to value when the flag was explicitly provided, or
+// nil when it was left at the unset sentinel (fall back to default).
+func tuningPtr(value int) *int {
+	if value == tuningFlagUnset {
+		return nil
+	}
+	v := value
+	return &v
+}
+
 type configContext struct {
 	OrgId                string
 	ConfigUrl            string
@@ -26,6 +141,7 @@ type configContext struct {
 	MqttQos              int
 	ServiceUsername      string
 	ServicePassword      string
+	Tuning               tuningFlags
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -59,6 +175,7 @@ func newConfigFlagSet(params *configContext) *flag.FlagSet {
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0 or 1)")
+	bindTuningFlags(fs, &params.Tuning)
 	fs.StringVar(
 		&params.ServiceUsername,
 		"service-username",
@@ -91,6 +208,8 @@ func newConfigContext(
 		return nil, err
 	}
 
+	params.Tuning.captureProvided(fs)
+
 	if params.OrgId == "" {
 		return nil, fmt.Errorf("missing org-id")
 	}
@@ -109,6 +228,10 @@ func newConfigContext(
 
 	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 1) {
 		return nil, fmt.Errorf("invalid mqtt-qos: must be 0 or 1")
+	}
+
+	if err := params.Tuning.validate(); err != nil {
+		return nil, err
 	}
 
 	if params.ServicePassword != "" && params.ServiceUsername == "" {

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -86,6 +86,48 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf("expected ServicePassword %q, got %q", "p@ss", resultWithCreds.ServicePassword)
 	}
 
+	// Tuning flags default to the unset sentinel when omitted.
+	if result.Tuning.MqttConnectTimeoutSeconds != tuningFlagUnset ||
+		result.Tuning.WorkerCount != tuningFlagUnset ||
+		result.Tuning.MessageQueueSize != tuningFlagUnset ||
+		result.Tuning.PostbackMaxAttempts != tuningFlagUnset ||
+		result.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset {
+		t.Errorf("expected tuning flags to default to unset, got %+v", result.Tuning)
+	}
+
+	// Tuning flags are parsed when provided.
+	resultWithTuning, err := newConfigContext(
+		[]string{
+			"--org-id", orgId,
+			"--config-url", configUrl,
+			"--config-secret", configSecret,
+			"--mqtt-connect-timeout-seconds", "45",
+			"--worker-count", "20",
+			"--message-queue-size", "250",
+			"--postback-max-attempts", "5",
+			"--postback-base-retry-backoff-seconds", "2",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error with tuning flags, got %v", err)
+	}
+	if resultWithTuning.Tuning.MqttConnectTimeoutSeconds != 45 {
+		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", resultWithTuning.Tuning.MqttConnectTimeoutSeconds)
+	}
+	if resultWithTuning.Tuning.WorkerCount != 20 {
+		t.Errorf("expected WorkerCount 20, got %v", resultWithTuning.Tuning.WorkerCount)
+	}
+	if resultWithTuning.Tuning.MessageQueueSize != 250 {
+		t.Errorf("expected MessageQueueSize 250, got %v", resultWithTuning.Tuning.MessageQueueSize)
+	}
+	if resultWithTuning.Tuning.PostbackMaxAttempts != 5 {
+		t.Errorf("expected PostbackMaxAttempts 5, got %v", resultWithTuning.Tuning.PostbackMaxAttempts)
+	}
+	if resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds != 2 {
+		t.Errorf("expected PostbackBaseRetryBackoffSeconds 2, got %v", resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -132,6 +174,51 @@ func TestNewConfigContext(t *testing.T) {
 				"p@ss",
 			},
 			"service-password requires service-username",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--worker-count", "-1",
+			},
+			"invalid worker-count: must be a positive integer",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--message-queue-size", "0",
+			},
+			"invalid message-queue-size: must be a positive integer",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--postback-max-attempts", "abc",
+			},
+			"invalid value",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--mqtt-connect-timeout-seconds", "0",
+			},
+			"invalid mqtt-connect-timeout-seconds: must be a positive integer",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--postback-base-retry-backoff-seconds", "-5",
+			},
+			"invalid postback-base-retry-backoff-seconds: must be a positive integer",
 		},
 	}
 

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -113,7 +113,10 @@ func TestNewConfigContext(t *testing.T) {
 		t.Fatalf("expected no error with tuning flags, got %v", err)
 	}
 	if resultWithTuning.Tuning.MqttConnectTimeoutSeconds != 45 {
-		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", resultWithTuning.Tuning.MqttConnectTimeoutSeconds)
+		t.Errorf(
+			"expected MqttConnectTimeoutSeconds 45, got %v",
+			resultWithTuning.Tuning.MqttConnectTimeoutSeconds,
+		)
 	}
 	if resultWithTuning.Tuning.WorkerCount != 20 {
 		t.Errorf("expected WorkerCount 20, got %v", resultWithTuning.Tuning.WorkerCount)
@@ -122,10 +125,16 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf("expected MessageQueueSize 250, got %v", resultWithTuning.Tuning.MessageQueueSize)
 	}
 	if resultWithTuning.Tuning.PostbackMaxAttempts != 5 {
-		t.Errorf("expected PostbackMaxAttempts 5, got %v", resultWithTuning.Tuning.PostbackMaxAttempts)
+		t.Errorf(
+			"expected PostbackMaxAttempts 5, got %v",
+			resultWithTuning.Tuning.PostbackMaxAttempts,
+		)
 	}
 	if resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds != 2 {
-		t.Errorf("expected PostbackBaseRetryBackoffSeconds 2, got %v", resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds)
+		t.Errorf(
+			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
+			resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds,
+		)
 	}
 
 	errorTests := []struct {

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -474,6 +474,110 @@ func TestRunConfig_PasswordNotPersistedToDisk(t *testing.T) {
 	}
 }
 
+// findWrittenConfig returns the bytes written to the config file (identified by
+// its JSON device_id field) among all files captured by a writeFileFunc mock.
+func findWrittenConfig(t *testing.T, writes map[string][]byte) agent.Device {
+	t.Helper()
+	for _, data := range writes {
+		var device agent.Device
+		if err := json.Unmarshal(data, &device); err == nil && device.DeviceId != "" {
+			return device
+		}
+	}
+	t.Fatalf("no config file was written")
+	return agent.Device{}
+}
+
+func TestRunConfig_AppliesTuningFlags(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	writtenFiles := map[string][]byte{}
+	params := newBaseConfigParams(srv.URL)
+	params.FS = &mockFileSystem{
+		mkdirAllFunc: func(string) error { return nil },
+		writeFileFunc: func(name string, data []byte, _ os.FileMode) error {
+			writtenFiles[name] = data
+			return nil
+		},
+		readFileFunc:   func(string) ([]byte, error) { return []byte("binary"), nil },
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+	}
+	params.Tuning = tuningFlags{
+		MqttConnectTimeoutSeconds:       45,
+		WorkerCount:                     20,
+		MessageQueueSize:                250,
+		PostbackMaxAttempts:             5,
+		PostbackBaseRetryBackoffSeconds: 2,
+	}
+
+	if err := runConfig(params); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	device := findWrittenConfig(t, writtenFiles)
+	if device.MqttConnectTimeoutSeconds == nil || *device.MqttConnectTimeoutSeconds != 45 {
+		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", device.MqttConnectTimeoutSeconds)
+	}
+	if device.WorkerCount == nil || *device.WorkerCount != 20 {
+		t.Errorf("expected WorkerCount 20, got %v", device.WorkerCount)
+	}
+	if device.MessageQueueSize == nil || *device.MessageQueueSize != 250 {
+		t.Errorf("expected MessageQueueSize 250, got %v", device.MessageQueueSize)
+	}
+	if device.PostbackMaxAttempts == nil || *device.PostbackMaxAttempts != 5 {
+		t.Errorf("expected PostbackMaxAttempts 5, got %v", device.PostbackMaxAttempts)
+	}
+	if device.PostbackBaseRetryBackoffSeconds == nil || *device.PostbackBaseRetryBackoffSeconds != 2 {
+		t.Errorf(
+			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
+			device.PostbackBaseRetryBackoffSeconds,
+		)
+	}
+}
+
+func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	writtenFiles := map[string][]byte{}
+	params := newBaseConfigParams(srv.URL)
+	params.FS = &mockFileSystem{
+		mkdirAllFunc: func(string) error { return nil },
+		writeFileFunc: func(name string, data []byte, _ os.FileMode) error {
+			writtenFiles[name] = data
+			return nil
+		},
+		readFileFunc:   func(string) ([]byte, error) { return []byte("binary"), nil },
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+	}
+	// Mirror the sentinel defaults a real invocation would carry.
+	params.Tuning = tuningFlags{
+		MqttConnectTimeoutSeconds:       tuningFlagUnset,
+		WorkerCount:                     tuningFlagUnset,
+		MessageQueueSize:                tuningFlagUnset,
+		PostbackMaxAttempts:             tuningFlagUnset,
+		PostbackBaseRetryBackoffSeconds: tuningFlagUnset,
+	}
+
+	if err := runConfig(params); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	device := findWrittenConfig(t, writtenFiles)
+	if device.MqttConnectTimeoutSeconds != nil ||
+		device.WorkerCount != nil ||
+		device.MessageQueueSize != nil ||
+		device.PostbackMaxAttempts != nil ||
+		device.PostbackBaseRetryBackoffSeconds != nil {
+		t.Errorf("expected omitted tuning flags to stay nil, got %+v", device)
+	}
+	// Resolved accessors must still return the documented defaults.
+	if device.ResolvedWorkerCount() != agent.DefaultWorkerCount {
+		t.Errorf("expected default worker count, got %d", device.ResolvedWorkerCount())
+	}
+}
+
 func TestRunConfig_HTTPTimeout(t *testing.T) {
 	done := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -528,7 +528,8 @@ func TestRunConfig_AppliesTuningFlags(t *testing.T) {
 	if device.PostbackMaxAttempts == nil || *device.PostbackMaxAttempts != 5 {
 		t.Errorf("expected PostbackMaxAttempts 5, got %v", device.PostbackMaxAttempts)
 	}
-	if device.PostbackBaseRetryBackoffSeconds == nil || *device.PostbackBaseRetryBackoffSeconds != 2 {
+	if device.PostbackBaseRetryBackoffSeconds == nil ||
+		*device.PostbackBaseRetryBackoffSeconds != 2 {
 		t.Errorf(
 			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
 			device.PostbackBaseRetryBackoffSeconds,

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -107,7 +107,9 @@ func runUpdate(params *updateContext) {
 		device.PostbackMaxAttempts = tuningPtr(params.Tuning.PostbackMaxAttempts)
 	}
 	if params.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset {
-		device.PostbackBaseRetryBackoffSeconds = tuningPtr(params.Tuning.PostbackBaseRetryBackoffSeconds)
+		device.PostbackBaseRetryBackoffSeconds = tuningPtr(
+			params.Tuning.PostbackBaseRetryBackoffSeconds,
+		)
 	}
 
 	// Save the updated configuration file

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -91,6 +91,25 @@ func runUpdate(params *updateContext) {
 		device.MqttQos = nil
 	}
 
+	// Overwrite each tuning field only when the operator provided the flag. An
+	// omitted flag leaves whatever was already in the config file unchanged so
+	// existing overrides are never silently reset to the default.
+	if params.Tuning.MqttConnectTimeoutSeconds != tuningFlagUnset {
+		device.MqttConnectTimeoutSeconds = tuningPtr(params.Tuning.MqttConnectTimeoutSeconds)
+	}
+	if params.Tuning.WorkerCount != tuningFlagUnset {
+		device.WorkerCount = tuningPtr(params.Tuning.WorkerCount)
+	}
+	if params.Tuning.MessageQueueSize != tuningFlagUnset {
+		device.MessageQueueSize = tuningPtr(params.Tuning.MessageQueueSize)
+	}
+	if params.Tuning.PostbackMaxAttempts != tuningFlagUnset {
+		device.PostbackMaxAttempts = tuningPtr(params.Tuning.PostbackMaxAttempts)
+	}
+	if params.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset {
+		device.PostbackBaseRetryBackoffSeconds = tuningPtr(params.Tuning.PostbackBaseRetryBackoffSeconds)
+	}
+
 	// Save the updated configuration file
 	configBytes, err := json.MarshalIndent(device, "", "  ")
 	if err != nil {

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -21,6 +21,7 @@ type updateContext struct {
 	MqttQos              int
 	ServiceUsername      string
 	ServicePassword      string
+	Tuning               tuningFlags
 
 	Sys    agent.SystemInfoProvider
 	Domain agent.DomainInfoProvider
@@ -52,6 +53,7 @@ func newUpdateFlagSet(params *updateContext) *flag.FlagSet {
 	fs.BoolVar(&params.NoAutoUpdates, "no-auto-updates", false, "No auto updates")
 	fs.StringVar(&params.GithubToken, "github-token", "", "GitHub token for update checks")
 	fs.IntVar(&params.MqttQos, "mqtt-qos", -1, "MQTT subscription QoS level (0 or 1)")
+	bindTuningFlags(fs, &params.Tuning)
 	fs.StringVar(
 		&params.ServiceUsername,
 		"service-username",
@@ -84,6 +86,8 @@ func newUpdateContext(
 		return nil, err
 	}
 
+	params.Tuning.captureProvided(fs)
+
 	if params.OrgId == "" {
 		return nil, fmt.Errorf("missing org-id")
 	}
@@ -98,6 +102,10 @@ func newUpdateContext(
 
 	if params.MqttQos != -1 && (params.MqttQos < 0 || params.MqttQos > 1) {
 		return nil, fmt.Errorf("invalid mqtt-qos: must be 0 or 1")
+	}
+
+	if err := params.Tuning.validate(); err != nil {
+		return nil, err
 	}
 
 	if params.ServicePassword != "" && params.ServiceUsername == "" {

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -63,6 +63,46 @@ func TestNewUpdateContext(t *testing.T) {
 		t.Errorf("expected ServicePassword %q, got %q", "p@ss", resultWithCreds.ServicePassword)
 	}
 
+	// Tuning flags default to the unset sentinel when omitted.
+	if result.Tuning.MqttConnectTimeoutSeconds != tuningFlagUnset ||
+		result.Tuning.WorkerCount != tuningFlagUnset ||
+		result.Tuning.MessageQueueSize != tuningFlagUnset ||
+		result.Tuning.PostbackMaxAttempts != tuningFlagUnset ||
+		result.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset {
+		t.Errorf("expected tuning flags to default to unset, got %+v", result.Tuning)
+	}
+
+	// Tuning flags are parsed when provided.
+	resultWithTuning, err := newUpdateContext(
+		[]string{
+			"--org-id", orgId, "--update",
+			"--mqtt-connect-timeout-seconds", "45",
+			"--worker-count", "20",
+			"--message-queue-size", "250",
+			"--postback-max-attempts", "5",
+			"--postback-base-retry-backoff-seconds", "2",
+		},
+		nil, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("expected no error with tuning flags, got %v", err)
+	}
+	if resultWithTuning.Tuning.MqttConnectTimeoutSeconds != 45 {
+		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", resultWithTuning.Tuning.MqttConnectTimeoutSeconds)
+	}
+	if resultWithTuning.Tuning.WorkerCount != 20 {
+		t.Errorf("expected WorkerCount 20, got %v", resultWithTuning.Tuning.WorkerCount)
+	}
+	if resultWithTuning.Tuning.MessageQueueSize != 250 {
+		t.Errorf("expected MessageQueueSize 250, got %v", resultWithTuning.Tuning.MessageQueueSize)
+	}
+	if resultWithTuning.Tuning.PostbackMaxAttempts != 5 {
+		t.Errorf("expected PostbackMaxAttempts 5, got %v", resultWithTuning.Tuning.PostbackMaxAttempts)
+	}
+	if resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds != 2 {
+		t.Errorf("expected PostbackBaseRetryBackoffSeconds 2, got %v", resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds)
+	}
+
 	errorTests := []struct {
 		args    []string
 		message string
@@ -81,6 +121,26 @@ func TestNewUpdateContext(t *testing.T) {
 		{
 			[]string{"--org-id", orgId, "--update", "--service-password", "p@ss"},
 			"service-password requires service-username",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--worker-count", "-1"},
+			"invalid worker-count: must be a positive integer",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--message-queue-size", "0"},
+			"invalid message-queue-size: must be a positive integer",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--postback-max-attempts", "abc"},
+			"invalid value",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--mqtt-connect-timeout-seconds", "0"},
+			"invalid mqtt-connect-timeout-seconds: must be a positive integer",
+		},
+		{
+			[]string{"--org-id", orgId, "--update", "--postback-base-retry-backoff-seconds", "-5"},
+			"invalid postback-base-retry-backoff-seconds: must be a positive integer",
 		},
 	}
 

--- a/cmd/agent_smith/update_context_test.go
+++ b/cmd/agent_smith/update_context_test.go
@@ -88,7 +88,10 @@ func TestNewUpdateContext(t *testing.T) {
 		t.Fatalf("expected no error with tuning flags, got %v", err)
 	}
 	if resultWithTuning.Tuning.MqttConnectTimeoutSeconds != 45 {
-		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", resultWithTuning.Tuning.MqttConnectTimeoutSeconds)
+		t.Errorf(
+			"expected MqttConnectTimeoutSeconds 45, got %v",
+			resultWithTuning.Tuning.MqttConnectTimeoutSeconds,
+		)
 	}
 	if resultWithTuning.Tuning.WorkerCount != 20 {
 		t.Errorf("expected WorkerCount 20, got %v", resultWithTuning.Tuning.WorkerCount)
@@ -97,10 +100,16 @@ func TestNewUpdateContext(t *testing.T) {
 		t.Errorf("expected MessageQueueSize 250, got %v", resultWithTuning.Tuning.MessageQueueSize)
 	}
 	if resultWithTuning.Tuning.PostbackMaxAttempts != 5 {
-		t.Errorf("expected PostbackMaxAttempts 5, got %v", resultWithTuning.Tuning.PostbackMaxAttempts)
+		t.Errorf(
+			"expected PostbackMaxAttempts 5, got %v",
+			resultWithTuning.Tuning.PostbackMaxAttempts,
+		)
 	}
 	if resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds != 2 {
-		t.Errorf("expected PostbackBaseRetryBackoffSeconds 2, got %v", resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds)
+		t.Errorf(
+			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
+			resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds,
+		)
 	}
 
 	errorTests := []struct {

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -59,6 +59,118 @@ func TestRunUpdate_Success(t *testing.T) {
 	runUpdate(newBaseUpdateParams())
 }
 
+// deviceWithTuningJSON returns valid device JSON that already carries tuning
+// overrides, simulating a config file written by a previous invocation.
+func deviceWithTuningJSON(orgId string, timeout, workers, queue, attempts, backoff int) []byte {
+	b, _ := json.Marshal(agent.Device{
+		DeviceId:                        "device-123",
+		RewstOrgId:                      orgId,
+		RewstEngineHost:                 "engine.example.com",
+		SharedAccessKey:                 "key123",
+		AzureIotHubHost:                 "hub.example.com",
+		MqttConnectTimeoutSeconds:       &timeout,
+		WorkerCount:                     &workers,
+		MessageQueueSize:                &queue,
+		PostbackMaxAttempts:             &attempts,
+		PostbackBaseRetryBackoffSeconds: &backoff,
+	})
+	return b
+}
+
+// captureUpdateFS returns an FS that serves the given config JSON on the first
+// read (binary afterwards) and records the config bytes written back.
+func captureUpdateFS(configJSON []byte, written *agent.Device) *mockFileSystem {
+	readCall := 0
+	return &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc: func(string) ([]byte, error) {
+			readCall++
+			if readCall == 1 {
+				return configJSON, nil
+			}
+			return []byte("binary"), nil
+		},
+		writeFileFunc: func(_ string, data []byte, _ os.FileMode) error {
+			var device agent.Device
+			if err := json.Unmarshal(data, &device); err == nil && device.DeviceId != "" {
+				*written = device
+			}
+			return nil
+		},
+		mkdirAllFunc:  func(string) error { return nil },
+		removeAllFunc: func(string) error { return nil },
+	}
+}
+
+func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
+	var written agent.Device
+	params := newBaseUpdateParams()
+	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 10, 1, 10, 1, 1), &written)
+	params.Tuning = tuningFlags{
+		MqttConnectTimeoutSeconds:       45,
+		WorkerCount:                     20,
+		MessageQueueSize:                250,
+		PostbackMaxAttempts:             5,
+		PostbackBaseRetryBackoffSeconds: 2,
+	}
+
+	runUpdate(params)
+
+	if written.MqttConnectTimeoutSeconds == nil || *written.MqttConnectTimeoutSeconds != 45 {
+		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", written.MqttConnectTimeoutSeconds)
+	}
+	if written.WorkerCount == nil || *written.WorkerCount != 20 {
+		t.Errorf("expected WorkerCount 20, got %v", written.WorkerCount)
+	}
+	if written.MessageQueueSize == nil || *written.MessageQueueSize != 250 {
+		t.Errorf("expected MessageQueueSize 250, got %v", written.MessageQueueSize)
+	}
+	if written.PostbackMaxAttempts == nil || *written.PostbackMaxAttempts != 5 {
+		t.Errorf("expected PostbackMaxAttempts 5, got %v", written.PostbackMaxAttempts)
+	}
+	if written.PostbackBaseRetryBackoffSeconds == nil || *written.PostbackBaseRetryBackoffSeconds != 2 {
+		t.Errorf(
+			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
+			written.PostbackBaseRetryBackoffSeconds,
+		)
+	}
+}
+
+func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
+	var written agent.Device
+	params := newBaseUpdateParams()
+	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 30, 8, 128, 4, 3), &written)
+	// Only overwrite one field; the others must be preserved as-is.
+	params.Tuning = tuningFlags{
+		MqttConnectTimeoutSeconds:       tuningFlagUnset,
+		WorkerCount:                     15,
+		MessageQueueSize:                tuningFlagUnset,
+		PostbackMaxAttempts:             tuningFlagUnset,
+		PostbackBaseRetryBackoffSeconds: tuningFlagUnset,
+	}
+
+	runUpdate(params)
+
+	if written.WorkerCount == nil || *written.WorkerCount != 15 {
+		t.Errorf("expected WorkerCount overwritten to 15, got %v", written.WorkerCount)
+	}
+	if written.MqttConnectTimeoutSeconds == nil || *written.MqttConnectTimeoutSeconds != 30 {
+		t.Errorf("expected MqttConnectTimeoutSeconds preserved at 30, got %v", written.MqttConnectTimeoutSeconds)
+	}
+	if written.MessageQueueSize == nil || *written.MessageQueueSize != 128 {
+		t.Errorf("expected MessageQueueSize preserved at 128, got %v", written.MessageQueueSize)
+	}
+	if written.PostbackMaxAttempts == nil || *written.PostbackMaxAttempts != 4 {
+		t.Errorf("expected PostbackMaxAttempts preserved at 4, got %v", written.PostbackMaxAttempts)
+	}
+	if written.PostbackBaseRetryBackoffSeconds == nil || *written.PostbackBaseRetryBackoffSeconds != 3 {
+		t.Errorf(
+			"expected PostbackBaseRetryBackoffSeconds preserved at 3, got %v",
+			written.PostbackBaseRetryBackoffSeconds,
+		)
+	}
+}
+
 func TestRunUpdate_OpenFails(t *testing.T) {
 	params := newBaseUpdateParams()
 	params.ServiceManager = &mockServiceManager{openErr: errors.New("service not found")}

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -128,7 +128,8 @@ func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
 	if written.PostbackMaxAttempts == nil || *written.PostbackMaxAttempts != 5 {
 		t.Errorf("expected PostbackMaxAttempts 5, got %v", written.PostbackMaxAttempts)
 	}
-	if written.PostbackBaseRetryBackoffSeconds == nil || *written.PostbackBaseRetryBackoffSeconds != 2 {
+	if written.PostbackBaseRetryBackoffSeconds == nil ||
+		*written.PostbackBaseRetryBackoffSeconds != 2 {
 		t.Errorf(
 			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
 			written.PostbackBaseRetryBackoffSeconds,
@@ -155,7 +156,10 @@ func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 		t.Errorf("expected WorkerCount overwritten to 15, got %v", written.WorkerCount)
 	}
 	if written.MqttConnectTimeoutSeconds == nil || *written.MqttConnectTimeoutSeconds != 30 {
-		t.Errorf("expected MqttConnectTimeoutSeconds preserved at 30, got %v", written.MqttConnectTimeoutSeconds)
+		t.Errorf(
+			"expected MqttConnectTimeoutSeconds preserved at 30, got %v",
+			written.MqttConnectTimeoutSeconds,
+		)
 	}
 	if written.MessageQueueSize == nil || *written.MessageQueueSize != 128 {
 		t.Errorf("expected MessageQueueSize preserved at 128, got %v", written.MessageQueueSize)
@@ -163,7 +167,8 @@ func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 	if written.PostbackMaxAttempts == nil || *written.PostbackMaxAttempts != 4 {
 		t.Errorf("expected PostbackMaxAttempts preserved at 4, got %v", written.PostbackMaxAttempts)
 	}
-	if written.PostbackBaseRetryBackoffSeconds == nil || *written.PostbackBaseRetryBackoffSeconds != 3 {
+	if written.PostbackBaseRetryBackoffSeconds == nil ||
+		*written.PostbackBaseRetryBackoffSeconds != 3 {
 		t.Errorf(
 			"expected PostbackBaseRetryBackoffSeconds preserved at 3, got %v",
 			written.PostbackBaseRetryBackoffSeconds,

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -45,7 +45,7 @@ type operationalMode struct {
 // historical one-line usage string so existing behavior is preserved.
 func operationalModes() []operationalMode {
 	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1] [--service-username <USER>] [--service-password <PASS>]",
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1] [--mqtt-connect-timeout-seconds <N>] [--worker-count <N>] [--message-queue-size <N>] [--postback-max-attempts <N>] [--postback-base-retry-backoff-seconds <N>] [--service-username <USER>] [--service-password <PASS>]",
 		getAllowedConfigLevelsString("|"),
 	)
 

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -133,6 +133,11 @@ func TestReportUsageHelp(t *testing.T) {
 				"--config-url",
 				"--config-file",
 				"--mqtt-qos",
+				"--mqtt-connect-timeout-seconds",
+				"--worker-count",
+				"--message-queue-size",
+				"--postback-max-attempts",
+				"--postback-base-retry-backoff-seconds",
 				"--logging-level",
 				"Organization ID",
 			} {


### PR DESCRIPTION
## Summary

Exposes the agent's MQTT, worker, and postback fine-tuning parameters as CLI flags in both **config** and **update** modes, so operators can override them without hand-editing the config file. Each flag is optional — an omitted flag leaves the agent on its documented default (config mode) or preserves the existing config value (update mode).

New flags (available in both config and update modes):

- `--mqtt-connect-timeout-seconds <N>` — MQTT connect timeout in seconds
- `--worker-count <N>` — number of concurrent command-execution workers
- `--message-queue-size <N>` — capacity of the inbound message queue
- `--postback-max-attempts <N>` — total postback attempts before spooling to disk
- `--postback-base-retry-backoff-seconds <N>` — base exponential-backoff delay between postback attempts

## Details

- Introduces a shared `tuningFlags` struct (`config_context.go`) so config and update modes bind an identical set of flags with identical descriptions.
- Follows the existing `--mqtt-qos` sentinel pattern (`tuningFlagUnset = -1`): a flag is only applied when explicitly provided.
- Uses `flag.FlagSet.Visit` to record which flags were provided, so validation can reject an explicitly-supplied non-positive value (e.g. `--worker-count -1`) even when it collides with the unset sentinel.
- **Config mode**: applies overrides to the fetched configuration, leaving omitted fields `nil` to fall back to documented defaults.
- **Update mode**: overwrites a field only when its flag is provided, so existing overrides are never silently reset.
- Updates the usage string to document the new flags.

## Testing

- `go test ./...`
- Added coverage for: default sentinel values, parsing provided flags, validation of non-positive/non-integer values, config-mode application + fall-back to defaults, and update-mode application + preservation of existing values.