### PR TITLE
fix: [sc-102476] Decouple MQTT connect timeout from backoff and tune keepalive

### DIFF
--- a/internal/mqtt/common.go
+++ b/internal/mqtt/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
@@ -41,6 +42,13 @@ func NewClientOptions(device agent.Device) (*mqtt.ClientOptions, error) {
 	// 30s default, so reconnect timing stays predictable across paho upgrades.
 	// See utils.DefaultMqttConnectTimeout for the value and rationale.
 	opts.SetConnectTimeout(device.MqttConnectTimeout())
+
+	// Explicitly configure keepalive/ping behavior rather than relying on paho's
+	// implicit defaults, so a marginal connection is detected and the reconnect
+	// loop is triggered within a bounded, predictable time. See
+	// utils.DefaultMqttKeepAlive / utils.DefaultMqttPingTimeout for the rationale.
+	opts.SetKeepAlive(utils.DefaultMqttKeepAlive)
+	opts.SetPingTimeout(utils.DefaultMqttPingTimeout)
 
 	return opts, nil
 }

--- a/internal/mqtt/common_test.go
+++ b/internal/mqtt/common_test.go
@@ -48,6 +48,24 @@ func TestNewClientOptions_DefaultAzureIotHub(t *testing.T) {
 			opts.ConnectTimeout,
 		)
 	}
+
+	// Keepalive/ping must be configured explicitly (not paho's implicit default)
+	// so a marginal connection is detected in a bounded, predictable time.
+	if opts.KeepAlive != int64(utils.DefaultMqttKeepAlive.Seconds()) {
+		t.Errorf(
+			"expected KeepAlive to default to %v seconds, got %v",
+			int64(utils.DefaultMqttKeepAlive.Seconds()),
+			opts.KeepAlive,
+		)
+	}
+
+	if opts.PingTimeout != utils.DefaultMqttPingTimeout {
+		t.Errorf(
+			"expected PingTimeout to default to %v, got %v",
+			utils.DefaultMqttPingTimeout,
+			opts.PingTimeout,
+		)
+	}
 }
 
 func TestNewClientOptions_ConnectTimeoutOverride(t *testing.T) {

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -15,13 +15,39 @@ const InitialReconnectInterval time.Duration = time.Second
 
 // DefaultMqttConnectTimeout bounds a single MQTT connect attempt.
 //
-// paho.mqtt.golang defaults ConnectTimeout to an implicit 30s. We set our own
-// value so reconnect timing is fully owned by this codebase and stays stable
-// across paho upgrades. The value is intentionally <= the shortest reconnect
-// backoff slot (1.5 * InitialReconnectInterval) so a connect attempt can never
-// outlive the next backoff slot. Endpoints with slow TLS handshakes can raise
-// it per-device via the device config (mqtt_connect_timeout_seconds).
-const DefaultMqttConnectTimeout time.Duration = InitialReconnectInterval
+// This is intentionally decoupled from InitialReconnectInterval. An earlier
+// design capped the connect timeout at the shortest reconnect backoff slot
+// (1.5 * InitialReconnectInterval, i.e. ~1s) so a connect attempt could never
+// outlive the next backoff slot. In practice that cap was far too aggressive:
+// the TCP + TLS + MQTT CONNACK handshake to Azure IoT Hub routinely takes
+// longer than a second on slow, high-latency, or lossy links (satellite,
+// congested VPN, poor cellular, distant regions), so every attempt timed out
+// before it could complete and the device never came online.
+//
+// The connect timeout and the reconnect backoff schedule serve different
+// purposes and are now sized independently: the backoff (ReconnectTimeout
+// Generator) governs how long to wait *between* attempts, while this value
+// governs how long a single attempt is allowed to run. A slow-but-successful
+// handshake is now allowed to complete rather than being aborted prematurely;
+// the reconnect loop still backs off and retries when an attempt genuinely
+// fails. 30s comfortably accommodates a slow TLS handshake while still bounding
+// a truly stuck attempt. Endpoints that need even more can raise it per-device
+// via the device config (mqtt_connect_timeout_seconds).
+const DefaultMqttConnectTimeout time.Duration = 30 * time.Second
+
+// DefaultMqttKeepAlive is the interval at which the client sends MQTT PING
+// requests to the broker while otherwise idle. It is configured explicitly
+// rather than relying on paho's implicit default so the liveness behavior of a
+// marginal connection is predictable. Together with DefaultMqttPingTimeout it
+// bounds how quickly a silently-dropped connection is detected: the client
+// declares the connection lost (triggering the reconnect loop) within roughly
+// DefaultMqttKeepAlive + DefaultMqttPingTimeout.
+const DefaultMqttKeepAlive time.Duration = 30 * time.Second
+
+// DefaultMqttPingTimeout is how long the client waits for a PINGRESP after
+// sending a PING before considering the connection dead. Set explicitly for the
+// same predictability reason as DefaultMqttKeepAlive.
+const DefaultMqttPingTimeout time.Duration = 10 * time.Second
 
 type ReconnectTimeoutGenerator struct {
 	base    time.Duration

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -45,19 +45,40 @@ func TestReconnectTimeoutGenerator(t *testing.T) {
 	}
 }
 
-// TestDefaultMqttConnectTimeoutFitsBackoff records the chosen connect timeout
-// and its rationale: a single connect attempt must never outlive the shortest
-// reconnect backoff slot, otherwise a connect attempt could still be blocking
-// when the next reconnect would already be due. The shortest slot is the first
-// one: base doubled to 2 * InitialReconnectInterval, minus up to 25% jitter,
-// i.e. 1.5 * InitialReconnectInterval.
-func TestDefaultMqttConnectTimeoutFitsBackoff(t *testing.T) {
+// TestDefaultMqttConnectTimeoutIsDecoupledFromBackoff records the intentionally
+// decoupled relationship between the connect timeout and the reconnect backoff
+// schedule.
+//
+// An earlier design capped DefaultMqttConnectTimeout at the shortest reconnect
+// backoff slot (1.5 * InitialReconnectInterval, ~1s) so a connect attempt could
+// never outlive the next backoff slot. That cap made the agent unable to
+// connect on slow/high-latency links where the TLS handshake alone exceeds a
+// second. The two values now serve independent purposes — the backoff governs
+// the wait *between* attempts, the connect timeout governs how long a single
+// attempt may run — so the connect timeout is sized to accommodate a slow
+// handshake and is deliberately larger than the shortest backoff slot. This
+// test asserts that decoupling holds (and would fail if the old cap were
+// reintroduced), and pins the default to a value comfortably above a
+// slow-handshake threshold.
+func TestDefaultMqttConnectTimeoutIsDecoupledFromBackoff(t *testing.T) {
 	shortestSlot := time.Duration(float64(2*InitialReconnectInterval) * (1 - 0.25))
-	if DefaultMqttConnectTimeout > shortestSlot {
+	if DefaultMqttConnectTimeout <= shortestSlot {
 		t.Errorf(
-			"DefaultMqttConnectTimeout (%v) must not exceed the shortest backoff slot (%v)",
+			"DefaultMqttConnectTimeout (%v) is expected to be decoupled from and larger "+
+				"than the shortest backoff slot (%v) so slow handshakes can complete",
 			DefaultMqttConnectTimeout,
 			shortestSlot,
+		)
+	}
+
+	// Guard against a regression that silently lowers the default back toward
+	// the old ~1s cap: it must comfortably accommodate a slow TLS handshake.
+	const minAcceptable = 10 * time.Second
+	if DefaultMqttConnectTimeout < minAcceptable {
+		t.Errorf(
+			"DefaultMqttConnectTimeout (%v) must be at least %v to accommodate slow handshakes",
+			DefaultMqttConnectTimeout,
+			minAcceptable,
 		)
 	}
 }


### PR DESCRIPTION
## Summary

Increases IoT Hub connection resilience by fixing two MQTT connection-timing issues that could prevent devices on slow or marginal links from staying online.

- **Decouple `DefaultMqttConnectTimeout` from the reconnect backoff.** The previous design capped a single connect attempt at the shortest reconnect backoff slot (~1s). On slow/high-latency/lossy links (satellite, congested VPN, poor cellular, distant regions) the TCP + TLS + MQTT CONNACK handshake to Azure IoT Hub routinely exceeds a second, so every attempt timed out before it could complete and the device never came online. Connect timeout is now sized independently at **30s** — the backoff governs the wait *between* attempts, the connect timeout governs how long a single attempt may run. Still overridable per-device via `mqtt_connect_timeout_seconds`.

- **Configure keepalive/ping explicitly.** Rather than relying on paho's implicit defaults, `SetKeepAlive` (30s) and `SetPingTimeout` (10s) are now set explicitly so a silently-dropped/marginal connection is detected and the reconnect loop is triggered within a bounded, predictable time (~keepalive + ping timeout).

## Changes

- `internal/utils/time.go`: bump `DefaultMqttConnectTimeout` to 30s with updated rationale; add `DefaultMqttKeepAlive` and `DefaultMqttPingTimeout`.
- `internal/mqtt/common.go`: apply keepalive/ping timeout in `NewClientOptions`.

## Testing

- Updated `TestDefaultMqttConnectTimeoutIsDecoupledFromBackoff` to assert the connect timeout is larger than the shortest backoff slot and guards against regression back toward the old ~1s cap.
- Added assertions in `TestNewClientOptions_DefaultAzureIotHub` for the explicit keepalive/ping defaults.
- `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)