### PR TITLE
fix: [sc-103835] Add configurable per-command execution timeout

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -116,6 +116,7 @@ jobs:
               service = "rewst_remote_agent_$orgId"
               success_commands = '"echo \"hello world\""'
               failure_commands = '"exit 1"'
+              timeout_commands = '"sleep 30"'
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/etc/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n/tmp/rewst_remote_agent/scripts/$orgId"
@@ -132,6 +133,7 @@ jobs:
               service = "RewstRemoteAgent_$orgId"
               success_commands = $winSuccess
               failure_commands = $winFailure
+              timeout_commands = '"Start-Sleep -Seconds 30"'
               success_patterns = "Command completed`nSending postback`nPostback already sent"
               no_auto_updates_extra = '--disable-agent-postback'
               uninstall_paths = "C:\ProgramData\RewstRemoteAgent\$orgId`nC:\Program Files\RewstRemoteAgent\$orgId`nC:\RewstRemoteAgent\scripts\$orgId"
@@ -148,6 +150,7 @@ jobs:
               service = "io.rewst.remote_agent_$orgId"
               success_commands = '"echo \"hello world\""'
               failure_commands = '"exit 1"'
+              timeout_commands = '"sleep 30"'
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/Library/Application Support/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n`$env:TMPDIR/rewst_remote_agent/scripts/$orgId"
@@ -460,6 +463,91 @@ jobs:
             exit 1
           }
           Write-Output "Confirmed exactly one post-reconnect command execution"
+
+      # ---- Per-command execution timeout scenario (sc-103835) ----
+      # Configure a short per-command timeout, dispatch a script that sleeps well
+      # beyond it, and confirm the agent kills the command (logging a timeout) and
+      # that a subsequent ordinary command still completes - i.e. the worker pool
+      # recovered instead of staying wedged. Counts are compared as deltas because
+      # the log already carries lines from earlier cycles.
+      - name: Enable short command timeout
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --command-timeout-seconds 5 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for fresh subscription after timeout update
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Subscribed to messages
+          max_attempts: "60"
+          interval_seconds: "2"
+
+      - name: Capture command-timeout baseline counts
+        id: timeout_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $timedOut  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command timed out"))).Count } else { 0 }
+          $completed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+          "timed_out=$timedOut" >> $env:GITHUB_OUTPUT
+          "completed=$completed" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> timed_out=$timedOut completed=$completed"
+
+      - name: Send hanging command
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.timeout_commands }}
+
+      - name: Assert hanging command was killed by the timeout
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.timeout_baseline.outputs.timed_out }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command timed out"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Command timed out as expected (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+          }
+          Write-Error "Hanging command was not killed by the per-command timeout (count stayed at $baseline)"
+          exit 1
+
+      - name: Send command after timeout
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Assert worker pool recovered after timeout
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.timeout_baseline.outputs.completed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Worker pool recovered; a later command completed (count $count > baseline $baseline)"
+              exit 0
+            }
+          }
+          Write-Error "Worker pool did not process a command after the timeout (count stayed at $baseline)"
+          exit 1
 
       - name: Uninstall agent
         uses: ./.github/actions/run-agent

--- a/README.md
+++ b/README.md
@@ -210,6 +210,34 @@ raising `worker_count` widens execution parallelism. Example snippet:
 }
 ```
 
+#### Bounding per-command execution time
+
+By default a received command runs with no execution deadline: it is only
+cancelled when the MQTT connection drops or the service stops. A script that
+hangs (infinite loop, blocked on a prompt/`stdin`, stuck network call) therefore
+occupies its worker indefinitely, and once as many hung commands accumulate as
+there are workers the whole pool is exhausted and no further commands run until
+the agent reconnects.
+
+Set `command_timeout_seconds` to bound how long any single command may run:
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `command_timeout_seconds` | *(unset — unbounded)* | Maximum seconds a single command may run before it is killed and its worker released. |
+
+When set to a positive value, each command runs under a derived context with
+that deadline; if it is exceeded the command's process group is killed, the
+worker is freed, and the result posted back is flagged with `"timed_out": true`
+(distinct from a normal non-zero exit) while the event is logged at `Error`
+level with the `post_id`. When omitted or set to a non-positive value, execution
+stays unbounded, preserving the historical behavior. Example snippet:
+
+```json
+{
+  "command_timeout_seconds": 300
+}
+```
+
 ### Command Result Delivery
 
 After a command runs, the agent posts its result back to the Rewst engine with

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -129,6 +129,7 @@ func runConfig(params *configContext) error {
 	response.Configuration.PostbackBaseRetryBackoffSeconds = tuningPtr(
 		params.Tuning.PostbackBaseRetryBackoffSeconds,
 	)
+	response.Configuration.CommandTimeoutSeconds = tuningPtr(params.Tuning.CommandTimeoutSeconds)
 
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -29,6 +29,7 @@ type tuningFlags struct {
 	MessageQueueSize                int
 	PostbackMaxAttempts             int
 	PostbackBaseRetryBackoffSeconds int
+	CommandTimeoutSeconds           int
 	// provided records which tuning flag names the operator explicitly set. It is
 	// populated from flag.FlagSet.Visit after parsing so validation can flag an
 	// explicitly-provided non-positive value (e.g. --worker-count -1) even when it
@@ -44,6 +45,7 @@ var tuningFlagNames = []string{
 	"message-queue-size",
 	"postback-max-attempts",
 	"postback-base-retry-backoff-seconds",
+	"command-timeout-seconds",
 }
 
 // captureProvided records which tuning flags were explicitly set on fs so that
@@ -95,6 +97,12 @@ func bindTuningFlags(fs *flag.FlagSet, t *tuningFlags) {
 		tuningFlagUnset,
 		"Base exponential-backoff delay between postback attempts in seconds (positive integer)",
 	)
+	fs.IntVar(
+		&t.CommandTimeoutSeconds,
+		"command-timeout-seconds",
+		tuningFlagUnset,
+		"Per-command execution timeout in seconds; unset means unbounded (positive integer)",
+	)
 }
 
 // validate rejects any tuning flag that was explicitly provided with a
@@ -110,6 +118,7 @@ func (t tuningFlags) validate() error {
 		{"message-queue-size", t.MessageQueueSize},
 		{"postback-max-attempts", t.PostbackMaxAttempts},
 		{"postback-base-retry-backoff-seconds", t.PostbackBaseRetryBackoffSeconds},
+		{"command-timeout-seconds", t.CommandTimeoutSeconds},
 	}
 	for _, c := range checks {
 		if t.provided[c.name] && c.value <= 0 {

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -91,7 +91,8 @@ func TestNewConfigContext(t *testing.T) {
 		result.Tuning.WorkerCount != tuningFlagUnset ||
 		result.Tuning.MessageQueueSize != tuningFlagUnset ||
 		result.Tuning.PostbackMaxAttempts != tuningFlagUnset ||
-		result.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset {
+		result.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset ||
+		result.Tuning.CommandTimeoutSeconds != tuningFlagUnset {
 		t.Errorf("expected tuning flags to default to unset, got %+v", result.Tuning)
 	}
 
@@ -106,6 +107,7 @@ func TestNewConfigContext(t *testing.T) {
 			"--message-queue-size", "250",
 			"--postback-max-attempts", "5",
 			"--postback-base-retry-backoff-seconds", "2",
+			"--command-timeout-seconds", "120",
 		},
 		nil, nil, nil, nil,
 	)
@@ -134,6 +136,12 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf(
 			"expected PostbackBaseRetryBackoffSeconds 2, got %v",
 			resultWithTuning.Tuning.PostbackBaseRetryBackoffSeconds,
+		)
+	}
+	if resultWithTuning.Tuning.CommandTimeoutSeconds != 120 {
+		t.Errorf(
+			"expected CommandTimeoutSeconds 120, got %v",
+			resultWithTuning.Tuning.CommandTimeoutSeconds,
 		)
 	}
 
@@ -228,6 +236,15 @@ func TestNewConfigContext(t *testing.T) {
 				"--postback-base-retry-backoff-seconds", "-5",
 			},
 			"invalid postback-base-retry-backoff-seconds: must be a positive integer",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--command-timeout-seconds", "0",
+			},
+			"invalid command-timeout-seconds: must be a positive integer",
 		},
 	}
 

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -509,6 +509,7 @@ func TestRunConfig_AppliesTuningFlags(t *testing.T) {
 		MessageQueueSize:                250,
 		PostbackMaxAttempts:             5,
 		PostbackBaseRetryBackoffSeconds: 2,
+		CommandTimeoutSeconds:           120,
 	}
 
 	if err := runConfig(params); err != nil {
@@ -535,6 +536,9 @@ func TestRunConfig_AppliesTuningFlags(t *testing.T) {
 			device.PostbackBaseRetryBackoffSeconds,
 		)
 	}
+	if device.CommandTimeoutSeconds == nil || *device.CommandTimeoutSeconds != 120 {
+		t.Errorf("expected CommandTimeoutSeconds 120, got %v", device.CommandTimeoutSeconds)
+	}
 }
 
 func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
@@ -559,6 +563,7 @@ func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
 		MessageQueueSize:                tuningFlagUnset,
 		PostbackMaxAttempts:             tuningFlagUnset,
 		PostbackBaseRetryBackoffSeconds: tuningFlagUnset,
+		CommandTimeoutSeconds:           tuningFlagUnset,
 	}
 
 	if err := runConfig(params); err != nil {
@@ -570,7 +575,8 @@ func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
 		device.WorkerCount != nil ||
 		device.MessageQueueSize != nil ||
 		device.PostbackMaxAttempts != nil ||
-		device.PostbackBaseRetryBackoffSeconds != nil {
+		device.PostbackBaseRetryBackoffSeconds != nil ||
+		device.CommandTimeoutSeconds != nil {
 		t.Errorf("expected omitted tuning flags to stay nil, got %+v", device)
 	}
 	// Resolved accessors must still return the documented defaults.

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -111,6 +111,9 @@ func runUpdate(params *updateContext) {
 			params.Tuning.PostbackBaseRetryBackoffSeconds,
 		)
 	}
+	if params.Tuning.CommandTimeoutSeconds != tuningFlagUnset {
+		device.CommandTimeoutSeconds = tuningPtr(params.Tuning.CommandTimeoutSeconds)
+	}
 
 	// Save the updated configuration file
 	configBytes, err := json.MarshalIndent(device, "", "  ")

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -61,7 +61,10 @@ func TestRunUpdate_Success(t *testing.T) {
 
 // deviceWithTuningJSON returns valid device JSON that already carries tuning
 // overrides, simulating a config file written by a previous invocation.
-func deviceWithTuningJSON(orgId string, timeout, workers, queue, attempts, backoff int) []byte {
+func deviceWithTuningJSON(
+	orgId string,
+	timeout, workers, queue, attempts, backoff, cmdTimeout int,
+) []byte {
 	b, _ := json.Marshal(agent.Device{
 		DeviceId:                        "device-123",
 		RewstOrgId:                      orgId,
@@ -73,6 +76,7 @@ func deviceWithTuningJSON(orgId string, timeout, workers, queue, attempts, backo
 		MessageQueueSize:                &queue,
 		PostbackMaxAttempts:             &attempts,
 		PostbackBaseRetryBackoffSeconds: &backoff,
+		CommandTimeoutSeconds:           &cmdTimeout,
 	})
 	return b
 }
@@ -105,13 +109,14 @@ func captureUpdateFS(configJSON []byte, written *agent.Device) *mockFileSystem {
 func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
 	var written agent.Device
 	params := newBaseUpdateParams()
-	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 10, 1, 10, 1, 1), &written)
+	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 10, 1, 10, 1, 1, 1), &written)
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       45,
 		WorkerCount:                     20,
 		MessageQueueSize:                250,
 		PostbackMaxAttempts:             5,
 		PostbackBaseRetryBackoffSeconds: 2,
+		CommandTimeoutSeconds:           120,
 	}
 
 	runUpdate(params)
@@ -135,12 +140,15 @@ func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
 			written.PostbackBaseRetryBackoffSeconds,
 		)
 	}
+	if written.CommandTimeoutSeconds == nil || *written.CommandTimeoutSeconds != 120 {
+		t.Errorf("expected CommandTimeoutSeconds 120, got %v", written.CommandTimeoutSeconds)
+	}
 }
 
 func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 	var written agent.Device
 	params := newBaseUpdateParams()
-	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 30, 8, 128, 4, 3), &written)
+	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 30, 8, 128, 4, 3, 90), &written)
 	// Only overwrite one field; the others must be preserved as-is.
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       tuningFlagUnset,
@@ -148,6 +156,7 @@ func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 		MessageQueueSize:                tuningFlagUnset,
 		PostbackMaxAttempts:             tuningFlagUnset,
 		PostbackBaseRetryBackoffSeconds: tuningFlagUnset,
+		CommandTimeoutSeconds:           tuningFlagUnset,
 	}
 
 	runUpdate(params)
@@ -172,6 +181,12 @@ func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 		t.Errorf(
 			"expected PostbackBaseRetryBackoffSeconds preserved at 3, got %v",
 			written.PostbackBaseRetryBackoffSeconds,
+		)
+	}
+	if written.CommandTimeoutSeconds == nil || *written.CommandTimeoutSeconds != 90 {
+		t.Errorf(
+			"expected CommandTimeoutSeconds preserved at 90, got %v",
+			written.CommandTimeoutSeconds,
 		)
 	}
 }

--- a/cmd/agent_smith/usage.go
+++ b/cmd/agent_smith/usage.go
@@ -45,7 +45,7 @@ type operationalMode struct {
 // historical one-line usage string so existing behavior is preserved.
 func operationalModes() []operationalMode {
 	configFlagsList := fmt.Sprintf(
-		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1] [--mqtt-connect-timeout-seconds <N>] [--worker-count <N>] [--message-queue-size <N>] [--postback-max-attempts <N>] [--postback-base-retry-backoff-seconds <N>] [--service-username <USER>] [--service-password <PASS>]",
+		"[--logging-level %s] [--syslog] [--disable-agent-postback] [--no-auto-updates] [--mqtt-qos 0|1] [--mqtt-connect-timeout-seconds <N>] [--worker-count <N>] [--message-queue-size <N>] [--postback-max-attempts <N>] [--postback-base-retry-backoff-seconds <N>] [--command-timeout-seconds <N>] [--service-username <USER>] [--service-password <PASS>]",
 		getAllowedConfigLevelsString("|"),
 	)
 

--- a/cmd/agent_smith/usage_test.go
+++ b/cmd/agent_smith/usage_test.go
@@ -138,6 +138,7 @@ func TestReportUsageHelp(t *testing.T) {
 				"--message-queue-size",
 				"--postback-max-attempts",
 				"--postback-base-retry-backoff-seconds",
+				"--command-timeout-seconds",
 				"--logging-level",
 				"Organization ID",
 			} {

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -47,6 +47,14 @@ type Device struct {
 	// exponential backoff between postback attempts, in seconds. When unset (or
 	// non-positive) the agent falls back to DefaultPostbackBaseRetryBackoff.
 	PostbackBaseRetryBackoffSeconds *int `json:"postback_base_retry_backoff_seconds,omitempty"`
+	// CommandTimeoutSeconds optionally bounds how long a single received command
+	// is allowed to run before it is killed. When unset (or non-positive) command
+	// execution is unbounded, preserving the historical behavior. Setting a
+	// positive value protects the worker pool from a hung or interactive script
+	// (infinite loop, blocked on stdin, stuck network call) permanently consuming
+	// a worker: the command is cancelled once the deadline elapses even if the
+	// MQTT connection stays up.
+	CommandTimeoutSeconds *int `json:"command_timeout_seconds,omitempty"`
 }
 
 const (
@@ -103,6 +111,17 @@ func (d Device) ResolvedPostbackBaseRetryBackoff() time.Duration {
 		return time.Duration(*d.PostbackBaseRetryBackoffSeconds) * time.Second
 	}
 	return DefaultPostbackBaseRetryBackoff
+}
+
+// ResolvedCommandTimeout returns the per-command execution timeout and whether
+// one is configured. It reports ok=false when CommandTimeoutSeconds is unset or
+// non-positive, in which case command execution is unbounded (historical
+// behavior); otherwise it returns the configured duration with ok=true.
+func (d Device) ResolvedCommandTimeout() (time.Duration, bool) {
+	if d.CommandTimeoutSeconds != nil && *d.CommandTimeoutSeconds > 0 {
+		return time.Duration(*d.CommandTimeoutSeconds) * time.Second, true
+	}
+	return 0, false
 }
 
 // MqttConnectTimeout returns the per-attempt MQTT connect timeout, honoring the

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -29,6 +29,33 @@ func TestResolvedWorkerCount(t *testing.T) {
 	}
 }
 
+func TestResolvedCommandTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *int
+		expectOk bool
+		expectD  time.Duration
+	}{
+		{"unset is unbounded", nil, false, 0},
+		{"zero is unbounded", intPtr(0), false, 0},
+		{"negative is unbounded", intPtr(-30), false, 0},
+		{"positive override honored", intPtr(45), true, 45 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{CommandTimeoutSeconds: tt.value}
+			got, ok := d.ResolvedCommandTimeout()
+			if ok != tt.expectOk {
+				t.Errorf("ResolvedCommandTimeout() ok = %v, want %v", ok, tt.expectOk)
+			}
+			if got != tt.expectD {
+				t.Errorf("ResolvedCommandTimeout() = %v, want %v", got, tt.expectD)
+			}
+		})
+	}
+}
+
 func TestResolvedMessageQueueSize(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -20,6 +21,12 @@ import (
 )
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// commandWaitDelay bounds how long cmd.Wait blocks on the output pipes after the
+// command's context is cancelled and the process (group) is killed. It is a
+// backstop for a child that briefly holds the inherited stdout/stderr pipe open;
+// once it elapses the runtime force-closes the pipes so the worker is released.
+const commandWaitDelay = 10 * time.Second
 
 type baseExecutor struct {
 	Shell                    string
@@ -164,15 +171,64 @@ func (e *baseExecutor) Execute(
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 
+	// Bound the command to the configured per-command timeout when one is set, so
+	// a hung or interactive script (infinite loop, blocked on stdin, stuck network
+	// call) is killed after the deadline instead of permanently occupying its
+	// worker. When no timeout is configured, execCtx is the unmodified per-cycle
+	// ctx and the command remains unbounded (historical behavior).
+	execCtx := ctx
+	if timeout, ok := device.ResolvedCommandTimeout(); ok {
+		var cancel context.CancelFunc
+		execCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	// #nosec G204
-	cmd := exec.CommandContext(ctx, e.Shell, e.BuildExecuteFileArgs(tempfile.Name())...)
+	cmd := exec.CommandContext(execCtx, e.Shell, e.BuildExecuteFileArgs(tempfile.Name())...)
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("AGENT_SMITH_VERSION=%s", version.Version[1:]))
 
+	// Kill the whole process group on cancellation (see configureProcessGroup) so
+	// a shell that spawned children is fully torn down, and bound how long Run may
+	// block on output pipes afterward. Because stdout/stderr are in-memory buffers
+	// (not *os.File), the runtime copies them through a pipe a killed child can
+	// still hold open; WaitDelay guarantees Run returns and the worker is released
+	// even then. This only takes effect when the context is cancelled, so commands
+	// that finish on their own are unaffected.
+	configureProcessGroup(cmd)
+	cmd.WaitDelay = commandWaitDelay
+
 	err = cmd.Run()
 	if err != nil {
+		// Distinguish a command killed by the per-command timeout from a normal
+		// non-zero exit. execCtx exceeding its deadline while the parent ctx is
+		// still live means the timeout fired (not a service stop / reconnect,
+		// which cancels the parent ctx instead).
+		if errors.Is(execCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			timeout, _ := device.ResolvedCommandTimeout()
+			logger.Error(
+				"Command timed out",
+				"message_id",
+				message.PostId,
+				"timeout",
+				timeout,
+			)
+			logger.Debug(
+				"Command timed out with outputs",
+				"error",
+				stderrBuf.String(),
+				"info",
+				stdoutBuf.String(),
+			)
+			errMsg := fmt.Sprintf("command timed out after %s", timeout)
+			if stderrBuf.Len() > 0 {
+				errMsg = fmt.Sprintf("%s: %s", errMsg, stderrBuf.String())
+			}
+			return timeoutResultBytes(logger, errMsg, stdoutBuf.String())
+		}
+
 		logger.Error("Command failed", "error", err)
 		logger.Debug(
 			"Command completed with outputs",

--- a/internal/interpreter/base_executor_unix_test.go
+++ b/internal/interpreter/base_executor_unix_test.go
@@ -5,11 +5,13 @@ package interpreter
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -70,6 +72,113 @@ func TestBaseExecutor_Diagnostics_CachedAcrossCommands(t *testing.T) {
 	}
 	if got := strings.Count(logs, "[debug] whoami"); got != commandCount {
 		t.Errorf("expected %d whoami log lines, got %d", commandCount, got)
+	}
+}
+
+// newBashExecutor returns a bash-backed executor that runs the user script file
+// directly, mirroring the production Bash executor without the plugin wiring.
+func newBashExecutor() *baseExecutor {
+	return &baseExecutor{
+		Shell:                    "bash",
+		ShellVersionCheckCommand: "echo 1.0",
+		WriteUtf8BOM:             false,
+		BuildExecuteCommandArgs:  func(command string) []string { return []string{"-c", command} },
+		BuildExecuteFileArgs:     func(path string) []string { return []string{path} },
+		FS:                       utils.NewFileSystem(),
+	}
+}
+
+func TestBaseExecutor_CommandTimeout_KillsHungScript(t *testing.T) {
+	executor := newBashExecutor()
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Error})
+	timeout := 1
+	device := agent.Device{RewstOrgId: "test-org-timeout", CommandTimeoutSeconds: &timeout}
+
+	// A script that would otherwise block a worker indefinitely.
+	msg := Message{PostId: "test:timeout", Commands: encodeCommand("sleep 30")}
+
+	start := time.Now()
+	done := make(chan []byte, 1)
+	go func() {
+		done <- executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+	}()
+
+	var resultJSON []byte
+	select {
+	case resultJSON = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return; command was not killed by timeout")
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Errorf("command took %v to be killed; expected roughly the 1s timeout", elapsed)
+	}
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if !r.TimedOut {
+		t.Errorf("expected timed_out=true, got result %s", resultJSON)
+	}
+	if !strings.Contains(r.Error, "timed out") {
+		t.Errorf("expected error to mention timeout, got %q", r.Error)
+	}
+
+	// The timeout must be logged at Error level with the post_id for diagnosis.
+	logs := buf.String()
+	if !strings.Contains(logs, "Command timed out") {
+		t.Errorf("expected an Error-level timeout log, got %q", logs)
+	}
+	if !strings.Contains(logs, "test:timeout") {
+		t.Errorf("expected the timeout log to include the post_id, got %q", logs)
+	}
+}
+
+func TestBaseExecutor_CommandTimeout_FastCommandUnaffected(t *testing.T) {
+	executor := newBashExecutor()
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Error})
+	timeout := 30
+	device := agent.Device{RewstOrgId: "test-org-fast", CommandTimeoutSeconds: &timeout}
+
+	msg := Message{PostId: "test:fast", Commands: encodeCommand("echo hello")}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if r.TimedOut {
+		t.Errorf("fast command should not be flagged as timed out: %s", resultJSON)
+	}
+	if !strings.Contains(r.Output, "hello") {
+		t.Errorf("expected command output to contain 'hello', got %q", r.Output)
+	}
+}
+
+func TestBaseExecutor_CommandTimeout_UnboundedByDefault(t *testing.T) {
+	executor := newBashExecutor()
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Error})
+	// No CommandTimeoutSeconds set: execution is unbounded (historical behavior).
+	device := agent.Device{RewstOrgId: "test-org-unbounded"}
+
+	msg := Message{PostId: "test:unbounded", Commands: encodeCommand("sleep 1; echo done")}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if r.TimedOut {
+		t.Errorf("command should not be timed out when no timeout is configured: %s", resultJSON)
+	}
+	if !strings.Contains(r.Output, "done") {
+		t.Errorf("expected command output to contain 'done', got %q", r.Output)
 	}
 }
 

--- a/internal/interpreter/proc_unix.go
+++ b/internal/interpreter/proc_unix.go
@@ -1,0 +1,32 @@
+//go:build darwin || linux
+
+package interpreter
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup places the command in its own process group and wires a
+// Cancel hook that kills the entire group when the command's context is
+// cancelled (per-command timeout or connection teardown).
+//
+// Without this, cancelling the context only signals the shell process itself.
+// Any child the shell spawned (a `sleep`, a stuck network client, a blocked
+// read) is reparented and keeps running, and — because it inherits the shell's
+// stdout/stderr pipe — keeps cmd.Wait blocked. That would leave the worker
+// wedged exactly as the timeout is meant to prevent. Killing the whole group
+// tears down the descendant tree so the pipe closes and Wait returns.
+func configureProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// A negative pid targets the entire process group led by the shell.
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/interpreter/proc_windows.go
+++ b/internal/interpreter/proc_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package interpreter
+
+import "os/exec"
+
+// configureProcessGroup is a no-op on Windows. Context cancellation falls back to
+// the default exec.CommandContext behavior (Process.Kill) plus the WaitDelay
+// backstop set by the caller, which is sufficient to release the worker.
+// Terminating a full descendant tree on Windows requires job objects and is out
+// of scope for this change.
+func configureProcessGroup(cmd *exec.Cmd) {}

--- a/internal/interpreter/result.go
+++ b/internal/interpreter/result.go
@@ -13,6 +13,11 @@ type errorResult struct {
 type result struct {
 	Error  string `json:"error"`
 	Output string `json:"output"`
+	// TimedOut is set when the command was killed because it exceeded the
+	// configured per-command execution timeout, so the receiving workflow can
+	// distinguish a timeout from a normal non-zero exit. Omitted for commands
+	// that finished on their own.
+	TimedOut bool `json:"timed_out,omitempty"`
 }
 
 func errorResultBytes(logger hclog.Logger, err error) []byte {
@@ -36,6 +41,24 @@ func resultBytes(logger hclog.Logger, err string, out string) []byte {
 	if marshalErr != nil {
 		logger.Error("Failed to marshal result", "error", marshalErr)
 		return []byte(`{"error":"failed to marshal result","output":""}`)
+	}
+	return b
+}
+
+// timeoutResultBytes marshals the result of a command that was killed because it
+// exceeded the configured per-command execution timeout. It carries whatever
+// output the command produced before it was cancelled and sets TimedOut so the
+// receiving workflow can tell a timeout apart from a normal non-zero exit.
+func timeoutResultBytes(logger hclog.Logger, errMsg string, out string) []byte {
+	r := &result{
+		Error:    errMsg,
+		Output:   out,
+		TimedOut: true,
+	}
+	b, marshalErr := json.Marshal(r)
+	if marshalErr != nil {
+		logger.Error("Failed to marshal timeout result", "error", marshalErr)
+		return []byte(`{"error":"command timed out","output":"","timed_out":true}`)
 	}
 	return b
 }


### PR DESCRIPTION
## Summary

Commands were executed under the per-connection `cycleCtx`, so a hung or interactive script (infinite loop, blocked on `stdin`, stuck network call) occupied its worker goroutine indefinitely — cancelled only when the MQTT connection dropped or the service stopped. Once as many hung commands accumulated as there were workers (`worker_count`, default 10), the pool was exhausted, the inbound queue filled, and the agent applied back-pressure to the broker so no further commands ran until reconnect. A single misbehaving workflow script could silently stall command execution on the endpoint.

## Changes

- **Opt-in per-device `command_timeout_seconds`** (`internal/agent/device.go`) with a `ResolvedCommandTimeout() (time.Duration, bool)` accessor following the existing `Resolved*` tuning-field pattern. Unset/non-positive → unbounded (historical behavior preserved).
- **Bounded execution context** (`internal/interpreter/base_executor.go`): when configured, each command runs under a `context.WithTimeout` derived from the cycle context, so it is killed after the deadline even if the connection stays up.
- **Full process-tree teardown** (`proc_unix.go` / `proc_windows.go`): on Unix the shell runs in its own process group and the whole group is killed on cancellation, so child processes (e.g. a `sleep` grandchild holding the stdout pipe) don't keep `cmd.Wait` blocked. `cmd.WaitDelay` is a portable backstop guaranteeing the worker is released.
- **Distinct timeout result** (`internal/interpreter/result.go`): a timed-out command posts back `"timed_out": true` (distinct from a normal non-zero exit) and the event is logged at `Error` level with the `post_id`.
- **CLI flag** `--command-timeout-seconds` wired through config and update modes (validated positive-only when provided), consistent with the other tuning flags.
- **Docs**: README section on bounding per-command execution time.

## Acceptance criteria

- ✅ Each command runs under a derived context with a bounded timeout; killed after a maximum duration even if the connection stays up.
- ✅ Configurable per device, falls back when unset/non-positive, consistent with the `Resolved*` pattern.
- ✅ Timeout result clearly indicates a timeout and is logged at `Error` with the `post_id`.
- ✅ A timed-out command releases its worker so the pool returns to full strength.
- ✅ Existing behavior preserved for commands that finish within the timeout.

## Testing

- Unit tests: `ResolvedCommandTimeout`, executor kill-hung-script / fast-command-unaffected / unbounded-by-default, plus CLI flag coverage across config/update/usage. Full `go test ./...` green; new executor tests pass under `-race`.
- Cross-compiles for Windows and Linux; `go vet` and `gofmt` clean.
- Integration test: added a per-command timeout scenario to `.github/workflows/integration-test.yml` (short timeout → hanging script killed → `Command timed out` logged → subsequent command completes, proving the pool recovered) across all three platforms.