### PR TITLE
fix: [sc-103965] Cap postback retry backoff to prevent overflow busy-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ The in-line retry budget is tunable per deployment:
 | `postback_max_attempts` | `3` | Total postback attempts (including the first try) before the result is spooled. |
 | `postback_base_retry_backoff_seconds` | `1` | Base delay for exponential backoff between attempts (`base * 2^(n-2)`). |
 
+The per-attempt backoff is capped at **64s** (with up to ±25% jitter) regardless
+of how high `postback_max_attempts` is raised, mirroring the reconnect backoff.
+This keeps a wide retry window from overflowing into a busy-loop or blocking a
+worker for days, so raising `postback_max_attempts` only ever adds more bounded
+retry slots.
+
 Both fall back to their defaults when omitted or set to a non-positive value, so
 existing configurations are unaffected. Example snippet:
 

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ const (
 	postbackHTTPTimeout      = 30 * time.Second
 	postbackMaxAttempts      = agent.DefaultPostbackMaxAttempts
 	postbackBaseRetryBackoff = agent.DefaultPostbackBaseRetryBackoff
+	postbackMaxRetryBackoff  = agent.DefaultPostbackMaxRetryBackoff
 
 	// maxNotificationPayloadBytes bounds how many bytes of a received message
 	// payload are embedded in the AgentReceivedMessage notification forwarded to
@@ -526,6 +528,60 @@ func (svc *serviceContext) processMessage(
 	svc.sendPostbackWithRetry(ctx, &message, device, resultBytes, logger, notifier)
 }
 
+// postbackRetryBackoff computes the delay to wait before the given postback
+// retry attempt. attempt is 1-based and counts the initial try, so the first
+// backoff is paid before attempt 2; the uncapped schedule is base * 2^(attempt-2).
+//
+// The doubling is performed by iterated multiplication with an early exit at
+// maxBackoff rather than the naive base * (1 << (attempt-2)) shift. That shift
+// grows without bound and, for a large operator-configured postback_max_attempts,
+// overflows int64 nanoseconds into a negative time.Duration — time.After then
+// fires immediately and the retry loop busy-spins. Clamping to maxBackoff before
+// any overflow can occur keeps every slot strictly positive and bounded, so
+// raising the attempt count widens the total retry window without ever producing
+// a negative, zero, or multi-day sleep.
+//
+// Up to ±25% jitter is applied — mirroring the reconnect backoff generator (see
+// internal/utils/time.go) — to avoid synchronized retry storms across many
+// agents, and the result is clamped again so it never exceeds maxBackoff and
+// always stays strictly positive.
+func postbackRetryBackoff(base, maxBackoff time.Duration, attempt int) time.Duration {
+	if base <= 0 {
+		base = postbackBaseRetryBackoff
+	}
+	if maxBackoff <= 0 {
+		maxBackoff = postbackMaxRetryBackoff
+	}
+	if base > maxBackoff {
+		base = maxBackoff
+	}
+
+	backoff := base
+	for i := 0; i < attempt-2; i++ {
+		// Stop before doubling would reach or overflow the cap. Because backoff
+		// never exceeds maxBackoff (a small, sane duration), base * 2^n can never
+		// overflow int64 nanoseconds into a negative value.
+		if backoff >= maxBackoff/2 {
+			backoff = maxBackoff
+			break
+		}
+		backoff *= 2
+	}
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+
+	jitter := time.Duration(float64(backoff) * 0.25 * (2*rand.Float64() - 1))
+	backoff += jitter
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	if backoff <= 0 {
+		backoff = base
+	}
+	return backoff
+}
+
 // sendPostbackWithRetry posts the command result to the Rewst engine, retrying
 // transient failures (network errors and 5xx responses) with exponential
 // backoff. Non-retryable responses (2xx success, 400 "already fulfilled", and
@@ -553,7 +609,7 @@ func (svc *serviceContext) sendPostbackWithRetry(
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if attempt > 1 {
-			backoff := baseBackoff * (1 << (attempt - 2))
+			backoff := postbackRetryBackoff(baseBackoff, postbackMaxRetryBackoff, attempt)
 			logger.Info(
 				"Retrying postback",
 				"post_id", message.PostId,

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -1417,3 +1417,84 @@ func TestExecute_NoUnsubscribeWhenSubscribeFails(t *testing.T) {
 		}
 	}
 }
+
+// TestPostbackRetryBackoff_DefaultScheduleUnchanged verifies that the default
+// configuration (base 1s) still yields the historical ~1s / ~2s schedule for the
+// first two retries. Jitter is bounded to ±25%, so each slot is asserted within
+// that band of the exponential base rather than exactly.
+func TestPostbackRetryBackoff_DefaultScheduleUnchanged(t *testing.T) {
+	base := agent.DefaultPostbackBaseRetryBackoff
+	maxBackoff := agent.DefaultPostbackMaxRetryBackoff
+
+	cases := []struct {
+		attempt  int
+		expected time.Duration // exponential base before jitter
+	}{
+		{attempt: 2, expected: 1 * time.Second},
+		{attempt: 3, expected: 2 * time.Second},
+	}
+
+	for _, c := range cases {
+		// Sample repeatedly so jitter variance is exercised.
+		for i := 0; i < 1000; i++ {
+			got := postbackRetryBackoff(base, maxBackoff, c.attempt)
+			low := time.Duration(float64(c.expected) * 0.75)
+			high := time.Duration(float64(c.expected) * 1.25)
+			if got < low || got > high {
+				t.Fatalf("attempt %d: backoff %v outside expected jittered band [%v, %v]",
+					c.attempt, got, low, high)
+			}
+		}
+	}
+}
+
+// TestPostbackRetryBackoff_LargeAttemptsStayPositiveAndCapped is the core
+// regression for the uncapped/overflowing backoff: for very large attempt
+// numbers (well past the point where base * (1 << (attempt-2)) overflows int64
+// nanoseconds into a negative duration) the computed backoff must remain
+// strictly positive and never exceed the configured cap.
+func TestPostbackRetryBackoff_LargeAttemptsStayPositiveAndCapped(t *testing.T) {
+	base := 1 * time.Second
+	maxBackoff := agent.DefaultPostbackMaxRetryBackoff
+
+	// attempt-2 == 33 already overflows the old 1<<(attempt-2) nanosecond shift;
+	// go well beyond it, including absurd operator values.
+	for _, attempt := range []int{20, 35, 40, 64, 100, 1000, 1 << 20} {
+		for i := 0; i < 200; i++ {
+			got := postbackRetryBackoff(base, maxBackoff, attempt)
+			if got <= 0 {
+				t.Fatalf("attempt %d: backoff must be strictly positive, got %v", attempt, got)
+			}
+			if got > maxBackoff {
+				t.Fatalf("attempt %d: backoff %v exceeds cap %v", attempt, got, maxBackoff)
+			}
+		}
+	}
+}
+
+// TestPostbackRetryBackoff_BaseAboveCapClamped verifies that an operator setting
+// a base delay larger than the cap still produces a bounded, positive slot.
+func TestPostbackRetryBackoff_BaseAboveCapClamped(t *testing.T) {
+	maxBackoff := agent.DefaultPostbackMaxRetryBackoff
+	base := maxBackoff * 10
+
+	for _, attempt := range []int{2, 3, 50} {
+		got := postbackRetryBackoff(base, maxBackoff, attempt)
+		if got <= 0 || got > maxBackoff {
+			t.Fatalf("attempt %d: expected 0 < backoff <= %v, got %v", attempt, maxBackoff, got)
+		}
+	}
+}
+
+// TestPostbackRetryBackoff_NonPositiveInputsFallBackToDefaults verifies the
+// guards that keep a misconfigured base/cap from producing a zero or negative
+// slot.
+func TestPostbackRetryBackoff_NonPositiveInputsFallBackToDefaults(t *testing.T) {
+	got := postbackRetryBackoff(0, 0, 5)
+	if got <= 0 {
+		t.Fatalf("expected positive backoff with defaulted inputs, got %v", got)
+	}
+	if got > postbackMaxRetryBackoff {
+		t.Fatalf("expected backoff within defaulted cap %v, got %v", postbackMaxRetryBackoff, got)
+	}
+}

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -71,6 +71,17 @@ const (
 	// between postback attempts when PostbackBaseRetryBackoffSeconds is not
 	// configured.
 	DefaultPostbackBaseRetryBackoff = 1 * time.Second
+	// DefaultPostbackMaxRetryBackoff caps the exponential-backoff delay between
+	// postback attempts regardless of how high PostbackMaxAttempts is raised. The
+	// in-line schedule doubles the base delay on every retry (base * 2^n); without
+	// a ceiling a moderately large postback_max_attempts produces multi-hour or
+	// multi-day sleeps that pin a worker, and a large value overflows the shift
+	// into a negative time.Duration that makes time.After fire immediately and the
+	// retry loop busy-spin. This mirrors maxTimeout in the reconnect backoff
+	// generator (see internal/utils/time.go): the per-slot wait is bounded so the
+	// total retry window still widens with more attempts, but no single sleep can
+	// overflow, hang a worker for days, or collapse into a tight loop.
+	DefaultPostbackMaxRetryBackoff = 64 * time.Second
 )
 
 // ResolvedWorkerCount returns the number of command-execution workers to start,


### PR DESCRIPTION
## Summary

Fixes [sc-103965]. The in-line postback retry backoff was computed as `baseBackoff * (1 << (attempt - 2))` in `service.go` with no maximum cap. Because `postback_max_attempts` is operator-configurable:

- A **large** value overflowed the `1 << (attempt-2)` shift into a **negative** `time.Duration`. `time.After(negative)` fires immediately, turning the retry loop into a tight busy-loop that hammers the engine and spikes CPU.
- A **mid-range** value (e.g. 20) produced a single ~3-day sleep that blocked the worker goroutine, reducing effective worker-pool capacity.

The reconnect backoff generator already caps at `maxTimeout`; the postback path did not. This PR brings the postback path in line.

## Changes

- **`internal/agent/device.go`** — new documented `DefaultPostbackMaxRetryBackoff = 64 * time.Second`, mirroring `maxTimeout` in the reconnect generator.
- **`cmd/agent_smith/service.go`** — new `postbackRetryBackoff` helper replacing the raw shift. It computes `base * 2^(attempt-2)` via iterated doubling with an early exit at the cap (so it can never overflow int64 nanoseconds), clamps a base larger than the cap down to it, applies ±25% jitter (consistent with the reconnect backoff), and re-clamps so the result is always strictly positive and ≤ cap.
- **`README.md`** — documented the 64s cap + jitter under the postback tuning table.
- **`cmd/agent_smith/service_test.go`** — unit tests: default schedule unchanged (~1s/2s within jitter band), large attempts (20 … 2^20) stay positive and ≤ cap, base-above-cap clamped, non-positive inputs fall back to defaults.

## Acceptance criteria

- [x] Backoff clamped to a documented maximum regardless of attempt number.
- [x] Shift/multiplication cannot overflow into a negative or zero duration for any configurable `postback_max_attempts`.
- [x] Jitter applied (optional item) to avoid synchronized retry storms.
- [x] Default behavior (`postback_max_attempts = 3`, base 1s) unchanged.

## Testing

- `go build ./...`, `go vet`, and `go test ./...` all pass.
- New unit tests assert the backoff for large attempt numbers is positive and does not exceed the cap.

## Note

The per-slot cap bounds each sleep, but with a very high `postback_max_attempts` the *cumulative* in-line wait still occupies one worker until the budget is exhausted or the result spools. That is inherent to the in-line retry design and is separately mitigated by the disk spool; the ticket's concerns (overflow, busy-loop, multi-day single sleeps) are fully addressed here.
