### PR TITLE
fix: [sc-103969] extend SAS token lifetime and renew before expiry to stop hourly disconnect churn

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -549,6 +549,120 @@ jobs:
           Write-Error "Worker pool did not process a command after the timeout (count stayed at $baseline)"
           exit 1
 
+      # ---- SAS token proactive renewal scenario (sc-103969) ----
+      # The integration test binary is built with a short SAS token lifetime
+      # (sasTokenLifetimeOverrideStr=90s), so the agent must proactively
+      # reconnect with a freshly minted token a safety margin BEFORE the token
+      # expires rather than being forcibly disconnected by the broker on expiry.
+      # Install the IT binary with auto-updates disabled so it stays the running
+      # service (otherwise the 30s auto-updater would swap it for the real
+      # release before renewal fires), then confirm: the renewal fires (distinct
+      # Info log), the agent re-subscribes with the fresh token, and it is
+      # graceful - no Error "Connection lost" is produced. Deltas are compared
+      # because earlier cycles already left "Subscribed to messages"/"Connection
+      # lost" lines in the log.
+      - name: Install IT binary with short SAS token lifetime
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.it_binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates ${{ matrix.no_auto_updates_extra }} --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for fresh subscription after SAS lifetime update
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Subscribed to messages
+          max_attempts: "60"
+          interval_seconds: "2"
+
+      - name: Capture SAS renewal baseline counts
+        id: sas_renewal_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $renewed    = if ($content) { ([regex]::Matches($content, [regex]::Escape("Renewing SAS token before expiry"))).Count } else { 0 }
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          $lost       = if ($content) { ([regex]::Matches($content, [regex]::Escape("Connection lost"))).Count } else { 0 }
+          $completed  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+          "renewed=$renewed"       >> $env:GITHUB_OUTPUT
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "lost=$lost"             >> $env:GITHUB_OUTPUT
+          "completed=$completed"   >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> renewed=$renewed subscribed=$subscribed lost=$lost completed=$completed"
+
+      - name: Wait for proactive SAS token renewal
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Renewing SAS token before expiry
+          max_attempts: "60"
+          interval_seconds: "2"
+
+      - name: Assert SAS token renewed and agent resubscribed with fresh token
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          RENEWED_BASELINE: ${{ steps.sas_renewal_baseline.outputs.renewed }}
+          SUBSCRIBED_BASELINE: ${{ steps.sas_renewal_baseline.outputs.subscribed }}
+        run: |
+          $renewedBaseline = [int]$env:RENEWED_BASELINE
+          $subscribedBaseline = [int]$env:SUBSCRIBED_BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $renewed    = if ($content) { ([regex]::Matches($content, [regex]::Escape("Renewing SAS token before expiry"))).Count } else { 0 }
+            $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if (($renewed -gt $renewedBaseline) -and ($subscribed -gt $subscribedBaseline)) {
+              Write-Output "SAS token renewed (count $renewed > baseline $renewedBaseline) and agent resubscribed (count $subscribed > baseline $subscribedBaseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Proactive SAS renewal did not fire and resubscribe (renewed stayed <= $renewedBaseline or subscribed stayed <= $subscribedBaseline)"
+          exit 1
+
+      - name: Assert SAS renewal was graceful (no forced disconnect)
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          LOST_BASELINE: ${{ steps.sas_renewal_baseline.outputs.lost }}
+        run: |
+          $baseline = [int]$env:LOST_BASELINE
+          $content = Get-Content $env:LOG_FILE -Raw
+          $lost = ([regex]::Matches($content, [regex]::Escape("Connection lost"))).Count
+          if ($lost -gt $baseline) {
+            Write-Error "SAS renewal was not graceful: 'Connection lost' count rose from $baseline to $lost (token expired before renewal fired?)"
+            exit 1
+          }
+          Write-Output "Confirmed graceful renewal: no new 'Connection lost' (count stayed at $baseline)"
+
+      - name: Send command after SAS renewal
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Assert command delivery continues after SAS renewal
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.sas_renewal_baseline.outputs.completed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Command delivery continues after renewal (count $count > baseline $baseline)"
+              exit 0
+            }
+          }
+          Write-Error "No command completed after SAS renewal (count stayed at $baseline)"
+          exit 1
+
       - name: Uninstall agent
         uses: ./.github/actions/run-agent
         with:

--- a/README.md
+++ b/README.md
@@ -278,6 +278,33 @@ existing configurations are unaffected. Example snippet:
 }
 ```
 
+### Staying Connected (SAS token renewal)
+
+The agent authenticates to Azure IoT Hub with a short-lived SAS token, and the
+hub forcibly disconnects a client the instant its token expires. To avoid a
+forced disconnect on a fixed cadence, the agent mints a long-lived token and
+proactively reconnects with a fresh one a safety margin **before** expiry. The
+old connection is therefore never torn down by an expired token: the reconnect
+is a routine, `Info`-level **`Renewing SAS token before expiry`** log line rather
+than an `Error`-level `Connection lost`. An `Error` `Connection lost` now
+reflects a genuine fault (network drop, broker-side disconnect), and reconnect
+behavior for those real losses is unchanged.
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `sas_token_lifetime_hours` | `24` | Lifetime (in hours) of the Azure IoT Hub SAS token minted for each connection. |
+
+The renewal margin is 10% of the lifetime, floored at 1 minute and capped at 15
+minutes, so the token is used for almost its entire lifetime yet always refreshed
+ahead of expiry. Falls back to the default when omitted or set to a non-positive
+value. Example snippet:
+
+```json
+{
+  "sas_token_lifetime_hours": 12
+}
+```
+
 ## Build
 Required tools and packages:
 

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -130,6 +130,7 @@ func runConfig(params *configContext) error {
 		params.Tuning.PostbackBaseRetryBackoffSeconds,
 	)
 	response.Configuration.CommandTimeoutSeconds = tuningPtr(params.Tuning.CommandTimeoutSeconds)
+	response.Configuration.SasTokenLifetimeHours = tuningPtr(params.Tuning.SasTokenLifetimeHours)
 
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -30,6 +30,7 @@ type tuningFlags struct {
 	PostbackMaxAttempts             int
 	PostbackBaseRetryBackoffSeconds int
 	CommandTimeoutSeconds           int
+	SasTokenLifetimeHours           int
 	// provided records which tuning flag names the operator explicitly set. It is
 	// populated from flag.FlagSet.Visit after parsing so validation can flag an
 	// explicitly-provided non-positive value (e.g. --worker-count -1) even when it
@@ -46,6 +47,7 @@ var tuningFlagNames = []string{
 	"postback-max-attempts",
 	"postback-base-retry-backoff-seconds",
 	"command-timeout-seconds",
+	"sas-token-lifetime-hours",
 }
 
 // captureProvided records which tuning flags were explicitly set on fs so that
@@ -103,6 +105,12 @@ func bindTuningFlags(fs *flag.FlagSet, t *tuningFlags) {
 		tuningFlagUnset,
 		"Per-command execution timeout in seconds; unset means unbounded (positive integer)",
 	)
+	fs.IntVar(
+		&t.SasTokenLifetimeHours,
+		"sas-token-lifetime-hours",
+		tuningFlagUnset,
+		"Azure IoT Hub SAS token lifetime in hours (positive integer)",
+	)
 }
 
 // validate rejects any tuning flag that was explicitly provided with a
@@ -119,6 +127,7 @@ func (t tuningFlags) validate() error {
 		{"postback-max-attempts", t.PostbackMaxAttempts},
 		{"postback-base-retry-backoff-seconds", t.PostbackBaseRetryBackoffSeconds},
 		{"command-timeout-seconds", t.CommandTimeoutSeconds},
+		{"sas-token-lifetime-hours", t.SasTokenLifetimeHours},
 	}
 	for _, c := range checks {
 		if t.provided[c.name] && c.value <= 0 {

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -393,12 +393,34 @@ func (svc *serviceContext) runCycle(
 		svc.flushPostbackSpool(cycleCtx, device, logger)
 	}, "scope", "postback_spool_flush")
 
+	// Proactively renew the SAS token before Azure IoT Hub expires it. The token
+	// minted for this connection is valid for device.SasTokenLifetime(); Azure
+	// tears down the MQTT connection the instant it expires, which would surface
+	// as an Error-level "Connection lost" (indistinguishable from a real fault)
+	// and a forced reconnect on a fixed cadence. Instead we end this cycle
+	// gracefully a safety margin ahead of expiry so the next cycle mints a fresh
+	// token — keeping the connection effectively continuous and reserving the
+	// "Connection lost" log for genuine faults. Like the lost-connection path it
+	// clears the reconnect backoff so the fresh cycle starts promptly.
+	tokenLifetime := device.SasTokenLifetime()
+	renewAfter := tokenLifetime - utils.SasTokenRenewMargin(tokenLifetime)
+	renewTimer := time.NewTimer(renewAfter)
+	defer renewTimer.Stop()
+
 	select {
 	case <-stopped:
 		_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
 		return true, true, 0
 	case <-lost:
 		_ = notifier.Notify("AgentStatus:Offline") // Best effort notification
+		return false, true, 0
+	case <-renewTimer.C:
+		logger.Info(
+			"Renewing SAS token before expiry",
+			"token_lifetime", tokenLifetime,
+			"renew_after", renewAfter,
+		)
+		_ = notifier.Notify("AgentStatus:Reconnecting") // Best effort notification
 		return false, true, 0
 	}
 }

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -114,6 +114,9 @@ func runUpdate(params *updateContext) {
 	if params.Tuning.CommandTimeoutSeconds != tuningFlagUnset {
 		device.CommandTimeoutSeconds = tuningPtr(params.Tuning.CommandTimeoutSeconds)
 	}
+	if params.Tuning.SasTokenLifetimeHours != tuningFlagUnset {
+		device.SasTokenLifetimeHours = tuningPtr(params.Tuning.SasTokenLifetimeHours)
+	}
 
 	// Save the updated configuration file
 	configBytes, err := json.MarshalIndent(device, "", "  ")

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -152,10 +152,28 @@ func (d Device) MqttConnectTimeout() time.Duration {
 	return utils.DefaultMqttConnectTimeout
 }
 
+// sasTokenLifetimeOverrideStr is overridable via -ldflags for integration
+// testing. When set to a valid, positive Go duration it forces the SAS token
+// lifetime — and therefore the proactive-renewal cadence (see
+// utils.SasTokenRenewMargin) — to a short, seconds-scale value so the renewal
+// path can be exercised in seconds instead of the production hours. It is empty
+// in production builds and, when set, takes precedence over the config-driven
+// sas_token_lifetime_hours.
+// Example: -ldflags "-X github.com/RewstApp/agent-smith-go/internal/agent.sasTokenLifetimeOverrideStr=90s"
+var sasTokenLifetimeOverrideStr = ""
+
 // SasTokenLifetime returns the lifetime of the Azure IoT Hub SAS token minted
-// for each MQTT connection, honoring the per-device override when set to a
-// positive value and falling back to utils.DefaultSasTokenLifetime otherwise.
+// for each MQTT connection. An ldflags-injected override (integration builds
+// only) wins when set; otherwise it honors the per-device
+// sas_token_lifetime_hours when set to a positive value and falls back to
+// utils.DefaultSasTokenLifetime.
 func (d Device) SasTokenLifetime() time.Duration {
+	if sasTokenLifetimeOverrideStr != "" {
+		if lifetime, err := time.ParseDuration(sasTokenLifetimeOverrideStr); err == nil &&
+			lifetime > 0 {
+			return lifetime
+		}
+	}
 	if d.SasTokenLifetimeHours != nil && *d.SasTokenLifetimeHours > 0 {
 		return time.Duration(*d.SasTokenLifetimeHours) * time.Hour
 	}

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -55,6 +55,14 @@ type Device struct {
 	// a worker: the command is cancelled once the deadline elapses even if the
 	// MQTT connection stays up.
 	CommandTimeoutSeconds *int `json:"command_timeout_seconds,omitempty"`
+	// SasTokenLifetimeHours optionally overrides the lifetime of the Azure IoT
+	// Hub SAS token minted for each MQTT connection, in hours. When unset (or
+	// non-positive) the agent falls back to utils.DefaultSasTokenLifetime. Azure
+	// IoT Hub disconnects a client when its SAS token expires; the agent
+	// proactively reconnects with a fresh token a safety margin ahead of that
+	// deadline (see utils.SasTokenRenewMargin), so a longer lifetime means less
+	// frequent — but always graceful — reconnects.
+	SasTokenLifetimeHours *int `json:"sas_token_lifetime_hours,omitempty"`
 }
 
 const (
@@ -142,6 +150,16 @@ func (d Device) MqttConnectTimeout() time.Duration {
 		return time.Duration(*d.MqttConnectTimeoutSeconds) * time.Second
 	}
 	return utils.DefaultMqttConnectTimeout
+}
+
+// SasTokenLifetime returns the lifetime of the Azure IoT Hub SAS token minted
+// for each MQTT connection, honoring the per-device override when set to a
+// positive value and falling back to utils.DefaultSasTokenLifetime otherwise.
+func (d Device) SasTokenLifetime() time.Duration {
+	if d.SasTokenLifetimeHours != nil && *d.SasTokenLifetimeHours > 0 {
+		return time.Duration(*d.SasTokenLifetimeHours) * time.Hour
+	}
+	return utils.DefaultSasTokenLifetime
 }
 
 type Plugin struct {

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"testing"
 	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 )
 
 func intPtr(v int) *int { return &v }
@@ -95,6 +97,28 @@ func TestResolvedPostbackMaxAttempts(t *testing.T) {
 			d := Device{PostbackMaxAttempts: tt.value}
 			if got := d.ResolvedPostbackMaxAttempts(); got != tt.expect {
 				t.Errorf("ResolvedPostbackMaxAttempts() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestSasTokenLifetime(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect time.Duration
+	}{
+		{"unset falls back to default", nil, utils.DefaultSasTokenLifetime},
+		{"zero falls back to default", intPtr(0), utils.DefaultSasTokenLifetime},
+		{"negative falls back to default", intPtr(-6), utils.DefaultSasTokenLifetime},
+		{"positive override honored", intPtr(12), 12 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{SasTokenLifetimeHours: tt.value}
+			if got := d.SasTokenLifetime(); got != tt.expect {
+				t.Errorf("SasTokenLifetime() = %v, want %v", got, tt.expect)
 			}
 		})
 	}

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -144,7 +144,12 @@ func TestSasTokenLifetimeOverride(t *testing.T) {
 	for _, bad := range []string{"not-a-duration", "0s", "-5s"} {
 		sasTokenLifetimeOverrideStr = bad
 		if got := d.SasTokenLifetime(); got != 12*time.Hour {
-			t.Errorf("with invalid override %q, SasTokenLifetime() = %v, want %v", bad, got, 12*time.Hour)
+			t.Errorf(
+				"with invalid override %q, SasTokenLifetime() = %v, want %v",
+				bad,
+				got,
+				12*time.Hour,
+			)
 		}
 	}
 

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -124,6 +124,37 @@ func TestSasTokenLifetime(t *testing.T) {
 	}
 }
 
+// TestSasTokenLifetimeOverride verifies the ldflags-injected override (used only
+// by the integration test binary) forces a short lifetime and takes precedence
+// over the config-driven sas_token_lifetime_hours, while an empty or invalid
+// override leaves normal resolution intact.
+func TestSasTokenLifetimeOverride(t *testing.T) {
+	orig := sasTokenLifetimeOverrideStr
+	t.Cleanup(func() { sasTokenLifetimeOverrideStr = orig })
+
+	// A valid override wins even over an explicit per-device lifetime.
+	sasTokenLifetimeOverrideStr = "90s"
+	d := Device{SasTokenLifetimeHours: intPtr(12)}
+	if got := d.SasTokenLifetime(); got != 90*time.Second {
+		t.Errorf("with override set, SasTokenLifetime() = %v, want %v", got, 90*time.Second)
+	}
+
+	// An invalid or non-positive override is ignored, falling back to normal
+	// resolution (here the per-device value).
+	for _, bad := range []string{"not-a-duration", "0s", "-5s"} {
+		sasTokenLifetimeOverrideStr = bad
+		if got := d.SasTokenLifetime(); got != 12*time.Hour {
+			t.Errorf("with invalid override %q, SasTokenLifetime() = %v, want %v", bad, got, 12*time.Hour)
+		}
+	}
+
+	// An empty override (production build) uses normal resolution.
+	sasTokenLifetimeOverrideStr = ""
+	if got := d.SasTokenLifetime(); got != 12*time.Hour {
+		t.Errorf("with empty override, SasTokenLifetime() = %v, want %v", got, 12*time.Hour)
+	}
+}
+
 func TestResolvedPostbackBaseRetryBackoff(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/mqtt/azure_iot_hub.go
+++ b/internal/mqtt/azure_iot_hub.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
@@ -15,6 +16,9 @@ type azureIotHubDevice struct {
 	DeviceId        string
 	Host            string
 	SharedAccessKey string
+	// TokenLifetime is how long the minted SAS token is valid. When zero the
+	// documented default (utils.DefaultSasTokenLifetime) is used.
+	TokenLifetime time.Duration
 }
 
 // generateSASToken generates a SAS token for Azure IoT Hub
@@ -47,9 +51,15 @@ func generateSASToken(resourceURI, key string, duration time.Duration) (string, 
 }
 
 func newAzureIotHubClientOptions(device azureIotHubDevice) (*mqtt.ClientOptions, error) {
-	// Generate SAS token
+	// Generate SAS token. Fall back to the documented default lifetime when the
+	// caller left it unset so the token is never minted with a zero (already
+	// expired) expiry.
+	lifetime := device.TokenLifetime
+	if lifetime <= 0 {
+		lifetime = utils.DefaultSasTokenLifetime
+	}
 	resourceURI := fmt.Sprintf("%s/devices/%s", device.Host, device.DeviceId)
-	sasToken, err := generateSASToken(resourceURI, device.SharedAccessKey, time.Hour)
+	sasToken, err := generateSASToken(resourceURI, device.SharedAccessKey, lifetime)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mqtt/azure_iot_hub_test.go
+++ b/internal/mqtt/azure_iot_hub_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,83 @@ func TestGenerateSASToken(t *testing.T) {
 
 	if !strings.Contains(token, "se=") {
 		t.Errorf("expected to have se=, got %s", token)
+	}
+}
+
+// parseSASTokenExpiry extracts the se= (expiry, unix seconds) field from a SAS
+// token so tests can assert the token lifetime was honored.
+func parseSASTokenExpiry(t *testing.T, token string) int64 {
+	t.Helper()
+	for _, part := range strings.Split(token, "&") {
+		if suffix, ok := strings.CutPrefix(part, "se="); ok {
+			exp, err := strconv.ParseInt(suffix, 10, 64)
+			if err != nil {
+				t.Fatalf("failed to parse se= from token %q: %v", token, err)
+			}
+			return exp
+		}
+	}
+	t.Fatalf("token %q missing se= expiry field", token)
+	return 0
+}
+
+func TestGenerateSASTokenHonorsLifetime(t *testing.T) {
+	resourceURI := "my-iot-hub.azure-devices.net/devices/mydevice"
+	key := "c2VjcmV0a2V5" // "secretkey" in base64
+
+	const lifetime = 24 * time.Hour
+	before := time.Now().Add(lifetime).Unix()
+	token, err := generateSASToken(resourceURI, key, lifetime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	after := time.Now().Add(lifetime).Unix()
+
+	exp := parseSASTokenExpiry(t, token)
+	if exp < before || exp > after {
+		t.Errorf(
+			"expected token expiry within [%d, %d] (now + %v), got %d",
+			before,
+			after,
+			lifetime,
+			exp,
+		)
+	}
+}
+
+func TestNewAzureIotHubClientOptionsTokenLifetime(t *testing.T) {
+	base := azureIotHubDevice{
+		DeviceId:        "testdevice",
+		Host:            "testhub.azure-devices.net",
+		SharedAccessKey: "c2VjcmV0a2V5", // "secretkey" in base64
+	}
+
+	// A zero lifetime falls back to the documented default rather than minting an
+	// already-expired token.
+	unsetOpts, err := newAzureIotHubClientOptions(base)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	unsetExp := parseSASTokenExpiry(t, unsetOpts.Password)
+	if unsetExp <= time.Now().Unix() {
+		t.Errorf("expected default-lifetime token to expire in the future, got %d", unsetExp)
+	}
+
+	// A short explicit lifetime must yield an earlier expiry than the (much
+	// longer) default, proving the configured lifetime is threaded through.
+	shortDevice := base
+	shortDevice.TokenLifetime = time.Hour
+	shortOpts, err := newAzureIotHubClientOptions(shortDevice)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	shortExp := parseSASTokenExpiry(t, shortOpts.Password)
+	if shortExp >= unsetExp {
+		t.Errorf(
+			"expected 1h-lifetime token (exp %d) to expire before the default-lifetime token (exp %d)",
+			shortExp,
+			unsetExp,
+		)
 	}
 }
 

--- a/internal/mqtt/common.go
+++ b/internal/mqtt/common.go
@@ -31,6 +31,7 @@ func NewClientOptions(device agent.Device) (*mqtt.ClientOptions, error) {
 			DeviceId:        device.DeviceId,
 			Host:            device.AzureIotHubHost,
 			SharedAccessKey: device.SharedAccessKey,
+			TokenLifetime:   device.SasTokenLifetime(),
 		})
 	}
 

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -49,6 +49,54 @@ const DefaultMqttKeepAlive time.Duration = 30 * time.Second
 // same predictability reason as DefaultMqttKeepAlive.
 const DefaultMqttPingTimeout time.Duration = 10 * time.Second
 
+// DefaultSasTokenLifetime is the lifetime of the Azure IoT Hub SAS token minted
+// for each MQTT connection.
+//
+// Azure IoT Hub forcibly disconnects a client the moment its SAS token expires.
+// An earlier design minted a token valid for only 1 hour, so every healthy
+// connection was torn down roughly once per hour — firing OnConnectionLost,
+// logging a spurious Error-level "Connection lost", and forcing a full reconnect
+// on every agent forever. At scale that also churned the hub as agents
+// reconnected on their own hourly cadence.
+//
+// The lifetime is raised to 24 hours so the forced-disconnect cadence drops from
+// hourly to at most daily, and the agent additionally reconnects gracefully a
+// safety margin ahead of expiry (see SasTokenRenewMargin) so the token never
+// actually expires on a live connection. Deployments that need a different
+// cadence can override it per-device via sas_token_lifetime_hours.
+const DefaultSasTokenLifetime time.Duration = 24 * time.Hour
+
+// SasTokenRenewMargin returns how long before an Azure IoT Hub SAS token's
+// expiry the agent should proactively reconnect with a freshly minted token.
+// Because Azure disconnects a client the instant its token expires, reconnecting
+// a safety margin ahead of that deadline keeps the connection continuous and
+// lets the reconnect be logged as a routine token renewal rather than an
+// Error-level "Connection lost".
+//
+// The margin is 10% of the token lifetime, floored at 1 minute so even a short
+// lifetime still renews ahead of expiry (accommodating clock skew and the
+// reconnect handshake), and capped at 15 minutes so a long-lived token spends
+// almost its entire lifetime in use rather than reconnecting needlessly early.
+// For a lifetime shorter than the floor it falls back to half the lifetime so
+// the resulting renew-after delay (lifetime - margin) always stays positive.
+func SasTokenRenewMargin(lifetime time.Duration) time.Duration {
+	const (
+		minMargin = 1 * time.Minute
+		maxMargin = 15 * time.Minute
+	)
+	margin := lifetime / 10
+	if margin < minMargin {
+		margin = minMargin
+	}
+	if margin > maxMargin {
+		margin = maxMargin
+	}
+	if margin >= lifetime {
+		margin = lifetime / 2
+	}
+	return margin
+}
+
 type ReconnectTimeoutGenerator struct {
 	base    time.Duration
 	timeout time.Duration

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -83,6 +83,47 @@ func TestDefaultMqttConnectTimeoutIsDecoupledFromBackoff(t *testing.T) {
 	}
 }
 
+// TestSasTokenRenewMargin asserts the renew margin is always a positive
+// duration strictly less than the token lifetime, so the derived renew-after
+// delay (lifetime - margin) is positive and the agent reconnects ahead of
+// expiry across the full range of configurable lifetimes.
+func TestSasTokenRenewMargin(t *testing.T) {
+	tests := []struct {
+		name     string
+		lifetime time.Duration
+		expect   time.Duration
+	}{
+		// 10% of lifetime when that sits between the floor and cap.
+		{"one hour uses 10 percent", time.Hour, 6 * time.Minute},
+		// 10% of 24h is 2.4h, capped at 15m.
+		{"one day capped at max", 24 * time.Hour, 15 * time.Minute},
+		// 10% of 5m is 30s, floored at 1m.
+		{"short lifetime floored", 5 * time.Minute, time.Minute},
+		// Lifetime below the floor falls back to half the lifetime so
+		// renew-after stays positive.
+		{"tiny lifetime uses half", 30 * time.Second, 15 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SasTokenRenewMargin(tt.lifetime)
+			if got != tt.expect {
+				t.Errorf("SasTokenRenewMargin(%v) = %v, want %v", tt.lifetime, got, tt.expect)
+			}
+			if got <= 0 {
+				t.Errorf("SasTokenRenewMargin(%v) must be positive, got %v", tt.lifetime, got)
+			}
+			if got >= tt.lifetime {
+				t.Errorf(
+					"SasTokenRenewMargin(%v) = %v must be < lifetime so renew-after stays positive",
+					tt.lifetime,
+					got,
+				)
+			}
+		})
+	}
+}
+
 func TestReconnectTimeoutGeneratorJitterDiffers(t *testing.T) {
 	// Two independent generators must produce different sequences
 	g1 := ReconnectTimeoutGenerator{}

--- a/scripts/build_integration_test.ps1
+++ b/scripts/build_integration_test.ps1
@@ -4,6 +4,9 @@
 # Builds a special integration test binary with:
 # - version overridden to 0.0.0-it (older than any real release, forces auto-update)
 # - updateIntervalStr overridden to 30s (triggers update check quickly)
+# - sasTokenLifetimeOverrideStr overridden to 90s (proactive SAS token renewal
+#   fires ~30s in - lifetime minus the ~60s renew margin - so the renewal path
+#   can be exercised in seconds not hours)
 
 $env:GOARCH = "amd64"
 
@@ -11,7 +14,8 @@ $versionFlag = "-X github.com/RewstApp/agent-smith-go/internal/version.Version=v
 $intervalFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.updateIntervalStr=30s"
 $baseBackoffFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.baseBackoffStr=10s"
 $maxRetriesFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.maxRetriesStr=6"
-$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag"
+$sasTokenLifetimeFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.sasTokenLifetimeOverrideStr=90s"
+$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag"
 
 if ($IsWindows) {
     $buildOutput = "./dist/rewst_agent_config.win.it.exe"


### PR DESCRIPTION
## Summary

The Azure IoT Hub SAS token was minted with a fixed **1-hour** lifetime and never renewed on a live connection. Azure disconnects a client the instant its token expires, so every healthy agent connection was torn down ~hourly — firing `OnConnectionLost`, logging a spurious `Error` "Connection lost", and forcing a full reconnect on every agent forever. At scale this also churned the hub as agents reconnected on their own hourly cadence.

This PR stops the forced hourly churn with two complementary changes, both following the repo's existing per-device tuning-flag pattern:

1. **Longer, documented, configurable token lifetime** — default raised from 1h to **24h** (`utils.DefaultSasTokenLifetime`), overridable via `sas_token_lifetime_hours` / `--sas-token-lifetime-hours`. The lifetime is threaded through `azureIotHubDevice.TokenLifetime` into token generation, with a safety fallback to the default on a zero value.
2. **Proactive graceful renewal before expiry** — `runCycle` now runs a renewal timer alongside the `stopped`/`lost` select. It fires a safety margin ahead of expiry (`utils.SasTokenRenewMargin`: 10% of lifetime, floored at 1m, capped at 15m) and ends the cycle cleanly so the next cycle mints a fresh token. This reconnect logs a routine `Info` **"Renewing SAS token before expiry"** — distinct from the `Error` "Connection lost".

## Acceptance criteria

- ✅ Longer lifetime **and** proactive renewal so healthy connections aren't torn down on a fixed hourly cadence.
- ✅ Token-renewal reconnect logged distinctly (`Info`) from an unexpected `Error` "Connection lost".
- ✅ Reconnect behavior on a genuine connection loss is unchanged (the `lost` path is untouched).
- ✅ No authentication regression — tokens remain valid; existing SAS-token/client-options tests pass.

## Tests

- `TestSasTokenRenewMargin` — margin is positive and always `< lifetime` across the range.
- `TestSasTokenLifetime` — resolver honors override / falls back to default.
- `TestGenerateSASTokenHonorsLifetime` and `TestNewAzureIotHubClientOptionsTokenLifetime` — configured lifetime reaches the token's `se=` expiry.

The renewal *timer firing* is not unit-tested because the lifetime is hour-granular by design (prevents pathologically short lifetimes); it's covered by the ticket's QA step of a real >1h agent run. `go test ./...`, `go vet`, and `gofmt` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)