### PR TITLE
fix: [sc-103967] Sweep stale temp script files on agent startup

### DIFF
--- a/.github/actions/kill-service/action.yml
+++ b/.github/actions/kill-service/action.yml
@@ -1,0 +1,75 @@
+name: Kill service
+description: >
+  Abruptly kill the agent service process tree with SIGKILL (taskkill /F /T on
+  Windows), giving the agent no chance to shut down cleanly. Unlike stop-service
+  this deliberately skips the graceful path, so the agent's deferred cleanup
+  never runs - the same state a force-stop, OOM kill or host power loss leaves
+  behind. On Linux and macOS the service manager brings the agent back up on its
+  own afterwards (Restart=always / KeepAlive), mirroring a real abrupt restart;
+  on Windows the service stays stopped until the next start.
+
+inputs:
+  service:
+    description: "Service name"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Kill service (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+      run: |
+        set -euo pipefail
+        echo "Force-killing service $SERVICE"
+        # systemctl kill signals every process in the unit's cgroup, so the shell
+        # the agent spawned for the in-flight command dies with it and cannot keep
+        # holding its script file open.
+        sudo systemctl kill --signal=SIGKILL "$SERVICE"
+        sudo systemctl status "$SERVICE" --no-pager || true
+
+    - name: Kill service (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+      run: |
+        set -euo pipefail
+        # Resolve the running pid from launchd and signal it directly: the
+        # "launchctl kill" signal argument spelling varies between releases,
+        # whereas kill -9 on the reported pid behaves the same everywhere.
+        service_pid=$(sudo launchctl print "system/$SERVICE" | awk '/^\tpid = /{print $3; exit}')
+        if [ -z "${service_pid:-}" ]; then
+          echo "Could not determine pid for service $SERVICE" >&2
+          sudo launchctl print "system/$SERVICE" >&2 || true
+          exit 1
+        fi
+        echo "Force-killing service $SERVICE (pid $service_pid)"
+        sudo kill -9 "$service_pid"
+
+    - name: Kill service (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+      run: |
+        $query = sc.exe queryex "$env:SERVICE"
+        $pidMatch = $query | Select-String -Pattern 'PID\s*:\s*(\d+)'
+        if (-not $pidMatch) {
+          Write-Output ($query | Out-String)
+          Write-Error "Could not determine PID for service $env:SERVICE"
+          exit 1
+        }
+        $servicePid = [int]$pidMatch.Matches[0].Groups[1].Value
+        if ($servicePid -le 0) {
+          Write-Error "Service $env:SERVICE is not running (reported PID $servicePid)"
+          exit 1
+        }
+        Write-Output "Force-killing service $env:SERVICE (PID $servicePid)"
+        # /T kills the spawned PowerShell along with the agent, so no child is
+        # left holding the in-flight script file open (Windows blocks deletion of
+        # open files, which would otherwise defeat the sweep under test).
+        taskkill.exe /F /T /PID $servicePid
+        sc.exe query "$env:SERVICE"

--- a/.github/actions/script-sweep-fixture/action.yml
+++ b/.github/actions/script-sweep-fixture/action.yml
@@ -1,0 +1,60 @@
+name: Script sweep fixture
+description: >
+  Seed (mode=seed) or verify (mode=assert) the script-file fixture for the
+  startup stale script sweep scenario. See fixture.ps1 for what the fixture
+  contains and asserts. The scripts directory belongs to the service account
+  (root / SYSTEM) and on macOS lives under root's own temp directory, so the
+  shared implementation runs elevated: under sudo on Unix, natively on the
+  already-elevated Windows runner.
+
+inputs:
+  mode:
+    description: "seed to place the fixture files, assert to verify the sweep result"
+    required: true
+  scripts_dir:
+    description: "Scripts directory the agent writes command script files to"
+    required: true
+  orphan_path:
+    description: "Script file left behind by the force-killed command, if any"
+    required: false
+    default: ""
+  stale_age_hours:
+    description: "How far back to backdate the files that must be swept"
+    required: false
+    default: "48"
+
+runs:
+  using: composite
+  steps:
+    - name: Run script sweep fixture (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
+        ORPHAN_PATH: ${{ inputs.orphan_path }}
+        STALE_AGE_HOURS: ${{ inputs.stale_age_hours }}
+      run: |
+        set -euo pipefail
+        # Resolve pwsh up front: sudo resets PATH via secure_path on some runners.
+        pwsh_path="$(command -v pwsh)"
+        sudo "$pwsh_path" -NoProfile -File "$GITHUB_ACTION_PATH/fixture.ps1" \
+          -Mode "$MODE" \
+          -ScriptsDir "$SCRIPTS_DIR" \
+          -OrphanPath "$ORPHAN_PATH" \
+          -StaleAgeHours "$STALE_AGE_HOURS"
+
+    - name: Run script sweep fixture (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        MODE: ${{ inputs.mode }}
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
+        ORPHAN_PATH: ${{ inputs.orphan_path }}
+        STALE_AGE_HOURS: ${{ inputs.stale_age_hours }}
+      run: |
+        & "$env:GITHUB_ACTION_PATH/fixture.ps1" `
+          -Mode $env:MODE `
+          -ScriptsDir $env:SCRIPTS_DIR `
+          -OrphanPath $env:ORPHAN_PATH `
+          -StaleAgeHours ([int]$env:STALE_AGE_HOURS)

--- a/.github/actions/script-sweep-fixture/fixture.ps1
+++ b/.github/actions/script-sweep-fixture/fixture.ps1
@@ -1,0 +1,109 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+Seeds (mode seed) or verifies (mode assert) the file fixture for the startup
+stale script sweep scenario (sc-103967).
+
+.DESCRIPTION
+Three control files are placed in the agent's scripts directory:
+
+  exec-900000001.ps1  matches the agent's own temp script pattern and is aged
+                      past the sweep threshold, so it must be reclaimed
+  exec-900000002.ps1  matches the pattern but keeps the current timestamp,
+                      standing in for a command that is still executing
+  operator-script.ps1 is aged but is not a name the agent ever creates, so the
+                      sweep must leave it alone however stale it is
+
+When -OrphanPath is supplied it is the script file a force-killed command left
+behind. Seeding requires that file to still exist - it is the leak the sweep
+exists to clean up, so its absence means the scenario is not exercising
+anything - and ages it alongside the control files. Ageing is the only thing
+simulated here: it is exactly what a long-lived install does by staying up.
+#>
+
+param(
+    [Parameter(Mandatory)][ValidateSet('seed', 'assert')][string]$Mode,
+    [Parameter(Mandatory)][string]$ScriptsDir,
+    [string]$OrphanPath = '',
+    [int]$StaleAgeHours = 48
+)
+
+$ErrorActionPreference = 'Stop'
+
+$stale = Join-Path $ScriptsDir 'exec-900000001.ps1'
+$fresh = Join-Path $ScriptsDir 'exec-900000002.ps1'
+$foreign = Join-Path $ScriptsDir 'operator-script.ps1'
+
+function Show-ScriptsDir {
+    Write-Output "Contents of ${ScriptsDir}:"
+    Get-ChildItem -LiteralPath $ScriptsDir -Force |
+        Select-Object Name, Length, LastWriteTime |
+        Format-Table |
+        Out-String |
+        Write-Output
+}
+
+if (-not (Test-Path -LiteralPath $ScriptsDir)) {
+    Write-Error "Scripts directory does not exist: $ScriptsDir"
+    exit 1
+}
+
+if ($Mode -eq 'seed') {
+    if ($OrphanPath) {
+        if (-not (Test-Path -LiteralPath $OrphanPath)) {
+            Write-Error "Expected the force-killed command to leave $OrphanPath behind, but it is already gone"
+            exit 1
+        }
+        Write-Output "Confirmed the interrupted command leaked $OrphanPath"
+    }
+
+    Set-Content -LiteralPath $stale -Value '# stale agent script (integration test)'
+    Set-Content -LiteralPath $fresh -Value '# fresh agent script (integration test)'
+    Set-Content -LiteralPath $foreign -Value '# operator script (integration test)'
+
+    $aged = (Get-Date).AddHours(-$StaleAgeHours)
+    $toAge = @($stale, $foreign)
+    if ($OrphanPath) { $toAge += $OrphanPath }
+    foreach ($path in $toAge) {
+        (Get-Item -LiteralPath $path -Force).LastWriteTime = $aged
+        Write-Output "Aged $path to $aged"
+    }
+
+    Show-ScriptsDir
+    exit 0
+}
+
+$failed = $false
+
+$mustBeGone = @($stale)
+if ($OrphanPath) { $mustBeGone += $OrphanPath }
+foreach ($path in $mustBeGone) {
+    if (Test-Path -LiteralPath $path) {
+        Write-Output "FAIL: stale script file was not swept: $path"
+        $failed = $true
+    }
+    else {
+        Write-Output "OK: stale script file was swept: $path"
+    }
+}
+
+foreach ($path in @($fresh, $foreign)) {
+    if (Test-Path -LiteralPath $path) {
+        Write-Output "OK: file the sweep must not touch survived: $path"
+    }
+    else {
+        Write-Output "FAIL: sweep removed a file it must not touch: $path"
+        $failed = $true
+    }
+}
+
+Show-ScriptsDir
+
+if ($failed) {
+    Write-Error 'Startup script sweep did not behave as expected'
+    exit 1
+}
+
+Write-Output 'Startup script sweep reclaimed the stale agent script files and nothing else'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -117,6 +117,7 @@ jobs:
               success_commands = '"echo \"hello world\""'
               failure_commands = '"exit 1"'
               timeout_commands = '"sleep 30"'
+              sweep_commands = '"sleep 180"'
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/etc/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n/tmp/rewst_remote_agent/scripts/$orgId"
@@ -134,6 +135,7 @@ jobs:
               success_commands = $winSuccess
               failure_commands = $winFailure
               timeout_commands = '"Start-Sleep -Seconds 30"'
+              sweep_commands = '"Start-Sleep -Seconds 180"'
               success_patterns = "Command completed`nSending postback`nPostback already sent"
               no_auto_updates_extra = '--disable-agent-postback'
               uninstall_paths = "C:\ProgramData\RewstRemoteAgent\$orgId`nC:\Program Files\RewstRemoteAgent\$orgId`nC:\RewstRemoteAgent\scripts\$orgId"
@@ -151,6 +153,7 @@ jobs:
               success_commands = '"echo \"hello world\""'
               failure_commands = '"exit 1"'
               timeout_commands = '"sleep 30"'
+              sweep_commands = '"sleep 180"'
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/Library/Application Support/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n`$env:TMPDIR/rewst_remote_agent/scripts/$orgId"
@@ -662,6 +665,152 @@ jobs:
           }
           Write-Error "No command completed after SAS renewal (count stayed at $baseline)"
           exit 1
+
+      # ---- Stale script file sweep scenario (sc-103967) ----
+      # A command interrupted by an abrupt kill (force-stop, OOM kill, power
+      # loss) never runs its deferred temp-file cleanup, so its script file is
+      # stranded in the scripts directory and nothing used to reclaim it. Verify
+      # the startup sweep now does: force-kill the service mid-command to strand
+      # a real script file, age it (plus a control set) into the months-old
+      # debris a long-lived install accumulates, restart, and confirm only the
+      # agent's own stale files are removed.
+      #
+      # The release binary is reinstalled first, with auto-updates off and the
+      # per-command timeout raised well past the command's runtime, so nothing
+      # ends the command before the kill lands - not the 5s timeout from the
+      # earlier scenario, the 30s auto-updater, or the IT binary's 90s SAS
+      # lifetime. Each of those tears the command down gracefully, and graceful
+      # teardown DOES run the cleanup, leaving no stranded file to sweep.
+      - name: Capture sweep scenario baseline counts
+        id: sweep_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          $saved      = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command saved to"))).Count } else { 0 }
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "saved=$saved"           >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed saved=$saved"
+
+      - name: Install release binary for the sweep scenario
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates ${{ matrix.no_auto_updates_extra }} --command-timeout-seconds 600 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for fresh subscription before the sweep scenario
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.sweep_baseline.outputs.subscribed }}
+        run: |
+          # A delta, not a bare match: the log already carries many "Subscribed to
+          # messages" lines from earlier scenarios, so only a new one proves the
+          # restarted agent is connected and ready to receive the command.
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent subscribed after the sweep-scenario install (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent did not subscribe after the sweep-scenario install (count stayed at $baseline)"
+          exit 1
+
+      - name: Send long-running command
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.sweep_commands }}
+
+      - name: Capture the in-flight script file path
+        id: inflight_script
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.sweep_baseline.outputs.saved }}
+        run: |
+          # The agent logs the temp file it wrote the command to, so read the path
+          # (and the scripts directory) straight from the log instead of
+          # re-deriving the platform path - the service's temp directory is not
+          # the runner's, notably root's private TMPDIR on macOS.
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $found = if ($content) { [regex]::Matches($content, 'Command saved to[^\r\n]*path=(?<p>\S+)') } else { @() }
+            if ($found.Count -gt $baseline) {
+              $path = $found[$found.Count - 1].Groups['p'].Value.Trim('"')
+              $dir = Split-Path -Parent $path
+              "path=$path" >> $env:GITHUB_OUTPUT
+              "scripts_dir=$dir" >> $env:GITHUB_OUTPUT
+              Write-Output "In-flight script file: $path (scripts directory $dir)"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent never logged a script file for the long-running command (count stayed at $baseline)"
+          exit 1
+
+      - name: Force-kill the agent mid-command
+        uses: ./.github/actions/kill-service
+        with:
+          service: ${{ matrix.service }}
+
+      - name: Age the stranded script file and seed sweep control files
+        uses: ./.github/actions/script-sweep-fixture
+        with:
+          mode: seed
+          scripts_dir: ${{ steps.inflight_script.outputs.scripts_dir }}
+          orphan_path: ${{ steps.inflight_script.outputs.path }}
+
+      - name: Capture sweep log baseline count
+        id: sweep_log_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $swept = if ($content) { ([regex]::Matches($content, [regex]::Escape("Swept stale script files"))).Count } else { 0 }
+          "swept=$swept" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> swept=$swept"
+
+      - name: Restart agent to trigger the startup sweep
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates ${{ matrix.no_auto_updates_extra }} --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for and assert the startup sweep was logged
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.sweep_log_baseline.outputs.swept }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $swept = if ($content) { ([regex]::Matches($content, [regex]::Escape("Swept stale script files"))).Count } else { 0 }
+            if ($swept -gt $baseline) {
+              Write-Output "Startup sweep logged (count $swept > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Startup sweep was never logged (count stayed at $baseline)"
+          exit 1
+
+      - name: Assert stale script files swept and live files untouched
+        uses: ./.github/actions/script-sweep-fixture
+        with:
+          mode: assert
+          scripts_dir: ${{ steps.inflight_script.outputs.scripts_dir }}
+          orphan_path: ${{ steps.inflight_script.outputs.path }}
 
       - name: Uninstall agent
         uses: ./.github/actions/run-agent

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -86,6 +86,17 @@ func (svc *serviceContext) loadLog() (*os.File, error) {
 	return logFile, nil
 }
 
+// scriptsOrgId returns the org id whose scripts directory the executor writes
+// command script files to. The executor derives that path from the device
+// config's org id, so the startup sweep must use the same value; svc.OrgId (from
+// the command line) is only a fallback for a config that omits it.
+func (svc *serviceContext) scriptsOrgId(device agent.Device) string {
+	if device.RewstOrgId != "" {
+		return device.RewstOrgId
+	}
+	return svc.OrgId
+}
+
 func (svc *serviceContext) Name() string {
 	return agent.GetServiceName(svc.OrgId)
 }
@@ -217,6 +228,21 @@ func (svc *serviceContext) Execute(
 
 	running <- struct{}{}
 	_ = notifier.Notify("AgentStarted") // Best effort notification
+
+	// Reclaim script files left behind by previous runs that were killed before
+	// their deferred cleanup could run (force-stop, host power loss, OOM kill).
+	// Nothing else ever removes them, so without this sweep they accumulate for
+	// the lifetime of the installation. It runs after the service has reported
+	// itself running so a slow or crowded scripts directory can never delay
+	// startup, and it is best effort by construction — failures are logged inside.
+	// The org id is taken from the device config rather than the command line so
+	// the swept directory is exactly the one the executor writes to.
+	interpreter.SweepStaleScripts(
+		agent.GetScriptsDirectory(svc.scriptsOrgId(device)),
+		interpreter.DefaultStaleScriptAge,
+		logger,
+	)
+
 	rg := utils.ReconnectTimeoutGenerator{}
 
 	for {

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -1498,3 +1498,104 @@ func TestPostbackRetryBackoff_NonPositiveInputsFallBackToDefaults(t *testing.T) 
 		t.Fatalf("expected backoff within defaulted cap %v, got %v", postbackMaxRetryBackoff, got)
 	}
 }
+
+// TestExecute_SweepsStaleScriptFilesOnStartup verifies the sc-103967 startup
+// sweep: script files orphaned by a previous run that was killed before its
+// deferred cleanup could run are reclaimed when the service starts, while files
+// that are recent (a command may still be executing) or not created by the agent
+// are left alone.
+func TestExecute_SweepsStaleScriptFilesOnStartup(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	orgId := "test-org-sweep"
+	device := agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		RewstOrgId:           orgId,
+		LoggingLevel:         "info",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+	configBytes, _ := json.Marshal(device)
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	scriptsDir := agent.GetScriptsDirectory(orgId)
+	if err := os.MkdirAll(scriptsDir, utils.DefaultDirMod); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(scriptsDir) })
+
+	write := func(name string, age time.Duration) string {
+		path := filepath.Join(scriptsDir, name)
+		if err := os.WriteFile(path, []byte("echo hello"), utils.DefaultFileMod); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+		modTime := time.Now().Add(-age)
+		if err := os.Chtimes(path, modTime, modTime); err != nil {
+			t.Fatalf("failed to set mtime on %s: %v", name, err)
+		}
+		return path
+	}
+
+	stale := write("exec-123456789.ps1", 48*time.Hour)
+	recent := write("exec-987654321.ps1", time.Minute)
+	foreign := write("operator-script.ps1", 48*time.Hour)
+
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(o *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &mockMQTTClient{}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      orgId,
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+
+	done := make(chan service.ServiceExitCode, 1)
+	go func() {
+		done <- svc.Execute(stop, running)
+	}()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("expected the stale script file to be swept, stat err = %v", err)
+	}
+	if _, err := os.Stat(recent); err != nil {
+		t.Errorf("expected the recent script file to survive: %v", err)
+	}
+	if _, err := os.Stat(foreign); err != nil {
+		t.Errorf("expected a file the agent did not create to survive: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "Swept stale script files") {
+		t.Errorf("expected the sweep to be logged, log was:\n%s", logBytes)
+	}
+}

--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -128,7 +128,7 @@ func (e *baseExecutor) Execute(
 		return errorResultBytes(logger, err)
 	}
 
-	tempfile, err := os.CreateTemp(scriptsDir, "exec-*.ps1")
+	tempfile, err := os.CreateTemp(scriptsDir, scriptTempPattern)
 	if err != nil {
 		return errorResultBytes(logger, err)
 	}

--- a/internal/interpreter/script_sweep.go
+++ b/internal/interpreter/script_sweep.go
@@ -1,0 +1,122 @@
+package interpreter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+const (
+	// scriptFilePrefix and scriptFileSuffix are the fixed parts of the temp script
+	// name pattern handed to os.CreateTemp in Execute ("exec-*.ps1"). They are
+	// shared with the startup sweep so the pattern it matches can never drift from
+	// the pattern the executor writes.
+	scriptFilePrefix = "exec-"
+	scriptFileSuffix = ".ps1"
+
+	// scriptTempPattern is the os.CreateTemp pattern for a command script file.
+	scriptTempPattern = scriptFilePrefix + "*" + scriptFileSuffix
+
+	// DefaultStaleScriptAge is how old an orphaned script file must be before the
+	// startup sweep reclaims it. Execute always removes its own script file on
+	// every exit path, so anything left behind belongs to a run that was killed
+	// abruptly (SIGKILL, service force-stop, power loss, OOM). The threshold is
+	// deliberately generous — commands are unbounded unless
+	// command_timeout_seconds is configured, so a file this old cannot plausibly
+	// belong to a command another agent process is still executing.
+	DefaultStaleScriptAge = 24 * time.Hour
+)
+
+// SweepStaleScripts removes orphaned command script files left in dir by agent
+// runs that were terminated before their deferred cleanup could run. Without it
+// exec-*.ps1 files accumulate for the lifetime of the installation, consuming
+// disk and leaving script contents on disk indefinitely.
+//
+// The sweep is intentionally conservative: it only considers regular files whose
+// name matches the exact pattern Execute creates (see isScriptFile) and whose
+// modification time is older than maxAge, so it can never delete a file created
+// by another process or a script belonging to a command still in flight. Every
+// failure — an unreadable directory, an unremovable file — is logged and
+// skipped; the sweep never returns an error, because housekeeping must not block
+// the agent from starting.
+//
+// It returns the number of files removed.
+func SweepStaleScripts(dir string, maxAge time.Duration, logger hclog.Logger) int {
+	if maxAge <= 0 {
+		maxAge = DefaultStaleScriptAge
+	}
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		// A missing scripts directory is the normal state of a fresh install.
+		if !os.IsNotExist(err) {
+			logger.Error("Failed to read scripts directory for sweep", "dir", dir, "error", err)
+		}
+		return 0
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+	removed := 0
+	for _, de := range dirEntries {
+		if de.IsDir() || !isScriptFile(de.Name()) {
+			continue
+		}
+
+		info, err := de.Info()
+		if err != nil {
+			// The file vanished (or became unreadable) between ReadDir and here;
+			// leave it for a later sweep rather than guessing at its age.
+			if !os.IsNotExist(err) {
+				logger.Error("Failed to stat stale script file", "file", de.Name(), "error", err)
+			}
+			continue
+		}
+
+		// Only regular files: a symlink or device node planted in the scripts
+		// directory is not something this agent created and must not be followed.
+		if !info.Mode().IsRegular() || !info.ModTime().Before(cutoff) {
+			continue
+		}
+
+		path := filepath.Join(dir, de.Name())
+		if err := os.Remove(path); err != nil {
+			if !os.IsNotExist(err) {
+				logger.Error("Failed to remove stale script file", "file", path, "error", err)
+			}
+			continue
+		}
+		logger.Debug("Removed stale script file", "file", path, "modified", info.ModTime())
+		removed++
+	}
+
+	if removed > 0 {
+		logger.Info("Swept stale script files", "dir", dir, "removed", removed, "max_age", maxAge)
+	}
+
+	return removed
+}
+
+// isScriptFile reports whether name matches the temp script names produced by
+// os.CreateTemp(dir, scriptTempPattern): the fixed prefix and suffix around a
+// non-empty run of decimal digits. Requiring the random middle to be numeric
+// keeps the sweep from touching similarly named files that this agent did not
+// create (for example an operator's own "exec-backup.ps1").
+func isScriptFile(name string) bool {
+	if !strings.HasPrefix(name, scriptFilePrefix) || !strings.HasSuffix(name, scriptFileSuffix) {
+		return false
+	}
+
+	middle := name[len(scriptFilePrefix) : len(name)-len(scriptFileSuffix)]
+	if middle == "" {
+		return false
+	}
+	for _, r := range middle {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/interpreter/script_sweep_test.go
+++ b/internal/interpreter/script_sweep_test.go
@@ -129,8 +129,13 @@ func TestSweepStaleScripts_MissingDirectoryIsNotAnError(t *testing.T) {
 }
 
 func TestSweepStaleScripts_ReadDirFailureIsLoggedNotFatal(t *testing.T) {
-	// A path that is a regular file, not a directory: ReadDir fails with a
-	// non-NotExist error, which must be logged and swallowed.
+	// A path that is a regular file rather than a directory. What ReadDir reports
+	// for that is platform-specific — ENOTDIR on Unix, but a not-exist-flavoured
+	// error or simply zero entries on Windows, where the directory read runs
+	// against an open file handle — so the log expectation is derived from what
+	// this platform actually reports. What must hold everywhere is that the sweep
+	// removes nothing and does not fail; a reported failure is logged, and an
+	// absent or not-exist error stays silent like the fresh-install case.
 	path := writeScriptFile(t, t.TempDir(), "not-a-dir", 0)
 
 	logger, buf := newSweepLogger()
@@ -138,8 +143,17 @@ func TestSweepStaleScripts_ReadDirFailureIsLoggedNotFatal(t *testing.T) {
 		t.Errorf("expected 0 files removed, got %d", removed)
 	}
 
-	if logs := buf.String(); !strings.Contains(logs, "Failed to read scripts directory") {
-		t.Errorf("expected the read failure to be logged, got %q", logs)
+	logs := buf.String()
+	_, readErr := os.ReadDir(path)
+	if readErr == nil || os.IsNotExist(readErr) {
+		if strings.Contains(logs, "[ERROR]") {
+			t.Errorf("expected no error log when ReadDir reports %v, got %q", readErr, logs)
+		}
+		return
+	}
+
+	if !strings.Contains(logs, "Failed to read scripts directory") {
+		t.Errorf("expected the read failure (%v) to be logged, got %q", readErr, logs)
 	}
 }
 

--- a/internal/interpreter/script_sweep_test.go
+++ b/internal/interpreter/script_sweep_test.go
@@ -1,0 +1,178 @@
+package interpreter
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
+)
+
+// writeScriptFile creates a file in dir with the given modification age.
+func writeScriptFile(t *testing.T, dir, name string, age time.Duration) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("echo hello"), utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+
+	modTime := time.Now().Add(-age)
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("failed to set mtime on %s: %v", name, err)
+	}
+	return path
+}
+
+func newSweepLogger() (hclog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Debug}), &buf
+}
+
+func TestSweepStaleScripts_RemovesStaleFiles(t *testing.T) {
+	dir := t.TempDir()
+	stale := []string{"exec-123456789.ps1", "exec-987654321.ps1", "exec-1.ps1"}
+	for _, name := range stale {
+		writeScriptFile(t, dir, name, 48*time.Hour)
+	}
+
+	logger, buf := newSweepLogger()
+	removed := SweepStaleScripts(dir, DefaultStaleScriptAge, logger)
+
+	if removed != len(stale) {
+		t.Errorf("expected %d files removed, got %d", len(stale), removed)
+	}
+	for _, name := range stale {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, stat err = %v", name, err)
+		}
+	}
+	if logs := buf.String(); !strings.Contains(logs, "Swept stale script files") {
+		t.Errorf("expected a summary log line, got %q", logs)
+	}
+}
+
+func TestSweepStaleScripts_KeepsRecentAndForeignFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// A script file younger than the threshold: it may belong to a command that is
+	// still executing, so it must survive.
+	recent := writeScriptFile(t, dir, "exec-111111111.ps1", time.Minute)
+
+	// Old files that do not match the agent's own temp pattern belong to someone
+	// else and must never be touched, however stale they are.
+	foreign := []string{
+		"exec-backup.ps1",       // non-numeric middle
+		"exec-.ps1",             // empty middle
+		"exec-123456789.ps1.gz", // wrong suffix
+		"exec-123456789.sh",     // wrong suffix
+		"prefix-exec-1.ps1",     // wrong prefix
+		"unrelated.ps1",         // unrelated file
+	}
+	for _, name := range foreign {
+		writeScriptFile(t, dir, name, 72*time.Hour)
+	}
+
+	// A stale directory that happens to match the pattern must also be left alone.
+	staleDir := filepath.Join(dir, "exec-222222222.ps1.d")
+	if err := os.Mkdir(staleDir, utils.DefaultDirMod); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	logger, _ := newSweepLogger()
+	if removed := SweepStaleScripts(dir, DefaultStaleScriptAge, logger); removed != 0 {
+		t.Errorf("expected no files removed, got %d", removed)
+	}
+
+	if _, err := os.Stat(recent); err != nil {
+		t.Errorf("expected recent script file to survive: %v", err)
+	}
+	for _, name := range foreign {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to survive the sweep: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(staleDir); err != nil {
+		t.Errorf("expected directory to survive the sweep: %v", err)
+	}
+}
+
+func TestSweepStaleScripts_MixedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeScriptFile(t, dir, "exec-100000001.ps1", 25*time.Hour)
+	survivor := writeScriptFile(t, dir, "exec-100000002.ps1", 23*time.Hour)
+
+	logger, _ := newSweepLogger()
+	if removed := SweepStaleScripts(dir, DefaultStaleScriptAge, logger); removed != 1 {
+		t.Errorf("expected exactly 1 file removed, got %d", removed)
+	}
+	if _, err := os.Stat(survivor); err != nil {
+		t.Errorf("expected file younger than the threshold to survive: %v", err)
+	}
+}
+
+func TestSweepStaleScripts_MissingDirectoryIsNotAnError(t *testing.T) {
+	logger, buf := newSweepLogger()
+
+	removed := SweepStaleScripts(filepath.Join(t.TempDir(), "does-not-exist"), time.Hour, logger)
+
+	if removed != 0 {
+		t.Errorf("expected 0 files removed, got %d", removed)
+	}
+	if logs := buf.String(); strings.Contains(logs, "[ERROR]") {
+		t.Errorf("a missing scripts directory must not log an error, got %q", logs)
+	}
+}
+
+func TestSweepStaleScripts_ReadDirFailureIsLoggedNotFatal(t *testing.T) {
+	// A path that is a regular file, not a directory: ReadDir fails with a
+	// non-NotExist error, which must be logged and swallowed.
+	path := writeScriptFile(t, t.TempDir(), "not-a-dir", 0)
+
+	logger, buf := newSweepLogger()
+	if removed := SweepStaleScripts(path, time.Hour, logger); removed != 0 {
+		t.Errorf("expected 0 files removed, got %d", removed)
+	}
+
+	if logs := buf.String(); !strings.Contains(logs, "Failed to read scripts directory") {
+		t.Errorf("expected the read failure to be logged, got %q", logs)
+	}
+}
+
+func TestSweepStaleScripts_DefaultsMaxAgeWhenNonPositive(t *testing.T) {
+	dir := t.TempDir()
+	// Younger than DefaultStaleScriptAge: a zero maxAge must fall back to the
+	// default rather than deleting everything it finds.
+	survivor := writeScriptFile(t, dir, "exec-333333333.ps1", time.Hour)
+	writeScriptFile(t, dir, "exec-444444444.ps1", 48*time.Hour)
+
+	logger, _ := newSweepLogger()
+	if removed := SweepStaleScripts(dir, 0, logger); removed != 1 {
+		t.Errorf("expected exactly 1 file removed, got %d", removed)
+	}
+	if _, err := os.Stat(survivor); err != nil {
+		t.Errorf("expected recent file to survive with a defaulted max age: %v", err)
+	}
+}
+
+// The sweep must match exactly what the executor creates: build a real temp file
+// through the same os.CreateTemp pattern and assert the matcher accepts it.
+func TestIsScriptFile_MatchesExecutorTempPattern(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, scriptTempPattern)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	name := filepath.Base(f.Name())
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+
+	if !isScriptFile(name) {
+		t.Errorf("isScriptFile(%q) = false, want true for an executor-created name", name)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [sc-103967]. Every command execution writes its script to a temp file in the scripts directory (`os.CreateTemp(scriptsDir, "exec-*.ps1")`) and relies on a deferred `Close`/`Remove` to clean it up. That deferred cleanup never runs when the process dies abruptly — SIGKILL, service force-stop (including during updates), host power loss, OOM kill — and **nothing else ever reclaimed those files**: the scripts directory was only cleared on uninstall. Orphaned `exec-*.ps1` files therefore accumulated for the lifetime of the installation, consuming disk and leaving command contents on disk indefinitely.

This PR adds a startup sweep that reclaims them.

## Changes

- **`internal/interpreter/script_sweep.go`** (new) — `SweepStaleScripts(dir, maxAge, logger) int` reads the scripts directory and removes matching files whose mtime is older than the threshold, returning the count. `DefaultStaleScriptAge = 24h`, deliberately generous: commands are unbounded unless `command_timeout_seconds` is configured, so a file that old cannot plausibly belong to a command another agent process is still executing.
- **`internal/interpreter/base_executor.go`** — the `os.CreateTemp` pattern is now the shared `scriptTempPattern` constant instead of a literal, so the sweep's matcher can't drift from what the executor writes. Per-command cleanup is otherwise unchanged.
- **`cmd/agent_smith/service.go`** — the sweep runs once per process, immediately after the service signals `running` (so a slow or crowded scripts directory can't delay the service-start ack) and before the connection loop. The new `scriptsOrgId` helper derives the directory from the device config's `RewstOrgId` — the value the executor itself uses — falling back to the `--org-id` flag.

## Acceptance criteria

- [x] **Orphaned `exec-*` files older than a safe threshold are removed on startup** — 24h threshold, mtime-based.
- [x] **Only the agent's own temp pattern is targeted** — `isScriptFile` matches `exec-<digits>.ps1` exactly, the shape `os.CreateTemp` produces. Non-numeric middles (`exec-backup.ps1`), wrong suffixes, directories, and non-regular files (symlinks, device nodes — never followed) are all skipped.
- [x] **Sweep failures are logged but never prevent startup** — the function returns no error; an unreadable directory, a failed stat, and a failed remove are each logged and skipped. A missing directory is silent, since that's the normal fresh-install state.
- [x] **In-flight command temp files for the current run are unaffected** — the sweep runs once at startup before any command executes, and the 24h threshold protects any file a concurrent process could be using.

## Testing

`go vet ./...` and `go test ./...` pass; `GOOS=windows`/`GOOS=linux` cross-builds and `GOOS=windows go vet` are clean; `golangci-lint run` reports 0 issues.

**Unit tests** (`internal/interpreter/script_sweep_test.go`) — 7 tests: stale removal; recent and foreign files preserved (including a pattern-matching *directory*); the 24h boundary (25h removed / 23h kept); missing directory logs no error; `ReadDir` failure logged-not-fatal; non-positive `maxAge` falls back to the default; and a real `os.CreateTemp` name is accepted by the matcher — that last one is what keeps the sweep and the executor from silently diverging.

**Service test** (`TestExecute_SweepsStaleScriptFilesOnStartup`) — drives the wiring end to end through `Execute` with a mock MQTT client, asserting the stale file is swept, a recent file and an operator-created file survive, and the sweep is logged.

QA step 3 (a normally-completing command still removes its own temp file) was already covered by the existing `TestExecute_TempFileRemovedOnCommandFailure`, which is unchanged.

## Integration test

The second commit adds a cross-platform scenario to the `test` job of `integration-test.yml` covering the ticket's QA step 2 for real: dispatch a long-running command, force-kill the service mid-command so the deferred cleanup cannot run, age the stranded file, restart, and assert only the agent's own stale files are reclaimed.

- The release binary is reinstalled first with auto-updates off and `--command-timeout-seconds 600`, so nothing ends the command *gracefully* before the kill lands — the 5s timeout from the earlier scenario, the 30s auto-updater, and the IT binary's 90s SAS lifetime would each tear it down cleanly, and clean teardown runs the cleanup, leaving nothing to sweep.
- The in-flight script path is read from the agent's own `Command saved to … path=` log line rather than re-derived, because the service's temp directory is not the runner's — notably root's private `TMPDIR` on macOS, which the runner user cannot even list.
- New **`kill-service`** action: SIGKILL the service process tree, skipping the graceful path. Windows uses `taskkill /F /T` — a surviving child PowerShell holding the script file open would block deletion there and defeat the very sweep under test.
- New **`script-sweep-fixture`** action (`seed`/`assert` modes, one shared `fixture.ps1`) runs elevated, since the scripts directory belongs to the service account. The fixture pairs the real stranded file with an aged agent-pattern file, a current-timestamp agent-pattern file (standing in for a command still executing), and an aged non-agent file.

Ageing the files is the only simulated part — it is exactly what a long-lived install does by staying up — which keeps the production 24h threshold in play and needs **no test-only override in the agent**.

Verified locally: `actionlint` is clean on the new workflow and action references (the one warning it reports is pre-existing in `release.yml`), the `set-matrix` block still emits valid JSON with the new `sweep_commands` entry on all three platforms, the capture step's regex extracts the right path from real agent log output, and `fixture.ps1 seed` → the real `SweepStaleScripts` → `fixture.ps1 assert` passes against a temp directory while all four fixture failure paths exit non-zero. The workflow itself is `workflow_dispatch`-only and needs the IT org secrets, so a real cross-platform run has not been kicked off yet.

## Note

`CHANGELOG.md` is intentionally untouched — entries there are generated by the release automation from commit messages at the next `cz bump`, and the commit messages follow the conventional format it parses.

The threshold is a fixed 24h constant rather than a config key. If operators should be able to tune it (e.g. a `stale_script_max_age_seconds` device setting alongside `command_timeout_seconds`), that's a small follow-up on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
