### PR TITLE
fix: [sc-103966] Supervise notification plugins so a crash stops silencing them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ Required tools:
 
 Agent Smith uses a plugin architecture for extensible notifications. Plugins are separate executables that implement the `Notifier` interface via RPC. The system supports loading multiple plugins simultaneously and sends status notifications (AgentStarted, AgentStatus:Online, AgentStatus:Offline, etc.) to all loaded plugins.
 
+Loaded plugins are supervised: a subprocess that exits or crashes is detected (by a periodic health check and on the notification path) and relaunched with backoff, and delivery failures increment counters and are logged once per failure transition. See the README's "Notification Plugin Supervision" section.
+
 ### Message Processing Flow
 
 1. Agent connects to Azure IoT Hub via MQTT on topic `devices/{device_id}/messages/devicebound/#`

--- a/README.md
+++ b/README.md
@@ -305,6 +305,34 @@ value. Example snippet:
 }
 ```
 
+### Notification Plugin Supervision
+
+Notification plugins run as separate subprocesses reached over RPC, and every
+notification the agent sends is best effort — a delivery failure never interferes
+with command execution. On its own that combination hides a plugin that dies:
+once the subprocess exits, its RPC client stays broken forever and every later
+notification (`AgentStatus:Online`/`Offline`/`Reconnecting`, `AgentPostbackFailed`,
+`AgentMessageDropped`) silently goes nowhere.
+
+Loaded plugins are therefore supervised for the lifetime of the service:
+
+- A subprocess that exits or crashes is detected — by a health check that polls
+  every 30s, and immediately on the notification path if one arrives first — and
+  **relaunched**, so notifications resume without restarting the agent.
+- Relaunches use an exponential backoff (5s up to 5 minutes) so a plugin that
+  crashes on startup cannot turn into a process-spawn loop. A plugin that ran
+  for at least 2 minutes before dying is treated as a one-off and relaunched
+  immediately.
+- Failures are observable instead of silent: a failed delivery is logged at
+  `Error` level once per failure transition (with a matching recovery line), so a
+  persistently broken plugin cannot flood the log, and cumulative counters for
+  missed notifications, restarts and failed restarts are reported in a
+  `Plugin notification health summary` line on shutdown.
+- An error the plugin itself returns is counted and logged but leaves the healthy
+  subprocess running; only a broken RPC channel triggers a relaunch.
+
+Deployments with no plugins configured are unaffected — no supervision runs.
+
 ## Build
 Required tools and packages:
 

--- a/cmd/agent_smith/message_queue_test.go
+++ b/cmd/agent_smith/message_queue_test.go
@@ -12,15 +12,18 @@ import (
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/interpreter"
+	"github.com/RewstApp/agent-smith-go/plugins"
 	"github.com/hashicorp/go-hclog"
 )
 
 // mockNotifierWrapper implements plugins.NotifierWrapper for tests.
 type mockNotifierWrapper struct{}
 
-func (m *mockNotifierWrapper) Kill()               {}
-func (m *mockNotifierWrapper) Plugins() []string   { return nil }
-func (m *mockNotifierWrapper) Notify(string) error { return nil }
+func (m *mockNotifierWrapper) Kill()                        {}
+func (m *mockNotifierWrapper) Plugins() []string            { return nil }
+func (m *mockNotifierWrapper) Notify(string) error          { return nil }
+func (m *mockNotifierWrapper) CheckHealth()                 {}
+func (m *mockNotifierWrapper) Stats() plugins.NotifierStats { return plugins.NotifierStats{} }
 
 // recordingNotifierWrapper records every notification message it receives so
 // tests can assert that drops are surfaced to plugins.
@@ -29,8 +32,10 @@ type recordingNotifierWrapper struct {
 	messages []string
 }
 
-func (m *recordingNotifierWrapper) Kill()             {}
-func (m *recordingNotifierWrapper) Plugins() []string { return nil }
+func (m *recordingNotifierWrapper) Kill()                        {}
+func (m *recordingNotifierWrapper) Plugins() []string            { return nil }
+func (m *recordingNotifierWrapper) CheckHealth()                 {}
+func (m *recordingNotifierWrapper) Stats() plugins.NotifierStats { return plugins.NotifierStats{} }
 func (m *recordingNotifierWrapper) Notify(msg string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -196,17 +196,31 @@ func (svc *serviceContext) Execute(
 		logger.Info("Service stopped")
 	}()
 
-	notifier, err := plugins.LoadNotifer(device.Plugins, logFile)
+	notifier, err := plugins.LoadNotifer(device.Plugins, logFile, logger)
 	if err != nil {
 		logger.Warn("Failed to load plugin", "error", err)
 	}
-	defer notifier.Kill()
+	defer func() {
+		// Notification delivery is best effort at every call site, so a plugin that
+		// dies mid-run would otherwise leave no trace at all. Surface the cumulative
+		// counters once on the way out whenever anything went wrong.
+		if stats := notifier.Stats(); stats != (plugins.NotifierStats{}) {
+			logger.Warn(
+				"Plugin notification health summary",
+				"notify_failures", stats.NotifyFailures,
+				"plugin_restarts", stats.Restarts,
+				"restart_failures", stats.RestartFailures,
+			)
+		}
 
-	plugins := notifier.Plugins()
-	if len(plugins) == 1 {
-		logger.Info("Plugin loaded", "plugin", plugins[0])
-	} else if len(plugins) > 1 {
-		logger.Info("Plugins loaded", "plugins", plugins)
+		notifier.Kill()
+	}()
+
+	loadedPlugins := notifier.Plugins()
+	if len(loadedPlugins) == 1 {
+		logger.Info("Plugin loaded", "plugin", loadedPlugins[0])
+	} else if len(loadedPlugins) > 1 {
+		logger.Info("Plugins loaded", "plugins", loadedPlugins)
 	}
 
 	// Create a channel for stopped signal. It is closed (never sent to) when a
@@ -228,6 +242,35 @@ func (svc *serviceContext) Execute(
 
 	running <- struct{}{}
 	_ = notifier.Notify("AgentStarted") // Best effort notification
+
+	// Supervise the plugin subprocesses for the lifetime of the service. A plugin
+	// that exits or crashes leaves its RPC client permanently broken, and because
+	// every Notify call is best effort the loss of all status notifications would
+	// otherwise be completely silent until the agent is restarted. Polling for
+	// exits relaunches the plugin proactively instead of waiting for the next
+	// notification, which on an idle agent may be a long way off. The monitor is
+	// only started when a plugin actually loaded, so a deployment without plugins
+	// keeps exactly its previous behaviour. Its stop channel is closed before the
+	// deferred notifier.Kill (later defers run first), so the monitor can never
+	// resurrect a plugin during teardown.
+	if len(loadedPlugins) > 0 {
+		monitorStopped := make(chan struct{})
+		defer close(monitorStopped)
+
+		utils.SafeGo(logger, func() {
+			ticker := time.NewTicker(plugins.DefaultHealthCheckInterval)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-monitorStopped:
+					return
+				case <-ticker.C:
+					notifier.CheckHealth()
+				}
+			}
+		}, "scope", "plugin_health_monitor")
+	}
 
 	// Reclaim script files left behind by previous runs that were killed before
 	// their deferred cleanup could run (force-stop, host power loss, OOM kill).

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -1599,3 +1599,126 @@ func TestExecute_SweepsStaleScriptFilesOnStartup(t *testing.T) {
 		t.Errorf("expected the sweep to be logged, log was:\n%s", logBytes)
 	}
 }
+
+// runExecuteWithDevice writes device to a config file, runs Execute against a
+// mock MQTT client until it reports running, stops it, and returns the log
+// contents. It is used by the plugin supervision tests, which care about what the
+// service logs around plugin loading rather than about message flow.
+func runExecuteWithDevice(t *testing.T, orgId string, device agent.Device) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	configBytes, err := json.Marshal(device)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	origNewClient := inmqtt.NewClient
+	inmqtt.NewClient = func(o *pahomqtt.ClientOptions) pahomqtt.Client {
+		return &mockMQTTClient{}
+	}
+	defer func() { inmqtt.NewClient = origNewClient }()
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      orgId,
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+
+	done := make(chan service.ServiceExitCode, 1)
+	go func() {
+		done <- svc.Execute(stop, running)
+	}()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log: %v", err)
+	}
+
+	return string(logBytes)
+}
+
+// TestExecute_NoPluginsConfiguredSkipsSupervision verifies that plugin
+// supervision is inert for the common case of a device with no plugins: nothing
+// is loaded, no health summary is reported, and the service starts and stops
+// exactly as before.
+func TestExecute_NoPluginsConfiguredSkipsSupervision(t *testing.T) {
+	orgId := "test-org-no-plugins"
+	logged := runExecuteWithDevice(t, orgId, agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		RewstOrgId:           orgId,
+		LoggingLevel:         "debug",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	})
+
+	for _, unexpected := range []string{
+		"Plugin loaded",
+		"Plugins loaded",
+		"Plugin notification health summary",
+		"Notification delivery failed",
+	} {
+		if strings.Contains(logged, unexpected) {
+			t.Errorf(
+				"expected no %q line with no plugins configured, log was:\n%s",
+				unexpected,
+				logged,
+			)
+		}
+	}
+}
+
+// TestExecute_UnloadablePluginIsReportedNotSupervised verifies that a plugin that
+// cannot be launched at startup is still reported (as before) and does not leave
+// the service supervising a plugin that was never loaded.
+func TestExecute_UnloadablePluginIsReportedNotSupervised(t *testing.T) {
+	orgId := "test-org-bad-plugin"
+	logged := runExecuteWithDevice(t, orgId, agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		RewstOrgId:           orgId,
+		LoggingLevel:         "debug",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+		Plugins: []agent.Plugin{
+			{Name: "missing-plugin", ExecutablePath: filepath.Join(t.TempDir(), "does-not-exist")},
+		},
+	})
+
+	if !strings.Contains(logged, "Failed to load plugin") {
+		t.Errorf("expected the failed plugin load to be logged, log was:\n%s", logged)
+	}
+	if strings.Contains(logged, "Plugin loaded") {
+		t.Errorf("expected no plugin to be reported as loaded, log was:\n%s", logged)
+	}
+	if strings.Contains(logged, "Plugin notification health summary") {
+		t.Errorf("expected no health summary for a plugin that never loaded, log was:\n%s", logged)
+	}
+}

--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -4,53 +4,371 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/rpc"
 	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/shared"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 )
 
 const (
 	defaultProtocolVersion = 1
 	defaultMagicCookieKey  = "AGENT_SMITH"
+
+	// DefaultHealthCheckInterval is how often the host should call CheckHealth to
+	// find notification plugin subprocesses that have exited and relaunch them.
+	// Notifications are sparse — a mostly idle agent can go a long time between
+	// them — so waiting for the next Notify to discover a dead plugin would leave
+	// a wide window with no delivery. The interval is short enough to recover
+	// promptly and cheap enough to be free in practice: each check reads an
+	// in-process exit flag per plugin and performs no RPC.
+	DefaultHealthCheckInterval = 30 * time.Second
+
+	// restartBaseBackoff and restartMaxBackoff bound how often a plugin that keeps
+	// dying is relaunched. Without a schedule, a plugin that exits immediately on
+	// every launch would be re-spawned on every health check and every
+	// notification, turning one broken plugin into a process-spawn loop.
+	restartBaseBackoff = 5 * time.Second
+	restartMaxBackoff  = 5 * time.Minute
+
+	// restartStableUptime is how long a subprocess must have been running before
+	// its death is treated as a one-off rather than a crash loop. A plugin that
+	// served notifications for hours and then crashed gets an immediate relaunch;
+	// one that dies right after launch stays on the backoff schedule.
+	restartStableUptime = 2 * time.Minute
 )
 
 var pluginMap = map[string]plugin.Plugin{
 	"notifier": &shared.NotifierPlugin{},
 }
 
+// NotifierStats holds cumulative, process-wide plugin health counters. They are
+// exposed so a silent notification outage — the failure mode this guards against
+// — is observable beyond the per-transition log lines. The zero value means
+// nothing has gone wrong.
+type NotifierStats struct {
+	// NotifyFailures counts notifications that could not be delivered to a
+	// plugin, whether because the RPC call failed or because no subprocess was
+	// running at the time.
+	NotifyFailures int64
+	// Restarts counts plugin subprocesses successfully relaunched after an exit.
+	Restarts int64
+	// RestartFailures counts relaunch attempts that themselves failed.
+	RestartFailures int64
+}
+
 type NotifierWrapper interface {
 	Kill()
 	Plugins() []string
 	Notify(message string) error
+	// CheckHealth relaunches any plugin subprocess that has exited. It is a no-op
+	// when every plugin is healthy, when no plugins are configured, or after Kill,
+	// and is safe to call concurrently with Notify.
+	CheckHealth()
+	// Stats returns a snapshot of the cumulative plugin health counters.
+	Stats() NotifierStats
 }
 
 type optionalNotifierWrapper struct {
+	// mu guards client, plugin, closed, failing, startedAt and the restart
+	// schedule. Notify is called from every message worker while CheckHealth runs
+	// on the host's health monitor goroutine, so the subprocess handle must never
+	// be swapped while another caller is using it.
+	mu     sync.Mutex
 	client *plugin.Client
 	plugin shared.Notifier
 	name   string
+
+	// info and logWriter are retained so a dead subprocess can be relaunched with
+	// exactly the command line and stderr sink it was first started with. info is
+	// zero for a wrapper that was not launched from a config entry, which leaves
+	// the wrapper a no-op and disables restart.
+	info      agent.Plugin
+	logWriter io.Writer
+	logger    hclog.Logger
+
+	// startedAt is when the current subprocess was launched; zero when none is
+	// running. It distinguishes a long-lived plugin's first crash from a crash
+	// loop.
+	startedAt time.Time
+
+	// nextRestartAt is the earliest time another relaunch may be attempted and
+	// restartBackoff is the current delay in the exponential schedule.
+	nextRestartAt  time.Time
+	restartBackoff time.Duration
+
+	// closed records that Kill has run, so a racing health check can never
+	// resurrect a plugin the host has torn down.
+	closed bool
+
+	// failing records whether the last delivery attempt failed, so a persistently
+	// broken plugin logs once per failure transition instead of once per
+	// notification.
+	failing bool
+
+	notifyFailures  atomic.Int64
+	restarts        atomic.Int64
+	restartFailures atomic.Int64
+}
+
+// log returns the wrapper's logger, falling back to a no-op logger so a wrapper
+// constructed without one never panics.
+func (p *optionalNotifierWrapper) log() hclog.Logger {
+	if p.logger == nil {
+		return hclog.NewNullLogger()
+	}
+	return p.logger
 }
 
 func (p *optionalNotifierWrapper) Kill() {
-	if p.client == nil {
-		return
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	p.dropLocked()
+}
+
+// dropLocked terminates the current subprocess (if any) and clears the handle,
+// leaving the wrapper in the "not running" state so the next Notify or
+// CheckHealth relaunches it. Killing an already-exited client returns promptly;
+// a wedged one can hold the lock for go-plugin's graceful-exit grace period,
+// which is bounded and only paid on a path that is already broken.
+func (p *optionalNotifierWrapper) dropLocked() {
+	if p.client != nil {
+		p.client.Kill()
 	}
 
-	p.client.Kill()
+	p.client = nil
+	p.plugin = nil
+	p.startedAt = time.Time{}
 }
 
 func (p *optionalNotifierWrapper) Plugins() []string {
 	return []string{p.name}
 }
 
+// Notify delivers a notification to the plugin, relaunching a dead subprocess
+// first. The RPC call itself is made without the lock held — every message worker
+// notifies plugins, and net/rpc is safe for concurrent calls, so serializing them
+// would let one slow plugin throttle message processing. Only the handle
+// bookkeeping (and any relaunch) is serialized.
 func (p *optionalNotifierWrapper) Notify(message string) error {
-	if p.plugin == nil {
+	p.mu.Lock()
+
+	if p.closed {
+		p.mu.Unlock()
 		return nil
 	}
 
-	return p.plugin.Notify(message)
+	// Relaunch before delivering so a notification arriving between the crash and
+	// the next health check is still delivered rather than lost.
+	if p.deadLocked() {
+		p.restartLocked("notify")
+	}
+
+	notifier := p.plugin
+	client := p.client
+	restartable := p.restartable()
+
+	p.mu.Unlock()
+
+	if notifier == nil {
+		// A wrapper with no config entry behind it was never launched and stays a
+		// silent no-op, preserving the historical behaviour. Otherwise the plugin is
+		// configured but not running, which is a real (previously invisible) missed
+		// notification.
+		if !restartable {
+			return nil
+		}
+
+		return p.recordFailure(fmt.Errorf("plugin %q is not running", p.name))
+	}
+
+	err := notifier.Notify(message)
+	if err == nil {
+		p.recordSuccess()
+		return nil
+	}
+
+	// A broken RPC channel means the subprocess is gone or unusable, so drop the
+	// handle and let the next attempt relaunch it. An error the plugin itself
+	// returned is a plugin-side failure: it is counted and logged, but the
+	// subprocess is working and must be left alone.
+	if isTransportError(err) {
+		p.mu.Lock()
+		// Only discard the handle this call actually used; a concurrent Notify or
+		// health check may already have relaunched the plugin.
+		if p.client == client {
+			p.dropLocked()
+		}
+		p.mu.Unlock()
+	}
+
+	return p.recordFailure(err)
+}
+
+func (p *optionalNotifierWrapper) CheckHealth() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed || !p.deadLocked() {
+		return
+	}
+
+	p.restartLocked("health_check")
+}
+
+func (p *optionalNotifierWrapper) Stats() NotifierStats {
+	return NotifierStats{
+		NotifyFailures:  p.notifyFailures.Load(),
+		Restarts:        p.restarts.Load(),
+		RestartFailures: p.restartFailures.Load(),
+	}
+}
+
+// restartable reports whether this wrapper knows how to launch a subprocess. It
+// is false only for wrappers not built from a device config plugin entry.
+func (p *optionalNotifierWrapper) restartable() bool {
+	return p.info.ExecutablePath != ""
+}
+
+// deadLocked reports whether the plugin needs relaunching: no handle at all, or
+// a subprocess go-plugin has observed exiting. It only ever reports true for a
+// restartable wrapper, so a plugin-less wrapper is never treated as broken.
+//
+// This detects a subprocess that exits or crashes, which is the failure mode
+// that silently killed notification delivery. A plugin whose process is alive
+// but wedged is not detectable this way; it surfaces instead as a failing Notify
+// (counted and logged), which then drops the handle for relaunch.
+func (p *optionalNotifierWrapper) deadLocked() bool {
+	if !p.restartable() {
+		return false
+	}
+
+	return p.client == nil || p.plugin == nil || p.client.Exited()
+}
+
+// restartLocked relaunches the subprocess, honoring the crash-loop backoff. The
+// trigger names what noticed the death and is logged for diagnosis.
+func (p *optionalNotifierWrapper) restartLocked(trigger string) {
+	if p.closed || !p.restartable() {
+		return
+	}
+
+	if p.restartBackoff <= 0 {
+		p.restartBackoff = restartBaseBackoff
+	}
+
+	now := time.Now()
+
+	// A subprocess that stayed up past the stability window earned a clean slate:
+	// its death is a one-off, not a crash loop, so relaunch it immediately.
+	if !p.startedAt.IsZero() && now.Sub(p.startedAt) >= restartStableUptime {
+		p.restartBackoff = restartBaseBackoff
+		p.nextRestartAt = time.Time{}
+	}
+
+	if now.Before(p.nextRestartAt) {
+		p.log().Debug(
+			"Notification plugin restart deferred by backoff",
+			"plugin", p.name,
+			"trigger", trigger,
+			"retry_at", p.nextRestartAt,
+		)
+		return
+	}
+
+	// Charge the wait up front so a launch that fails — or that succeeds and then
+	// immediately dies again — cannot be retried until the backoff elapses.
+	backoff := p.restartBackoff
+	p.nextRestartAt = now.Add(backoff)
+	p.restartBackoff = min(2*backoff, restartMaxBackoff)
+
+	p.dropLocked()
+
+	client, notifier, err := launchNotifier(p.info, p.logWriter, p.logger)
+	if err != nil {
+		failures := p.restartFailures.Add(1)
+		p.log().Error(
+			"Failed to restart notification plugin",
+			"plugin", p.name,
+			"trigger", trigger,
+			"retry_after", backoff,
+			"restart_failures", failures,
+			"error", err,
+		)
+		return
+	}
+
+	p.client = client
+	p.plugin = notifier
+	p.startedAt = now
+
+	p.log().Warn(
+		"Notification plugin restarted after subprocess exit",
+		"plugin", p.name,
+		"trigger", trigger,
+		"restarts", p.restarts.Add(1),
+	)
+}
+
+// recordFailure counts a missed notification and logs it once per failure
+// transition — the plugin is notified on every status change and every received
+// message, so logging each individual failure would flood the log for a plugin
+// that stays broken. The error is returned unchanged for the caller to combine.
+func (p *optionalNotifierWrapper) recordFailure(err error) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	failures := p.notifyFailures.Add(1)
+
+	if p.failing {
+		p.log().Debug(
+			"Notification delivery still failing",
+			"plugin", p.name,
+			"notify_failures", failures,
+			"error", err,
+		)
+		return err
+	}
+
+	p.failing = true
+	p.log().Error(
+		"Notification delivery failed",
+		"plugin", p.name,
+		"notify_failures", failures,
+		"error", err,
+	)
+
+	return err
+}
+
+// recordSuccess marks a delivered notification. A working plugin proves it is not
+// crash looping, so the restart schedule is reset, and a recovery after a failure
+// run is logged to close out the failure log line.
+func (p *optionalNotifierWrapper) recordSuccess() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.restartBackoff = restartBaseBackoff
+	p.nextRestartAt = time.Time{}
+
+	if !p.failing {
+		return
+	}
+
+	p.failing = false
+	p.log().Warn(
+		"Notification delivery recovered",
+		"plugin", p.name,
+		"notify_failures", p.notifyFailures.Load(),
+	)
 }
 
 type notifierSetWrapper struct {
@@ -86,62 +404,138 @@ func (s *notifierSetWrapper) Notify(message string) error {
 	return combinedErrors
 }
 
-func LoadNotifer(plugins []agent.Plugin, logWriter io.Writer) (NotifierWrapper, error) {
+func (s *notifierSetWrapper) CheckHealth() {
+	for _, notifier := range s.notifiers {
+		notifier.CheckHealth()
+	}
+}
+
+func (s *notifierSetWrapper) Stats() NotifierStats {
+	var stats NotifierStats
+
+	for _, notifier := range s.notifiers {
+		pluginStats := notifier.Stats()
+		stats.NotifyFailures += pluginStats.NotifyFailures
+		stats.Restarts += pluginStats.Restarts
+		stats.RestartFailures += pluginStats.RestartFailures
+	}
+
+	return stats
+}
+
+// pluginLogger returns the logger go-plugin uses for its own diagnostics
+// (handshake progress, subprocess exit), named per plugin so those lines are
+// attributable in the agent log. A nil host logger yields a no-op logger rather
+// than go-plugin's default, which writes to the host process stderr — a place a
+// service has no reader for.
+func pluginLogger(logger hclog.Logger, name string) hclog.Logger {
+	if logger == nil {
+		return hclog.NewNullLogger()
+	}
+
+	return logger.Named("plugin." + name)
+}
+
+// launchNotifier starts the plugin subprocess described by info and dispenses its
+// notifier implementation. The magic cookie value is minted per launch, so each
+// subprocess — including a relaunch of the same plugin — handshakes with its own
+// secret. On any failure the partially started subprocess is killed rather than
+// left orphaned, which matters now that launches are retried.
+func launchNotifier(
+	info agent.Plugin,
+	logWriter io.Writer,
+	logger hclog.Logger,
+) (*plugin.Client, shared.Notifier, error) {
+	handshakeConfig := plugin.HandshakeConfig{
+		ProtocolVersion:  defaultProtocolVersion,
+		MagicCookieKey:   defaultMagicCookieKey,
+		MagicCookieValue: uuid.New().String(),
+	}
+
+	// #nosec G204
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: handshakeConfig,
+		Plugins:         pluginMap,
+		Cmd: exec.Command(
+			info.ExecutablePath,
+			"--magic-cookie-key",
+			handshakeConfig.MagicCookieKey,
+			"--magic-cookie-value",
+			handshakeConfig.MagicCookieValue,
+		),
+		Stderr: logWriter,
+		Logger: pluginLogger(logger, info.Name),
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, nil, err
+	}
+
+	raw, err := rpcClient.Dispense("notifier")
+	if err != nil {
+		client.Kill()
+		return nil, nil, err
+	}
+
+	notifier, ok := toNotifier(raw)
+	if !ok {
+		client.Kill()
+		return nil, nil, fmt.Errorf("plugin %q: Dispense returned unexpected type", info.Name)
+	}
+
+	return client, notifier, nil
+}
+
+// LoadNotifer launches every configured notification plugin and returns a
+// wrapper that fans notifications out to all of them. Plugins that fail to
+// launch are reported in the returned error and left out of the set, as before;
+// plugins that launch successfully are supervised from then on — see CheckHealth
+// and Notify, which relaunch a subprocess that later exits or crashes.
+func LoadNotifer(
+	plugins []agent.Plugin,
+	logWriter io.Writer,
+	logger hclog.Logger,
+) (NotifierWrapper, error) {
 	set := &notifierSetWrapper{}
 	var combinedErrors error
 
 	for _, pluginInfo := range plugins {
-		magicCookieValueUuid := uuid.New()
-
-		handshakeConfig := plugin.HandshakeConfig{
-			ProtocolVersion:  defaultProtocolVersion,
-			MagicCookieKey:   defaultMagicCookieKey,
-			MagicCookieValue: magicCookieValueUuid.String(),
-		}
-
-		// #nosec G204
-		client := plugin.NewClient(&plugin.ClientConfig{
-			HandshakeConfig: handshakeConfig,
-			Plugins:         pluginMap,
-			Cmd: exec.Command(
-				pluginInfo.ExecutablePath,
-				"--magic-cookie-key",
-				handshakeConfig.MagicCookieKey,
-				"--magic-cookie-value",
-				handshakeConfig.MagicCookieValue,
-			),
-			Stderr: logWriter,
-		})
-
-		rpcClient, err := client.Client()
+		client, notifier, err := launchNotifier(pluginInfo, logWriter, logger)
 		if err != nil {
 			combinedErrors = errors.Join(combinedErrors, err)
-			continue
-		}
-
-		raw, err := rpcClient.Dispense("notifier")
-		if err != nil {
-			combinedErrors = errors.Join(combinedErrors, err)
-			continue
-		}
-
-		notifier, ok := raw.(shared.Notifier)
-		if !ok {
-			combinedErrors = errors.Join(
-				combinedErrors,
-				fmt.Errorf("plugin %q: Dispense returned unexpected type", pluginInfo.Name),
-			)
 			continue
 		}
 
 		set.notifiers = append(set.notifiers, &optionalNotifierWrapper{
-			client: client,
-			plugin: notifier,
-			name:   pluginInfo.Name,
+			client:         client,
+			plugin:         notifier,
+			name:           pluginInfo.Name,
+			info:           pluginInfo,
+			logWriter:      logWriter,
+			logger:         logger,
+			startedAt:      time.Now(),
+			restartBackoff: restartBaseBackoff,
 		})
 	}
 
 	return set, combinedErrors
+}
+
+// isTransportError reports whether an error returned by a plugin's Notify call
+// means the RPC channel to the subprocess is broken rather than the plugin
+// having reported a failure of its own. net/rpc wraps any error returned by the
+// remote method in rpc.ServerError; everything else (rpc.ErrShutdown, io.EOF, a
+// closed pipe) means the connection — and in practice the subprocess — is gone.
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var serverErr rpc.ServerError
+
+	return !errors.As(err, &serverErr)
 }
 
 // toNotifier safely asserts raw to shared.Notifier, returning (nil, false) on failure.

--- a/plugins/loader_test.go
+++ b/plugins/loader_test.go
@@ -3,9 +3,20 @@ package plugins
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"io"
+	"net/rpc"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/hashicorp/go-hclog"
 )
 
 // mockNotifier for testing
@@ -313,7 +324,7 @@ func TestLoadNotifer_EmptyPluginList(t *testing.T) {
 	logBuf := &bytes.Buffer{}
 	plugins := []agent.Plugin{}
 
-	wrapper, err := LoadNotifer(plugins, logBuf)
+	wrapper, err := LoadNotifer(plugins, logBuf, hclog.NewNullLogger())
 	if err != nil {
 		t.Errorf("expected no error for empty list, got %v", err)
 	}
@@ -338,7 +349,7 @@ func TestLoadNotifer_InvalidExecutable(t *testing.T) {
 		},
 	}
 
-	wrapper, err := LoadNotifer(plugins, logBuf)
+	wrapper, err := LoadNotifer(plugins, logBuf, hclog.NewNullLogger())
 
 	// Should return a wrapper even with errors
 	if wrapper == nil {
@@ -375,7 +386,7 @@ func TestLoadNotifer_MultipleInvalidPlugins(t *testing.T) {
 		},
 	}
 
-	wrapper, err := LoadNotifer(plugins, logBuf)
+	wrapper, err := LoadNotifer(plugins, logBuf, hclog.NewNullLogger())
 
 	if wrapper == nil {
 		t.Fatal("expected non-nil wrapper")
@@ -402,7 +413,7 @@ func TestLoadNotifer_NilLogWriter(t *testing.T) {
 		},
 	}
 
-	wrapper, err := LoadNotifer(plugins, nil)
+	wrapper, err := LoadNotifer(plugins, nil, nil)
 
 	if wrapper == nil {
 		t.Fatal("expected non-nil wrapper")
@@ -470,6 +481,528 @@ func TestToNotifier_Nil(t *testing.T) {
 	}
 	if notifier != nil {
 		t.Fatal("expected nil notifier")
+	}
+}
+
+// syncBuffer is a concurrency-safe log sink. go-plugin drains the plugin's
+// stderr on its own goroutine, so a buffer shared with the host logger must be
+// locked.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// newBufferedLogger returns a logger writing to out so tests can assert on the
+// log lines emitted for failures, restarts and recoveries.
+func newBufferedLogger(out io.Writer) hclog.Logger {
+	return hclog.New(&hclog.LoggerOptions{
+		Name:   "test",
+		Output: out,
+		Level:  hclog.Debug,
+	})
+}
+
+// countLines counts how many times substr appears at the start of a log line.
+func countLines(logged, substr string) int {
+	count := 0
+	for _, line := range strings.Split(logged, "\n") {
+		if strings.Contains(line, substr) {
+			count++
+		}
+	}
+	return count
+}
+
+// TestIsTransportError distinguishes a broken RPC channel (the subprocess is
+// gone) from an error the plugin itself returned.
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"plugin_returned_error", rpc.ServerError("webhook rejected"), false},
+		{"wrapped_plugin_error", fmt.Errorf("notify: %w", rpc.ServerError("nope")), false},
+		{"rpc_shutdown", rpc.ErrShutdown, true},
+		{"eof", io.EOF, true},
+		{"generic", errors.New("broken pipe"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransportError(tt.err); got != tt.expected {
+				t.Errorf("isTransportError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestOptionalNotifierWrapper_Notify_TransportErrorDropsHandle verifies that a
+// broken RPC channel drops the plugin handle so the next attempt relaunches the
+// subprocess instead of calling a dead client forever.
+func TestOptionalNotifierWrapper_Notify_TransportErrorDropsHandle(t *testing.T) {
+	mock := &mockNotifier{notifyErr: rpc.ErrShutdown}
+	wrapper := &optionalNotifierWrapper{plugin: mock, name: "test"}
+
+	if err := wrapper.Notify("hello"); err == nil {
+		t.Fatal("expected an error from a broken RPC channel")
+	}
+
+	if wrapper.plugin != nil {
+		t.Error("expected the plugin handle to be dropped after a transport error")
+	}
+
+	if got := wrapper.Stats().NotifyFailures; got != 1 {
+		t.Errorf("expected 1 notify failure, got %d", got)
+	}
+}
+
+// TestOptionalNotifierWrapper_Notify_PluginErrorKeepsHandle verifies that an
+// error the plugin itself returned is counted but does not tear down a healthy
+// subprocess.
+func TestOptionalNotifierWrapper_Notify_PluginErrorKeepsHandle(t *testing.T) {
+	mock := &mockNotifier{notifyErr: rpc.ServerError("webhook rejected")}
+	wrapper := &optionalNotifierWrapper{plugin: mock, name: "test"}
+
+	if err := wrapper.Notify("hello"); err == nil {
+		t.Fatal("expected the plugin error to be returned")
+	}
+
+	if wrapper.plugin == nil {
+		t.Error("expected a plugin-side error to leave the subprocess handle in place")
+	}
+
+	if got := wrapper.Stats().NotifyFailures; got != 1 {
+		t.Errorf("expected 1 notify failure, got %d", got)
+	}
+}
+
+// TestOptionalNotifierWrapper_Notify_LogsOncePerFailureTransition verifies the
+// counter increments on every failure while the log stays quiet until the plugin
+// recovers, so a persistently broken plugin cannot flood the agent log.
+func TestOptionalNotifierWrapper_Notify_LogsOncePerFailureTransition(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	mock := &mockNotifier{notifyErr: rpc.ServerError("still broken")}
+	wrapper := &optionalNotifierWrapper{
+		plugin: mock,
+		name:   "test",
+		logger: newBufferedLogger(logBuf),
+	}
+
+	for range 3 {
+		if err := wrapper.Notify("hello"); err == nil {
+			t.Fatal("expected notify to fail")
+		}
+	}
+
+	if got := wrapper.Stats().NotifyFailures; got != 3 {
+		t.Errorf("expected 3 notify failures counted, got %d", got)
+	}
+
+	if got := countLines(logBuf.String(), "Notification delivery failed"); got != 1 {
+		t.Errorf("expected exactly 1 failure log line for 3 failures, got %d", got)
+	}
+
+	// Recovery closes out the failure, and the next failure run logs again.
+	mock.notifyErr = nil
+	if err := wrapper.Notify("hello"); err != nil {
+		t.Fatalf("expected recovery notify to succeed, got %v", err)
+	}
+
+	if got := countLines(logBuf.String(), "Notification delivery recovered"); got != 1 {
+		t.Errorf("expected 1 recovery log line, got %d", got)
+	}
+
+	mock.notifyErr = rpc.ServerError("broken again")
+	if err := wrapper.Notify("hello"); err == nil {
+		t.Fatal("expected notify to fail again")
+	}
+
+	if got := countLines(logBuf.String(), "Notification delivery failed"); got != 2 {
+		t.Errorf("expected a second failure log line after recovery, got %d", got)
+	}
+}
+
+// TestOptionalNotifierWrapper_Notify_NotRunningIsSurfaced verifies that a
+// configured plugin with no live subprocess reports the missed notification
+// instead of silently discarding it.
+func TestOptionalNotifierWrapper_Notify_NotRunningIsSurfaced(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	wrapper := &optionalNotifierWrapper{
+		name:   "test",
+		info:   agent.Plugin{Name: "test", ExecutablePath: "/nonexistent/path/to/plugin"},
+		logger: newBufferedLogger(logBuf),
+	}
+
+	err := wrapper.Notify("hello")
+	if err == nil {
+		t.Fatal("expected an error when the configured plugin is not running")
+	}
+
+	stats := wrapper.Stats()
+	if stats.NotifyFailures != 1 {
+		t.Errorf("expected 1 notify failure, got %d", stats.NotifyFailures)
+	}
+	if stats.RestartFailures != 1 {
+		t.Errorf("expected 1 restart failure, got %d", stats.RestartFailures)
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "Failed to restart notification plugin") {
+		t.Errorf("expected the failed relaunch to be logged, got %q", logged)
+	}
+	if !strings.Contains(logged, "Notification delivery failed") {
+		t.Errorf("expected the missed notification to be logged, got %q", logged)
+	}
+}
+
+// TestOptionalNotifierWrapper_CheckHealth_RestartBackoff verifies a plugin that
+// cannot be relaunched is retried on a backoff schedule rather than re-spawned on
+// every check.
+func TestOptionalNotifierWrapper_CheckHealth_RestartBackoff(t *testing.T) {
+	wrapper := &optionalNotifierWrapper{
+		name:           "test",
+		info:           agent.Plugin{Name: "test", ExecutablePath: "/nonexistent/path/to/plugin"},
+		restartBackoff: restartBaseBackoff,
+	}
+
+	wrapper.CheckHealth()
+	if got := wrapper.Stats().RestartFailures; got != 1 {
+		t.Fatalf("expected 1 restart attempt, got %d", got)
+	}
+
+	// An immediate second check falls inside the backoff window.
+	wrapper.CheckHealth()
+	if got := wrapper.Stats().RestartFailures; got != 1 {
+		t.Errorf("expected the second check to be deferred by backoff, got %d attempts", got)
+	}
+
+	if wrapper.restartBackoff <= restartBaseBackoff {
+		t.Errorf(
+			"expected the backoff to grow after a failed restart, got %v",
+			wrapper.restartBackoff,
+		)
+	}
+}
+
+// TestOptionalNotifierWrapper_CheckHealth_StableUptimeResetsBackoff verifies that
+// a plugin which ran past the stability window is relaunched immediately when it
+// dies, rather than waiting out a backoff inherited from an earlier crash.
+func TestOptionalNotifierWrapper_CheckHealth_StableUptimeResetsBackoff(t *testing.T) {
+	wrapper := &optionalNotifierWrapper{
+		name:           "test",
+		info:           agent.Plugin{Name: "test", ExecutablePath: "/nonexistent/path/to/plugin"},
+		startedAt:      time.Now().Add(-2 * restartStableUptime),
+		nextRestartAt:  time.Now().Add(restartMaxBackoff),
+		restartBackoff: restartMaxBackoff,
+	}
+
+	wrapper.CheckHealth()
+
+	if got := wrapper.Stats().RestartFailures; got != 1 {
+		t.Errorf("expected an immediate relaunch attempt after stable uptime, got %d", got)
+	}
+}
+
+// TestOptionalNotifierWrapper_CheckHealth_NotRestartable verifies a wrapper with
+// no plugin behind it is left alone.
+func TestOptionalNotifierWrapper_CheckHealth_NotRestartable(t *testing.T) {
+	wrapper := &optionalNotifierWrapper{name: "test"}
+
+	wrapper.CheckHealth()
+
+	if stats := wrapper.Stats(); stats != (NotifierStats{}) {
+		t.Errorf("expected no activity for a wrapper with no plugin, got %+v", stats)
+	}
+}
+
+// TestOptionalNotifierWrapper_CheckHealth_AfterKill verifies teardown wins: a
+// health check racing with shutdown must not resurrect the plugin.
+func TestOptionalNotifierWrapper_CheckHealth_AfterKill(t *testing.T) {
+	wrapper := &optionalNotifierWrapper{
+		name:           "test",
+		info:           agent.Plugin{Name: "test", ExecutablePath: "/nonexistent/path/to/plugin"},
+		restartBackoff: restartBaseBackoff,
+	}
+
+	wrapper.Kill()
+	wrapper.CheckHealth()
+
+	if got := wrapper.Stats().RestartFailures; got != 0 {
+		t.Errorf("expected no relaunch attempt after Kill, got %d", got)
+	}
+
+	if err := wrapper.Notify("hello"); err != nil {
+		t.Errorf("expected Notify after Kill to be a no-op, got %v", err)
+	}
+	if got := wrapper.Stats().NotifyFailures; got != 0 {
+		t.Errorf("expected no notify failures counted after Kill, got %d", got)
+	}
+}
+
+// TestNotifierSetWrapper_CheckHealth_Empty tests CheckHealth with an empty set
+func TestNotifierSetWrapper_CheckHealth_Empty(t *testing.T) {
+	set := &notifierSetWrapper{}
+
+	// Should not panic
+	set.CheckHealth()
+
+	if stats := set.Stats(); stats != (NotifierStats{}) {
+		t.Errorf("expected zero stats for an empty set, got %+v", stats)
+	}
+}
+
+// TestNotifierSetWrapper_Stats_Aggregates verifies the set reports the sum of its
+// plugins' counters.
+func TestNotifierSetWrapper_Stats_Aggregates(t *testing.T) {
+	first := &optionalNotifierWrapper{name: "plugin1"}
+	first.notifyFailures.Add(2)
+	first.restarts.Add(1)
+
+	second := &optionalNotifierWrapper{name: "plugin2"}
+	second.notifyFailures.Add(3)
+	second.restartFailures.Add(4)
+
+	set := &notifierSetWrapper{notifiers: []*optionalNotifierWrapper{first, second}}
+
+	expected := NotifierStats{NotifyFailures: 5, Restarts: 1, RestartFailures: 4}
+	if got := set.Stats(); got != expected {
+		t.Errorf("expected %+v, got %+v", expected, got)
+	}
+}
+
+// buildTestNotifierPlugin compiles the testdata notifier plugin and returns the
+// path to the binary.
+func buildTestNotifierPlugin(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not available; skipping plugin subprocess test")
+	}
+
+	name := "notifier_plugin"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+
+	path := filepath.Join(t.TempDir(), name)
+	output, err := exec.Command("go", "build", "-o", path, "./testdata/notifier_plugin").
+		CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build test plugin: %v\n%s", err, output)
+	}
+
+	return path
+}
+
+// waitFor polls cond until it returns true or the timeout elapses.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return cond()
+}
+
+// loadTestNotifier builds and loads the testdata plugin, returning the wrapper,
+// the single loaded plugin wrapper and the path of the file the plugin appends
+// delivered notifications to.
+func loadTestNotifier(t *testing.T) (NotifierWrapper, *optionalNotifierWrapper, string) {
+	t.Helper()
+
+	executablePath := buildTestNotifierPlugin(t)
+	notifyLog := filepath.Join(t.TempDir(), "notifications.log")
+	t.Setenv("AGENT_SMITH_TEST_NOTIFY_LOG", notifyLog)
+
+	logBuf := &syncBuffer{}
+	wrapper, err := LoadNotifer(
+		[]agent.Plugin{{Name: "test-plugin", ExecutablePath: executablePath}},
+		logBuf,
+		newBufferedLogger(logBuf),
+	)
+	if err != nil {
+		t.Fatalf("failed to load test plugin: %v\n%s", err, logBuf.String())
+	}
+	t.Cleanup(wrapper.Kill)
+
+	set, ok := wrapper.(*notifierSetWrapper)
+	if !ok || len(set.notifiers) != 1 {
+		t.Fatalf("expected exactly 1 loaded plugin, got %v", wrapper.Plugins())
+	}
+
+	return wrapper, set.notifiers[0], notifyLog
+}
+
+// killPlugin kills the plugin subprocess and waits until go-plugin observes the
+// exit, mimicking a plugin that crashes mid-run.
+func killPlugin(t *testing.T, notifier *optionalNotifierWrapper) {
+	t.Helper()
+
+	notifier.mu.Lock()
+	reattach := notifier.client.ReattachConfig()
+	notifier.mu.Unlock()
+
+	if reattach == nil || reattach.Pid == 0 {
+		t.Fatal("expected a running plugin subprocess with a pid")
+	}
+
+	process, err := os.FindProcess(reattach.Pid)
+	if err != nil {
+		t.Fatalf("failed to find plugin process %d: %v", reattach.Pid, err)
+	}
+	if err := process.Kill(); err != nil {
+		t.Fatalf("failed to kill plugin process %d: %v", reattach.Pid, err)
+	}
+
+	exited := waitFor(t, 10*time.Second, func() bool {
+		notifier.mu.Lock()
+		defer notifier.mu.Unlock()
+		return notifier.client != nil && notifier.client.Exited()
+	})
+	if !exited {
+		t.Fatal("plugin subprocess exit was never observed")
+	}
+}
+
+// deliveredNotifications returns the notifications the plugin subprocess has
+// written to its log file.
+func deliveredNotifications(t *testing.T, notifyLog string) []string {
+	t.Helper()
+
+	contents, err := os.ReadFile(notifyLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("failed to read notification log: %v", err)
+	}
+
+	var messages []string
+	for _, line := range strings.Split(string(contents), "\n") {
+		if line != "" {
+			messages = append(messages, line)
+		}
+	}
+
+	return messages
+}
+
+// TestLoadNotifer_HealthCheckRestartsCrashedPlugin is the end-to-end regression
+// test for the silent-notification-loss bug: a plugin subprocess that is killed
+// mid-run is detected by the health check, relaunched, and keeps delivering
+// notifications without the agent being restarted.
+func TestLoadNotifer_HealthCheckRestartsCrashedPlugin(t *testing.T) {
+	wrapper, notifier, notifyLog := loadTestNotifier(t)
+
+	if err := wrapper.Notify("AgentStatus:Online"); err != nil {
+		t.Fatalf("expected the first notification to be delivered, got %v", err)
+	}
+
+	killPlugin(t, notifier)
+
+	wrapper.CheckHealth()
+
+	if got := wrapper.Stats().Restarts; got != 1 {
+		t.Fatalf("expected the crashed plugin to be restarted once, got %d", got)
+	}
+
+	if err := wrapper.Notify("AgentStatus:Reconnecting"); err != nil {
+		t.Fatalf("expected notifications to resume after the restart, got %v", err)
+	}
+
+	expected := []string{"AgentStatus:Online", "AgentStatus:Reconnecting"}
+	delivered := waitFor(t, 5*time.Second, func() bool {
+		return len(deliveredNotifications(t, notifyLog)) == len(expected)
+	})
+	if !delivered {
+		t.Fatalf(
+			"expected %v to be delivered, got %v",
+			expected,
+			deliveredNotifications(t, notifyLog),
+		)
+	}
+
+	for i, message := range deliveredNotifications(t, notifyLog) {
+		if message != expected[i] {
+			t.Errorf("notification %d: expected %q, got %q", i, expected[i], message)
+		}
+	}
+}
+
+// TestLoadNotifer_NotifyRestartsCrashedPlugin verifies the relaunch also happens
+// on the notification path, so a notification arriving between the crash and the
+// next health check is still delivered.
+func TestLoadNotifer_NotifyRestartsCrashedPlugin(t *testing.T) {
+	wrapper, notifier, notifyLog := loadTestNotifier(t)
+
+	killPlugin(t, notifier)
+
+	if err := wrapper.Notify("AgentStatus:Offline"); err != nil {
+		t.Fatalf("expected Notify to relaunch the plugin and deliver, got %v", err)
+	}
+
+	stats := wrapper.Stats()
+	if stats.Restarts != 1 {
+		t.Errorf("expected 1 restart, got %d", stats.Restarts)
+	}
+	if stats.NotifyFailures != 0 {
+		t.Errorf("expected no missed notifications, got %d", stats.NotifyFailures)
+	}
+
+	delivered := waitFor(t, 5*time.Second, func() bool {
+		return len(deliveredNotifications(t, notifyLog)) == 1
+	})
+	if !delivered {
+		t.Fatalf(
+			"expected the notification to be delivered by the relaunched plugin, got %v",
+			deliveredNotifications(t, notifyLog),
+		)
+	}
+}
+
+// TestLoadNotifer_HealthyPluginIsNotRestarted verifies the supervision is inert
+// while the plugin stays healthy.
+func TestLoadNotifer_HealthyPluginIsNotRestarted(t *testing.T) {
+	wrapper, _, notifyLog := loadTestNotifier(t)
+
+	for range 3 {
+		wrapper.CheckHealth()
+		if err := wrapper.Notify("AgentStatus:Online"); err != nil {
+			t.Fatalf("expected the notification to be delivered, got %v", err)
+		}
+	}
+
+	if stats := wrapper.Stats(); stats != (NotifierStats{}) {
+		t.Errorf("expected no failures or restarts for a healthy plugin, got %+v", stats)
+	}
+
+	delivered := waitFor(t, 5*time.Second, func() bool {
+		return len(deliveredNotifications(t, notifyLog)) == 3
+	})
+	if !delivered {
+		t.Errorf(
+			"expected 3 notifications delivered, got %v",
+			deliveredNotifications(t, notifyLog),
+		)
 	}
 }
 

--- a/plugins/testdata/notifier_plugin/main.go
+++ b/plugins/testdata/notifier_plugin/main.go
@@ -1,0 +1,61 @@
+// Command notifier_plugin is a minimal Notifier plugin used by the loader tests
+// to exercise real subprocess crash and restart handling. Every notification it
+// receives is appended to the file named by the AGENT_SMITH_TEST_NOTIFY_LOG
+// environment variable, so a test can assert that delivery survives the plugin
+// process being killed and relaunched.
+//
+// It lives under testdata so it is skipped by ./... build and vet patterns; the
+// test builds it explicitly by path.
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/RewstApp/agent-smith-go/shared"
+	"github.com/hashicorp/go-plugin"
+)
+
+// notifyLogEnvVar names the file notifications are appended to. It is read from
+// the environment because the host launches plugins with a fixed argument list.
+const notifyLogEnvVar = "AGENT_SMITH_TEST_NOTIFY_LOG"
+
+type fileNotifier struct {
+	path string
+}
+
+func (n *fileNotifier) Notify(message string) error {
+	file, err := os.OpenFile(n.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = file.Close()
+	}()
+
+	_, err = file.WriteString(message + "\n")
+
+	return err
+}
+
+func main() {
+	// The host passes the handshake secret on the command line, exactly as a real
+	// Agent Smith notification plugin receives it.
+	magicCookieKey := flag.String("magic-cookie-key", "", "Handshake magic cookie key")
+	magicCookieValue := flag.String("magic-cookie-value", "", "Handshake magic cookie value")
+	flag.Parse()
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: plugin.HandshakeConfig{
+			ProtocolVersion:  1,
+			MagicCookieKey:   *magicCookieKey,
+			MagicCookieValue: *magicCookieValue,
+		},
+		Plugins: map[string]plugin.Plugin{
+			"notifier": &shared.NotifierPlugin{
+				Impl: &fileNotifier{path: os.Getenv(notifyLogEnvVar)},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

Notification plugins were loaded exactly once at service start and never health-checked or restarted. When a plugin subprocess exited or crashed, its go-plugin RPC client stayed broken for the life of the agent — and because every notification is best effort with the error deliberately discarded (`_ = notifier.Notify(...)`), the failure was completely invisible.

A long-running agent that lost its plugin silently stopped delivering `AgentStarted`, `AgentStatus:Online`/`Offline`/`Reconnecting`, `AgentPostbackFailed` and `AgentMessageDropped` until someone restarted it — exactly the events an operator relies on to know the agent is unhealthy. Nothing was logged, so the customer believed alerting was fine while it was dead.

## Fix

Loaded plugins are now supervised for the lifetime of the service.

- **Detection** — each wrapper retains the command line and stderr sink it was launched with, and a death is detected via `client.Exited()` from two triggers: a 30s health check polled by the service, and the notification path itself, so a notification arriving between the crash and the next poll is still delivered rather than lost.
- **Relaunch** — exponential backoff (5s → 5min) so a plugin that dies on every launch cannot become a process-spawn loop. A subprocess that stayed up past a 2 minute stability window is treated as a one-off death and relaunched immediately. `Kill` marks the wrapper closed and the service closes the monitor's stop channel before the deferred `Kill`, so a health check racing teardown can never resurrect a plugin.
- **Observability** — missed notifications, restarts and failed restarts increment cumulative counters exposed through `Stats()`. A delivery failure is logged at `Error` level **once per failure transition** (with a matching recovery line) so a persistently broken plugin cannot flood the log, and the service logs a `Plugin notification health summary` on shutdown whenever a counter is non-zero. go-plugin's own diagnostics now go to the agent log, named per plugin.
- **No false restarts** — an error the plugin itself returned (`rpc.ServerError`) is counted and logged but leaves the healthy subprocess alone; only a broken RPC channel drops the handle for relaunch.

Two incidental improvements fell out of the refactor: the RPC call is made without the wrapper lock held so notifications from the worker pool stay concurrent as before, and `launchNotifier` (now shared by the initial load and every relaunch) kills a partially started subprocess when the handshake or dispense fails instead of leaving it orphaned.

## Behavior unchanged when

- No plugins are configured — the health monitor is never started.
- A plugin fails to load at startup — still reported via `Failed to load plugin` and excluded from the set, as before.
- Plugins stay healthy — supervision is inert (no failures, restarts, or extra log lines).

## Acceptance criteria

| Criterion | Where |
|---|---|
| Exit/crash is detected | `deadLocked` via `client.Exited()`, from `CheckHealth` and `Notify` |
| Plugin is re-launched, or failure loudly surfaced | `restartLocked` (+ `Error` log & counter when the relaunch itself fails) |
| Notify failures increment a counter, logged once per transition | `recordFailure` / `recordSuccess`, `NotifierStats` |
| Notifications resume without an agent restart | End-to-end tests below |
| Unchanged with no plugins / healthy plugins | `TestExecute_NoPluginsConfiguredSkipsSupervision`, `TestLoadNotifer_HealthyPluginIsNotRestarted` |

## Testing

A real notifier plugin is built from `plugins/testdata/notifier_plugin`, killed mid-run, and asserted to be relaunched and delivering again through both the health-check and notify paths — mirroring the ticket's QA steps. Plus unit coverage for the backoff and stability reset, transport-vs-plugin error classification, log-once-per-transition, no-restart-after-`Kill`, stats aggregation, and service-level tests for the no-plugin and unloadable-plugin paths.

- `go test ./...` — pass
- `go test -race -count=3 ./plugins/...` — pass
- `golangci-lint run ./...` — 0 issues
- Windows/Linux cross-builds — pass
- `plugins` package coverage: 96.5%

### QA steps

1. Configure a notifier plugin, start the service, confirm `AgentStatus:Online` is delivered.
2. Kill the plugin subprocess. Within 30s the agent logs `Notification plugin restarted after subprocess exit` and relaunches it.
3. Trigger another notification (e.g. force a reconnect) and confirm it is delivered by the new process.
4. Run with no plugins configured and confirm no errors or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
