### PR TITLE
fix: [sc-106105] Bound command output size so a verbose script cannot OOM the agent

### DIFF
--- a/.github/actions/assert-no-orphaned-scripts/action.yml
+++ b/.github/actions/assert-no-orphaned-scripts/action.yml
@@ -1,0 +1,55 @@
+name: Assert no orphaned script files
+description: >
+  Snapshot (mode=snapshot) the agent's exec-<digits>.ps1 temp script files before
+  a scenario and verify (mode=assert) afterwards that none were left behind, which
+  proves each command exited cleanly enough to run its deferred cleanup. See
+  fixture.ps1 for details. The scripts directory belongs to the service account
+  (root / SYSTEM) and on macOS lives under root's own temp directory, so the
+  shared implementation runs elevated: under sudo on Unix, natively on the
+  already-elevated Windows runner.
+
+inputs:
+  mode:
+    description: "snapshot to record the current files, assert to verify nothing new was left behind"
+    required: true
+  scripts_dir:
+    description: "Scripts directory the agent writes command script files to"
+    required: true
+  baseline_file:
+    description: "Path the snapshot is written to and read back from"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Assert no orphaned scripts (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
+        BASELINE_FILE: ${{ inputs.baseline_file }}
+      run: |
+        set -euo pipefail
+        baseline="${BASELINE_FILE:-$RUNNER_TEMP/agent-script-files.baseline}"
+        # Resolve pwsh up front: sudo resets PATH via secure_path on some runners.
+        pwsh_path="$(command -v pwsh)"
+        sudo "$pwsh_path" -NoProfile -File "$GITHUB_ACTION_PATH/fixture.ps1" \
+          -Mode "$MODE" \
+          -ScriptsDir "$SCRIPTS_DIR" \
+          -BaselineFile "$baseline"
+
+    - name: Assert no orphaned scripts (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        MODE: ${{ inputs.mode }}
+        SCRIPTS_DIR: ${{ inputs.scripts_dir }}
+        BASELINE_FILE: ${{ inputs.baseline_file }}
+      run: |
+        $baseline = if ($env:BASELINE_FILE) { $env:BASELINE_FILE } else { Join-Path $env:RUNNER_TEMP 'agent-script-files.baseline' }
+        & "$env:GITHUB_ACTION_PATH/fixture.ps1" `
+          -Mode $env:MODE `
+          -ScriptsDir $env:SCRIPTS_DIR `
+          -BaselineFile $baseline

--- a/.github/actions/assert-no-orphaned-scripts/fixture.ps1
+++ b/.github/actions/assert-no-orphaned-scripts/fixture.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+Snapshots (mode snapshot) or verifies (mode assert) that a scenario left no
+orphaned agent temp script files behind (sc-106105).
+
+.DESCRIPTION
+Every command writes its script to a temp file in the scripts directory and
+relies on deferred cleanup to remove it. That cleanup runs on every path the
+agent returns from - success, non-zero exit, and a command killed by its timeout
+- but not when the process is terminated outright, which is what an OOM kill from
+an unbounded output buffer does. So "the file count did not grow" is the
+observable proof that the verbose commands in this scenario each exited cleanly
+instead of taking the agent down with them.
+
+Only the exact exec-<digits>.ps1 shape os.CreateTemp produces is counted, so
+operator files sharing the directory are never mistaken for agent leftovers, and
+the check is a delta against a snapshot rather than an absolute "directory is
+empty": other scenarios in the same run legitimately seed files here.
+
+The snapshot is written to -BaselineFile so it survives between steps.
+#>
+
+param(
+    [Parameter(Mandatory)][ValidateSet('snapshot', 'assert')][string]$Mode,
+    [Parameter(Mandatory)][string]$ScriptsDir,
+    [Parameter(Mandatory)][string]$BaselineFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ScriptFileNames {
+    if (-not (Test-Path -LiteralPath $ScriptsDir)) {
+        Write-Output "Scripts directory does not exist yet: $ScriptsDir"
+        return @()
+    }
+    return @(
+        Get-ChildItem -LiteralPath $ScriptsDir -File -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^exec-\d+\.ps1$' } |
+            Select-Object -ExpandProperty Name |
+            Sort-Object
+    )
+}
+
+$names = Get-ScriptFileNames
+Write-Output "Agent temp script files in ${ScriptsDir}: $($names.Count)"
+foreach ($name in $names) {
+    Write-Output "  $name"
+}
+
+if ($Mode -eq 'snapshot') {
+    $names | Out-File -FilePath $BaselineFile -Encoding utf8
+    Write-Output "Wrote baseline of $($names.Count) file(s) to $BaselineFile"
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $BaselineFile)) {
+    Write-Error "Baseline file not found: $BaselineFile (was the snapshot step run?)"
+    exit 1
+}
+
+$baseline = @(
+    Get-Content -LiteralPath $BaselineFile -ErrorAction SilentlyContinue |
+        Where-Object { $_ -and $_.Trim() } |
+        ForEach-Object { $_.Trim() }
+)
+Write-Output "Baseline had $($baseline.Count) file(s): $($baseline -join ', ')"
+
+$orphans = @($names | Where-Object { $baseline -notcontains $_ })
+if ($orphans.Count -gt 0) {
+    Write-Error "Scenario orphaned $($orphans.Count) temp script file(s), so a command did not exit cleanly: $($orphans -join ', ')"
+    exit 1
+}
+
+Write-Output "Confirmed no orphaned temp script files: deferred cleanup ran for every command in this scenario"
+exit 0

--- a/.github/actions/assert-output-bounded/action.yml
+++ b/.github/actions/assert-output-bounded/action.yml
@@ -1,0 +1,111 @@
+name: Assert command output bounded
+description: >
+  Sample the agent process's RSS while a verbose command runs and assert the
+  output was bounded rather than buffered whole (sc-106105): the process
+  survives with peak RSS near the configured ceiling, and exactly one truncation
+  warning is logged carrying the message id, the ceiling and both byte counts.
+  See assert.ps1 for the full set of assertions. Resolving the service pid and
+  reading the agent log require elevation, so the shared implementation runs
+  under sudo on Unix and natively on the already-elevated Windows runner.
+
+inputs:
+  service:
+    description: "Service name, used to resolve the running agent pid"
+    required: true
+  log_file:
+    description: "Path to the agent log file"
+    required: true
+  baseline_truncations:
+    description: "Count of 'Command output truncated' lines before this command was sent"
+    required: true
+  expected_ceiling_bytes:
+    description: "The max_output_bytes value configured for the device; the warning must report exactly this"
+    required: true
+  min_kept_bytes:
+    description: "Lower bound for the reported output_bytes_kept"
+    required: true
+  max_kept_bytes:
+    description: "Upper bound for the reported output_bytes_kept"
+    required: true
+  min_produced_bytes:
+    description: "Minimum volume the command must have written for the scenario to be meaningful"
+    required: true
+  max_rss_mb:
+    description: "Peak agent RSS allowed while the command runs"
+    required: true
+  max_attempts:
+    description: "Maximum number of RSS samples to take while waiting for the truncation warning"
+    required: false
+    default: "120"
+  interval_seconds:
+    description: "Seconds between RSS samples"
+    required: false
+    default: "1"
+  settle_samples:
+    description: "Extra samples taken after the warning appears, so the post-command result copies are included in the peak"
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Assert output bounded (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        SERVICE: ${{ inputs.service }}
+        LOG_FILE: ${{ inputs.log_file }}
+        BASELINE_TRUNCATIONS: ${{ inputs.baseline_truncations }}
+        EXPECTED_CEILING_BYTES: ${{ inputs.expected_ceiling_bytes }}
+        MIN_KEPT_BYTES: ${{ inputs.min_kept_bytes }}
+        MAX_KEPT_BYTES: ${{ inputs.max_kept_bytes }}
+        MIN_PRODUCED_BYTES: ${{ inputs.min_produced_bytes }}
+        MAX_RSS_MB: ${{ inputs.max_rss_mb }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        INTERVAL_SECONDS: ${{ inputs.interval_seconds }}
+        SETTLE_SAMPLES: ${{ inputs.settle_samples }}
+      run: |
+        set -euo pipefail
+        # Resolve pwsh up front: sudo resets PATH via secure_path on some runners.
+        pwsh_path="$(command -v pwsh)"
+        sudo --preserve-env=GITHUB_STEP_SUMMARY "$pwsh_path" -NoProfile -File "$GITHUB_ACTION_PATH/assert.ps1" \
+          -Service "$SERVICE" \
+          -LogFile "$LOG_FILE" \
+          -BaselineTruncations "$BASELINE_TRUNCATIONS" \
+          -ExpectedCeilingBytes "$EXPECTED_CEILING_BYTES" \
+          -MinKeptBytes "$MIN_KEPT_BYTES" \
+          -MaxKeptBytes "$MAX_KEPT_BYTES" \
+          -MinProducedBytes "$MIN_PRODUCED_BYTES" \
+          -MaxRssMb "$MAX_RSS_MB" \
+          -MaxAttempts "$MAX_ATTEMPTS" \
+          -IntervalSeconds "$INTERVAL_SECONDS" \
+          -SettleSamples "$SETTLE_SAMPLES"
+
+    - name: Assert output bounded (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        LOG_FILE: ${{ inputs.log_file }}
+        BASELINE_TRUNCATIONS: ${{ inputs.baseline_truncations }}
+        EXPECTED_CEILING_BYTES: ${{ inputs.expected_ceiling_bytes }}
+        MIN_KEPT_BYTES: ${{ inputs.min_kept_bytes }}
+        MAX_KEPT_BYTES: ${{ inputs.max_kept_bytes }}
+        MIN_PRODUCED_BYTES: ${{ inputs.min_produced_bytes }}
+        MAX_RSS_MB: ${{ inputs.max_rss_mb }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        INTERVAL_SECONDS: ${{ inputs.interval_seconds }}
+        SETTLE_SAMPLES: ${{ inputs.settle_samples }}
+      run: |
+        & "$env:GITHUB_ACTION_PATH/assert.ps1" `
+          -Service $env:SERVICE `
+          -LogFile $env:LOG_FILE `
+          -BaselineTruncations ([int]$env:BASELINE_TRUNCATIONS) `
+          -ExpectedCeilingBytes ([int]$env:EXPECTED_CEILING_BYTES) `
+          -MinKeptBytes ([int]$env:MIN_KEPT_BYTES) `
+          -MaxKeptBytes ([int]$env:MAX_KEPT_BYTES) `
+          -MinProducedBytes ([long]$env:MIN_PRODUCED_BYTES) `
+          -MaxRssMb ([int]$env:MAX_RSS_MB) `
+          -MaxAttempts ([int]$env:MAX_ATTEMPTS) `
+          -IntervalSeconds ([int]$env:INTERVAL_SECONDS) `
+          -SettleSamples ([int]$env:SETTLE_SAMPLES)

--- a/.github/actions/assert-output-bounded/assert.ps1
+++ b/.github/actions/assert-output-bounded/assert.ps1
@@ -1,0 +1,266 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+Asserts that a verbose command's output was bounded rather than buffered whole
+(sc-106105).
+
+.DESCRIPTION
+Run immediately after dispatching a command that writes far more output than the
+configured max_output_bytes ceiling. While waiting for the agent to report the
+truncation, the agent process's resident set size is sampled every interval so
+the run captures the property the fix exists for: peak RSS tracks the ceiling,
+not the volume the command wrote.
+
+Four things are asserted:
+
+  1. The agent process survives, keeping the same pid throughout. A process that
+     vanishes or is replaced mid-command is exactly what the OOM kill this fix
+     prevents looks like, so either is a failure rather than a retry.
+  2. Peak RSS stays under -MaxRssMb. Before the fix the agent's heap tracked the
+     command's output at roughly 3-4x, so a command writing hundreds of MB moved
+     RSS by hundreds of MB; afterwards it is a small multiple of the ceiling.
+  3. Exactly one truncation warning is emitted for the command - the report is
+     per command, never per write - and it carries the message id, the ceiling in
+     effect, and both byte counts.
+  4. The reported counts are consistent with a bounded capture: the command
+     produced at least -MinProducedBytes, and what was kept falls in the
+     [-MinKeptBytes, -MaxKeptBytes] window the caller expects.
+
+The kept-bytes window is what distinguishes the two flood shapes. For a stdout
+flood it is the ceiling exactly. For a stderr flood the caller sets the window
+just above the ceiling, because the small stdout line the script also writes is
+kept on top of a full stderr capture - which can only happen if the two streams
+are bounded independently instead of sharing one budget.
+
+Counts are compared against a caller-supplied baseline because the agent log
+accumulates across scenarios and already carries warnings from earlier commands.
+#>
+
+param(
+    [Parameter(Mandatory)][string]$Service,
+    [Parameter(Mandatory)][string]$LogFile,
+    [Parameter(Mandatory)][int]$BaselineTruncations,
+    [Parameter(Mandatory)][int]$ExpectedCeilingBytes,
+    [Parameter(Mandatory)][int]$MinKeptBytes,
+    [Parameter(Mandatory)][int]$MaxKeptBytes,
+    [Parameter(Mandatory)][long]$MinProducedBytes,
+    [Parameter(Mandatory)][int]$MaxRssMb,
+    [int]$MaxAttempts = 120,
+    [int]$IntervalSeconds = 1,
+    [int]$SettleSamples = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+$truncationPattern = 'Command output truncated'
+
+# Resolve the running agent from the platform service manager. The pid is
+# re-resolved on every sample so a service the manager restarted underneath us
+# (Restart=always on Linux, KeepAlive on macOS) is detected as a restart rather
+# than silently sampled as a different process.
+function Get-AgentPid {
+    if ($IsWindows) {
+        $query = sc.exe queryex $Service 2>$null
+        $match = $query | Select-String -Pattern 'PID\s*:\s*(\d+)'
+        if (-not $match) { return 0 }
+        return [int]$match.Matches[0].Groups[1].Value
+    }
+
+    if ($IsLinux) {
+        $mainPid = (systemctl show -p MainPID --value $Service 2>$null | Select-Object -First 1)
+        if (-not $mainPid) { return 0 }
+        return [int]($mainPid.Trim())
+    }
+
+    # macOS: launchctl reports the pid of the running job.
+    $print = sudo launchctl print "system/$Service" 2>$null
+    $match = $print | Select-String -Pattern '^\s*pid = (\d+)'
+    if (-not $match) { return 0 }
+    return [int]$match.Matches[0].Groups[1].Value
+}
+
+# Resident set size in MB, or -1 when the process is gone.
+function Get-RssMb([int]$ProcessId) {
+    if ($ProcessId -le 0) { return -1 }
+
+    if ($IsWindows) {
+        $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+        if (-not $proc) { return -1 }
+        return [math]::Round($proc.WorkingSet64 / 1MB, 1)
+    }
+
+    # ps reports RSS in KiB on both Linux and macOS.
+    $rssKb = (ps -o rss= -p $ProcessId 2>$null | Select-Object -First 1)
+    if (-not $rssKb -or -not $rssKb.Trim()) { return -1 }
+    return [math]::Round(([double]$rssKb.Trim()) / 1024, 1)
+}
+
+function Get-TruncationCount {
+    $content = Get-Content $LogFile -Raw -ErrorAction SilentlyContinue
+    if (-not $content) { return 0 }
+    return ([regex]::Matches($content, [regex]::Escape($truncationPattern))).Count
+}
+
+$agentPid = Get-AgentPid
+if ($agentPid -le 0) {
+    Write-Error "Could not resolve a running pid for service $Service" -ErrorAction Continue
+    exit 1
+}
+
+$startRss = Get-RssMb $agentPid
+Write-Output "Sampling agent RSS (service $Service, pid $agentPid, start ${startRss} MB, ceiling $ExpectedCeilingBytes bytes)"
+
+$peakRss = $startRss
+$samples = [System.Collections.Generic.List[string]]::new()
+$samples.Add("0`t$startRss")
+
+$found = $false
+$settle = 0
+
+for ($i = 1; $i -le $MaxAttempts; $i++) {
+    Start-Sleep -Seconds $IntervalSeconds
+
+    # A changed pid means the service was restarted mid-command; a missing one
+    # means the process is simply gone. Both are the failure this fix prevents.
+    $currentPid = Get-AgentPid
+    if ($currentPid -ne $agentPid) {
+        Write-Output ($samples -join "`n")
+        Write-Error "Agent process changed mid-command (pid $agentPid -> $currentPid): the service died and was restarted, which is what an OOM kill looks like" -ErrorAction Continue
+        exit 1
+    }
+
+    $rss = Get-RssMb $agentPid
+    if ($rss -lt 0) {
+        Write-Output ($samples -join "`n")
+        Write-Error "Agent process $agentPid disappeared mid-command (OOM kill?)" -ErrorAction Continue
+        exit 1
+    }
+
+    $samples.Add("$($i * $IntervalSeconds)`t$rss")
+    if ($rss -gt $peakRss) { $peakRss = $rss }
+
+    if (-not $found) {
+        if ((Get-TruncationCount) -gt $BaselineTruncations) {
+            $found = $true
+            Write-Output "Truncation reported after ~$($i * $IntervalSeconds)s (RSS ${rss} MB, peak ${peakRss} MB)"
+        }
+    }
+
+    if ($found) {
+        # Keep sampling briefly past the warning: it is logged as soon as the
+        # command exits, but the kept bytes are copied into a string and
+        # marshalled into the result afterwards, so peak RSS lands slightly
+        # later. Stopping at the warning would under-report the peak.
+        $settle++
+        if ($settle -ge $SettleSamples) { break }
+    }
+}
+
+$rssTrace = "elapsed_s`trss_mb`n" + ($samples -join "`n")
+Write-Output "RSS samples:`n$rssTrace"
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    @(
+        "### Agent RSS while a verbose command ran ($Service)",
+        "",
+        "- ceiling (max_output_bytes): $ExpectedCeilingBytes bytes",
+        "- start RSS: $startRss MB",
+        "- peak RSS: $peakRss MB (allowed: $MaxRssMb MB)",
+        "",
+        '```',
+        $rssTrace,
+        '```',
+        ""
+    ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+$failed = $false
+
+if (-not $found) {
+    Write-Error "Agent never reported '$truncationPattern' (count stayed at $BaselineTruncations) within ~$($MaxAttempts * $IntervalSeconds)s" -ErrorAction Continue
+    exit 1
+}
+
+# The bound is on peak memory, not on the command: this is the assertion that
+# fails loudly if the output is ever buffered whole again.
+if ($peakRss -gt $MaxRssMb) {
+    Write-Error "Peak agent RSS ${peakRss} MB exceeded the ${MaxRssMb} MB ceiling: command output is not bounded (start was ${startRss} MB)" -ErrorAction Continue
+    $failed = $true
+} else {
+    Write-Output "OK: peak RSS ${peakRss} MB stayed under the ${MaxRssMb} MB ceiling (start ${startRss} MB)"
+}
+
+$finalCount = Get-TruncationCount
+$delta = $finalCount - $BaselineTruncations
+if ($delta -ne 1) {
+    Write-Error "Expected exactly one '$truncationPattern' warning for this command, got $delta (baseline $BaselineTruncations, final $finalCount) - is truncation being logged per write?" -ErrorAction Continue
+    $failed = $true
+} else {
+    Write-Output "OK: exactly one truncation warning for this command"
+}
+
+$content = Get-Content $LogFile -Raw
+$lines = [regex]::Matches(
+    $content,
+    '(?<line>[^\r\n]*Command output truncated[^\r\n]*)'
+)
+$line = $lines[$lines.Count - 1].Groups['line'].Value
+Write-Output "Truncation log line: $line"
+
+if ($line -notmatch '\[WARN\]') {
+    Write-Error "Truncation was not logged at Warn level: $line" -ErrorAction Continue
+    $failed = $true
+} else {
+    Write-Output "OK: truncation logged at Warn level"
+}
+
+$fields = [regex]::Match(
+    $line,
+    'message_id=(?<mid>\S+)\s+max_output_bytes=(?<ceiling>\d+)\s+output_bytes_produced=(?<produced>\d+)\s+output_bytes_kept=(?<kept>\d+)'
+)
+if (-not $fields.Success) {
+    Write-Error "Truncation log line is missing the message_id / max_output_bytes / output_bytes_produced / output_bytes_kept fields: $line" -ErrorAction Continue
+    exit 1
+}
+
+$messageId = $fields.Groups['mid'].Value.Trim('"')
+$ceiling = [long]$fields.Groups['ceiling'].Value
+$produced = [long]$fields.Groups['produced'].Value
+$kept = [long]$fields.Groups['kept'].Value
+Write-Output "Parsed truncation fields -> message_id=$messageId max_output_bytes=$ceiling produced=$produced kept=$kept"
+
+if (-not $messageId) {
+    Write-Error "Truncation log line carried an empty message_id: $line" -ErrorAction Continue
+    $failed = $true
+}
+
+if ($ceiling -ne $ExpectedCeilingBytes) {
+    Write-Error "Truncation reported max_output_bytes=$ceiling, expected the configured ${ExpectedCeilingBytes}: the per-device override was not honored" -ErrorAction Continue
+    $failed = $true
+}
+
+if ($produced -lt $MinProducedBytes) {
+    Write-Error "Truncation reported output_bytes_produced=$produced, expected at least ${MinProducedBytes}: the command did not write the volume this scenario needs" -ErrorAction Continue
+    $failed = $true
+}
+
+if ($kept -lt $MinKeptBytes -or $kept -gt $MaxKeptBytes) {
+    Write-Error "Truncation reported output_bytes_kept=$kept, expected between $MinKeptBytes and $MaxKeptBytes" -ErrorAction Continue
+    $failed = $true
+}
+
+if ($kept -ge $produced) {
+    Write-Error "Truncation reported kept=$kept >= produced=$produced, so nothing was actually discarded" -ErrorAction Continue
+    $failed = $true
+}
+
+if ($failed) { exit 1 }
+
+Write-Output "Confirmed bounded output: produced $produced bytes, kept $kept, peak RSS $peakRss MB (ceiling $ExpectedCeilingBytes bytes)"
+
+# Explicit success: this script shells out to ps / sc.exe / launchctl while
+# sampling, so returning implicitly would let one of those exit codes stand in
+# for the assertions' verdict.
+exit 0

--- a/.github/actions/assert-output-bounded/assert.ps1
+++ b/.github/actions/assert-output-bounded/assert.ps1
@@ -28,11 +28,19 @@ Four things are asserted:
      produced at least -MinProducedBytes, and what was kept falls in the
      [-MinKeptBytes, -MaxKeptBytes] window the caller expects.
 
-The kept-bytes window is what distinguishes the two flood shapes. For a stdout
-flood it is the ceiling exactly. For a stderr flood the caller sets the window
-just above the ceiling, because the small stdout line the script also writes is
+The kept-bytes window is what distinguishes the two flood shapes. A stdout flood
+starts at the ceiling, because stdout fills it on its own. A stderr flood starts
+just *above* the ceiling, because the small stdout line the script also writes is
 kept on top of a full stderr capture - which can only happen if the two streams
 are bounded independently instead of sharing one budget.
+
+Callers give the upper end of that window several KiB of headroom rather than
+pinning it exactly. The shell contributes output of its own that the scenario does
+not control: on Windows this run deliberately injects a PROFILE_NOISE_<guid>
+marker into the all-users PowerShell profile, and every agent-spawned PowerShell
+echoes it. What the upper bound exists to catch is a stream that was not capped at
+all, which lands near the produced volume rather than a few bytes past the
+ceiling, so the headroom costs nothing.
 
 Counts are compared against a caller-supplied baseline because the agent log
 accumulates across scenarios and already carries warnings from earlier commands.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -106,6 +106,24 @@ jobs:
 
           $orgId = $env:ORG_ID
 
+          # Output-flood scripts for the bounded-output scenario (sc-106105).
+          # Deliberately quote-free and backslash-free so they survive the trip
+          # through the trigger's JSON-quoted commands field unchanged, and
+          # byte-exact so the produced counts the agent reports are predictable:
+          #   verbose        200 MiB to stdout, then a clean exit
+          #   verbose_stderr a short stdout line, then 200 MiB to stderr
+          #   verbose_hang   200 MiB to stdout, then a hang past the timeout
+          # All three write 200 MiB - three orders of magnitude past the ceiling
+          # the scenario configures - so the RSS ceiling asserted while they run
+          # is far below what buffering the output whole would cost.
+          $winVerbose = '"$chunk = [string]::new([char]120, 1048576); 1..200 | ForEach-Object { $chunk }"'
+          $winVerboseStderr = '"Write-Output keep-stdout; $chunk = [string]::new([char]101, 1048576); 1..200 | ForEach-Object { [Console]::Error.Write($chunk) }"'
+          $winVerboseHang = '"$chunk = [string]::new([char]120, 1048576); 1..200 | ForEach-Object { $chunk }; Start-Sleep -Seconds 60"'
+
+          $unixVerbose = '"yes x | head -c 209715200"'
+          $unixVerboseStderr = '"echo keep-stdout; yes e | head -c 209715200 >&2"'
+          $unixVerboseHang = '"yes x | head -c 209715200; sleep 60"'
+
           $entries = @(
             [ordered]@{
               os = 'ubuntu-latest'
@@ -118,6 +136,9 @@ jobs:
               failure_commands = '"exit 1"'
               timeout_commands = '"sleep 30"'
               sweep_commands = '"sleep 180"'
+              verbose_commands = $unixVerbose
+              verbose_stderr_commands = $unixVerboseStderr
+              verbose_hang_commands = $unixVerboseHang
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/etc/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n/tmp/rewst_remote_agent/scripts/$orgId"
@@ -136,6 +157,9 @@ jobs:
               failure_commands = $winFailure
               timeout_commands = '"Start-Sleep -Seconds 30"'
               sweep_commands = '"Start-Sleep -Seconds 180"'
+              verbose_commands = $winVerbose
+              verbose_stderr_commands = $winVerboseStderr
+              verbose_hang_commands = $winVerboseHang
               success_patterns = "Command completed`nSending postback`nPostback already sent"
               no_auto_updates_extra = '--disable-agent-postback'
               uninstall_paths = "C:\ProgramData\RewstRemoteAgent\$orgId`nC:\Program Files\RewstRemoteAgent\$orgId`nC:\RewstRemoteAgent\scripts\$orgId"
@@ -154,6 +178,9 @@ jobs:
               failure_commands = '"exit 1"'
               timeout_commands = '"sleep 30"'
               sweep_commands = '"sleep 180"'
+              verbose_commands = $unixVerbose
+              verbose_stderr_commands = $unixVerboseStderr
+              verbose_hang_commands = $unixVerboseHang
               success_patterns = "Command completed`nSending postback`nPostback sent"
               no_auto_updates_extra = ''
               uninstall_paths = "/Library/Application Support/rewst_remote_agent/$orgId`n/usr/local/bin/rewst_remote_agent/$orgId`n`$env:TMPDIR/rewst_remote_agent/scripts/$orgId"
@@ -665,6 +692,389 @@ jobs:
           }
           Write-Error "No command completed after SAS renewal (count stayed at $baseline)"
           exit 1
+
+      # ---- Bounded command output scenario (sc-106105) ----
+      # A command's stdout and stderr used to be buffered whole in memory, so the
+      # agent's heap tracked however much a script decided to write and a verbose
+      # one could OOM-kill the service. Configure a deliberately small ceiling,
+      # flood it by three orders of magnitude, and assert the two properties that
+      # matter: the agent's RSS stays near the ceiling instead of near the output
+      # size, and the discarded output is reported rather than silently dropped.
+      #
+      # The release binary is installed first with the per-command timeout raised
+      # well past the floods' runtime, because the earlier timeout scenario left a
+      # 5s deadline in the config that would kill these commands mid-write, and
+      # the SAS scenario left the IT binary running with a 90s token lifetime
+      # whose reconnect would cancel them. --logging-level is deliberately not
+      # passed: it resets to the default (Info), which keeps the Warn under test
+      # visible while leaving the debug handler that dumps whole command outputs
+      # into the log switched off. --disable-agent-postback is likewise not
+      # passed (unlike the sweep scenario) so the truncated result actually
+      # traverses the postback path on every platform.
+      #
+      # Coverage note: these steps assert on the agent log, which is where the
+      # byte counts are observable on the endpoint. The same counts are what the
+      # postback carries as truncated/output_bytes_produced/output_bytes_kept -
+      # both come from one value computed once per command - but the postback body
+      # is never logged, so confirming the workflow's received payload stays a
+      # Rewst-side QA step.
+      - name: Resolve the scripts directory
+        id: scripts_dir
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          # Read the directory off a "Command saved to" line rather than
+          # re-deriving the platform path: the service's temp directory is not the
+          # runner's, notably root's private TMPDIR on macOS. Many earlier
+          # scenarios have already logged one.
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $found = if ($content) { [regex]::Matches($content, 'Command saved to[^\r\n]*path=(?<p>\S+)') } else { @() }
+          if ($found.Count -eq 0) {
+            Write-Error "No 'Command saved to' line in the log; cannot resolve the scripts directory"
+            exit 1
+          }
+          $path = $found[$found.Count - 1].Groups['p'].Value.Trim('"')
+          $dir = Split-Path -Parent $path
+          "path=$dir" >> $env:GITHUB_OUTPUT
+          Write-Output "Scripts directory: $dir"
+
+      - name: Snapshot temp script files before the output floods
+        uses: ./.github/actions/assert-no-orphaned-scripts
+        with:
+          mode: snapshot
+          scripts_dir: ${{ steps.scripts_dir.outputs.path }}
+
+      # Captured before the update below restarts the service: the restart's own
+      # "Subscribed to messages" line must land after this snapshot for the delta
+      # wait to mean anything.
+      - name: Capture bounded-output baseline counts
+        id: output_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          $truncated  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command output truncated"))).Count } else { 0 }
+          $completed  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "truncated=$truncated"   >> $env:GITHUB_OUTPUT
+          "completed=$completed"   >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed truncated=$truncated completed=$completed"
+
+      - name: Configure a small output ceiling
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates --max-output-bytes 262144 --command-timeout-seconds 600 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert a non-positive output ceiling is rejected
+        shell: pwsh
+        env:
+          BINARY: ${{ matrix.binary }}
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+        run: |
+          # The bound must not be disablable by configuration: a non-positive
+          # value is refused outright rather than accepted as "no limit" (a
+          # hand-edited config falls back to the documented default instead).
+          foreach ($value in @('0', '-1')) {
+            if ($IsWindows) {
+              $out = & "./dist/$env:BINARY" --update --org-id $env:ORG_ID --max-output-bytes $value 2>&1 | Out-String
+            } else {
+              $out = & sudo "./dist/$env:BINARY" --update --org-id $env:ORG_ID --max-output-bytes $value 2>&1 | Out-String
+            }
+            $code = $LASTEXITCODE
+            if ($code -eq 0) {
+              Write-Output $out
+              Write-Error "--max-output-bytes $value was accepted (exit 0); the bound must not be disablable"
+              exit 1
+            }
+            if ($out -notmatch 'invalid max-output-bytes: must be a positive integer') {
+              Write-Output $out
+              Write-Error "--max-output-bytes $value was rejected without the expected validation message"
+              exit 1
+            }
+            Write-Output "OK: --max-output-bytes $value rejected (exit $code) with the expected message"
+          }
+          # Explicit success: the runner appends "exit $LASTEXITCODE" to pwsh
+          # steps, and the last thing this step ran was a deliberately failing
+          # agent invocation, so falling off the end would report that failure as
+          # the step's own.
+          exit 0
+
+      - name: Wait for fresh subscription after the output ceiling update
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.output_baseline.outputs.subscribed }}
+        run: |
+          # A delta, not a bare match: the log already carries many "Subscribed to
+          # messages" lines, so only a new one proves the restarted agent is
+          # connected with the new ceiling in effect.
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent subscribed with the new output ceiling (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent did not subscribe after the output ceiling update (count stayed at $baseline)"
+          exit 1
+
+      - name: Send stdout flood command
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.verbose_commands }}
+
+      - name: Assert the stdout flood was bounded
+        uses: ./.github/actions/assert-output-bounded
+        with:
+          service: ${{ matrix.service }}
+          log_file: ${{ matrix.log_file }}
+          baseline_truncations: ${{ steps.output_baseline.outputs.truncated }}
+          expected_ceiling_bytes: "262144"
+          # Exactly the ceiling: stdout alone was flooded, so nothing else
+          # contributes to the kept total.
+          min_kept_bytes: "262144"
+          max_kept_bytes: "262144"
+          min_produced_bytes: "209715200"
+          max_rss_mb: "250"
+
+      - name: Assert the flooding command still succeeded
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.output_baseline.outputs.completed }}
+        run: |
+          # Being verbose is not a failure: the command runs to completion with the
+          # excess discarded, so it reports "Command completed", not "Command
+          # failed" or "Command timed out".
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Flooding command completed normally (count $count > baseline $baseline)"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "The flooding command never completed (count stayed at $baseline): it was killed for being verbose"
+          exit 1
+
+      - name: Capture small-output baseline counts
+        id: small_output_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $truncated = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command output truncated"))).Count } else { 0 }
+          $completed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+          "truncated=$truncated" >> $env:GITHUB_OUTPUT
+          "completed=$completed" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> truncated=$truncated completed=$completed"
+
+      - name: Send ordinary command after the flood
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Assert output below the ceiling is untouched and the worker recovered
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          COMPLETED_BASELINE: ${{ steps.small_output_baseline.outputs.completed }}
+          TRUNCATED_BASELINE: ${{ steps.small_output_baseline.outputs.truncated }}
+        run: |
+          # Two things at once: the worker the flood used was released (a later
+          # command completes), and a command whose output fits under the ceiling
+          # is not flagged - the bound only engages on the output that exceeds it.
+          $completedBaseline = [int]$env:COMPLETED_BASELINE
+          $truncatedBaseline = [int]$env:TRUNCATED_BASELINE
+          $completed = $completedBaseline
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $completed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($completed -gt $completedBaseline) { break }
+          }
+          if ($completed -le $completedBaseline) {
+            Write-Error "No command completed after the flood (count stayed at $completedBaseline): the worker was not released"
+            exit 1
+          }
+          Write-Output "Worker released; a later command completed (count $completed > baseline $completedBaseline)"
+
+          $content = Get-Content $env:LOG_FILE -Raw
+          $truncated = ([regex]::Matches($content, [regex]::Escape("Command output truncated"))).Count
+          if ($truncated -ne $truncatedBaseline) {
+            Write-Error "A small-output command was flagged as truncated (count rose from $truncatedBaseline to $truncated)"
+            exit 1
+          }
+          Write-Output "Confirmed small-output command was not truncated (count stayed at $truncatedBaseline)"
+
+      - name: Capture stderr-flood baseline counts
+        id: stderr_flood_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $truncated = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command output truncated"))).Count } else { 0 }
+          "truncated=$truncated" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> truncated=$truncated"
+
+      - name: Send stderr flood command
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.verbose_stderr_commands }}
+
+      - name: Assert stderr is bounded independently of stdout
+        uses: ./.github/actions/assert-output-bounded
+        with:
+          service: ${{ matrix.service }}
+          log_file: ${{ matrix.log_file }}
+          baseline_truncations: ${{ steps.stderr_flood_baseline.outputs.truncated }}
+          expected_ceiling_bytes: "262144"
+          # Above the ceiling on purpose: the script floods stderr to its full
+          # ceiling AND writes a short stdout line, so the kept total can only
+          # exceed the ceiling if the two streams have separate budgets. A shared
+          # budget would cap the total at 262144 and starve one of them.
+          min_kept_bytes: "262145"
+          max_kept_bytes: "262208"
+          min_produced_bytes: "209715200"
+          max_rss_mb: "250"
+
+      # Captured before the update below restarts the service, for the same
+      # reason as the bounded-output baseline.
+      - name: Capture timeout-composition baseline counts
+        id: compose_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          $truncated  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command output truncated"))).Count } else { 0 }
+          $timedOut   = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command timed out"))).Count } else { 0 }
+          $completed  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "truncated=$truncated"   >> $env:GITHUB_OUTPUT
+          "timed_out=$timedOut"    >> $env:GITHUB_OUTPUT
+          "completed=$completed"   >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed truncated=$truncated timed_out=$timedOut completed=$completed"
+
+      - name: Shorten the command timeout for the composition check
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates --max-output-bytes 262144 --command-timeout-seconds 30 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for fresh subscription after the timeout update
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.compose_baseline.outputs.subscribed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent subscribed with the short timeout (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent did not subscribe after the timeout update (count stayed at $baseline)"
+          exit 1
+
+      - name: Send verbose command that then hangs
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.verbose_hang_commands }}
+
+      - name: Assert the hanging command's output was still bounded
+        uses: ./.github/actions/assert-output-bounded
+        with:
+          service: ${{ matrix.service }}
+          log_file: ${{ matrix.log_file }}
+          baseline_truncations: ${{ steps.compose_baseline.outputs.truncated }}
+          expected_ceiling_bytes: "262144"
+          min_kept_bytes: "262144"
+          max_kept_bytes: "262144"
+          # Lower than the flood's full 200 MiB: the command is killed at its
+          # deadline, so only the volume written before the kill is counted.
+          min_produced_bytes: "104857600"
+          max_rss_mb: "250"
+          # The warning lands once the deadline kills the process group, and
+          # cmd.WaitDelay can hold Run for up to 10s more after that.
+          max_attempts: "120"
+
+      - name: Assert the hanging command also timed out and released its worker
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          TIMED_OUT_BASELINE: ${{ steps.compose_baseline.outputs.timed_out }}
+        run: |
+          # The two bounds compose: the same command is reported as truncated
+          # (asserted above) and as timed out, neither masking the other.
+          $baseline = [int]$env:TIMED_OUT_BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command timed out"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Verbose hanging command was killed by the timeout (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Verbose hanging command was not killed by the per-command timeout (count stayed at $baseline)"
+          exit 1
+
+      - name: Send command after the verbose timeout
+        uses: ./.github/actions/send-command
+        with:
+          trigger_url: ${{ vars.IT_SEND_COMMAND_TRIGGER_URL }}
+          device_id: ${{ steps.config.outputs.device_id }}
+          commands: ${{ matrix.success_commands }}
+
+      - name: Assert the worker recovered after the verbose timeout
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.compose_baseline.outputs.completed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 30; $i++) {
+            Start-Sleep -Seconds 2
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Command completed"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Worker recovered after the verbose timeout (count $count > baseline $baseline)"
+              exit 0
+            }
+          }
+          Write-Error "No command completed after the verbose timeout (count stayed at $baseline)"
+          exit 1
+
+      - name: Assert the output floods left no orphaned script files
+        uses: ./.github/actions/assert-no-orphaned-scripts
+        with:
+          mode: assert
+          scripts_dir: ${{ steps.scripts_dir.outputs.path }}
 
       # ---- Stale script file sweep scenario (sc-103967) ----
       # A command interrupted by an abrupt kill (force-stop, OOM kill, power

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -839,10 +839,16 @@ jobs:
           log_file: ${{ matrix.log_file }}
           baseline_truncations: ${{ steps.output_baseline.outputs.truncated }}
           expected_ceiling_bytes: "262144"
-          # Exactly the ceiling: stdout alone was flooded, so nothing else
-          # contributes to the kept total.
+          # At least the whole ceiling, since stdout alone floods it. The upper
+          # bound carries 4 KiB of headroom rather than being exact because the
+          # shell contributes a preamble of its own that is not this scenario's to
+          # control - on Windows the run deliberately injects a
+          # PROFILE_NOISE_<guid> marker into the all-users PowerShell profile,
+          # which every agent-spawned PowerShell echoes. What the bound has to
+          # catch is a stream that was not capped at all, and that would land
+          # near the 200 MiB produced, not a few bytes over.
           min_kept_bytes: "262144"
-          max_kept_bytes: "262144"
+          max_kept_bytes: "266240"
           min_produced_bytes: "209715200"
           max_rss_mb: "250"
 
@@ -949,9 +955,12 @@ jobs:
           # Above the ceiling on purpose: the script floods stderr to its full
           # ceiling AND writes a short stdout line, so the kept total can only
           # exceed the ceiling if the two streams have separate budgets. A shared
-          # budget would cap the total at 262144 and starve one of them.
+          # budget would cap the total at 262144 and starve one of them. The upper
+          # bound has the same 4 KiB of headroom as the stdout flood, for the same
+          # reason: the stdout side carries the shell's preamble as well as the
+          # scenario's own line.
           min_kept_bytes: "262145"
-          max_kept_bytes: "262208"
+          max_kept_bytes: "266240"
           min_produced_bytes: "209715200"
           max_rss_mb: "250"
 
@@ -1013,8 +1022,10 @@ jobs:
           log_file: ${{ matrix.log_file }}
           baseline_truncations: ${{ steps.compose_baseline.outputs.truncated }}
           expected_ceiling_bytes: "262144"
+          # Same headroom as the other floods: stdout fills the ceiling on its
+          # own, and anything the shell adds on either stream is incidental.
           min_kept_bytes: "262144"
-          max_kept_bytes: "262144"
+          max_kept_bytes: "266240"
           # Lower than the flood's full 200 MiB: the command is killed at its
           # deadline, so only the volume written before the kill is counted.
           min_produced_bytes: "104857600"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Loaded plugins are supervised: a subprocess that exits or crashes is detected (b
 
 1. Agent connects to Azure IoT Hub via MQTT on topic `devices/{device_id}/messages/devicebound/#`
 2. Receives JSON messages containing either `commands` (shell scripts) or `get_installation` (system info requests)
-3. Executes commands using platform-appropriate interpreter (PowerShell on Windows, Bash on Unix)
+3. Executes commands using platform-appropriate interpreter (PowerShell on Windows, Bash on Unix). Stdout and stderr are each captured through an independently bounded writer (`max_output_bytes`, default 10 MiB per stream) so a verbose script cannot OOM the agent; output past the ceiling is discarded and the result is flagged `truncated` with both byte counts. See the README's "Bounding per-command output size" section.
 4. Posts results back to Rewst engine at `https://{rewst_engine_host}/webhooks/custom/action/{post_id}`
 
 ### Client System Deployment

--- a/README.md
+++ b/README.md
@@ -238,6 +238,54 @@ stays unbounded, preserving the historical behavior. Example snippet:
 }
 ```
 
+#### Bounding per-command output size
+
+A command's `stdout` and `stderr` are each captured through a **bounded writer**,
+so a script that writes a very large volume of output cannot exhaust memory on
+the endpoint and get the agent OOM-killed. Once a stream reaches its ceiling,
+further bytes from that stream are discarded instead of accumulated, which keeps
+the memory one command's output costs the agent a small constant multiple of the
+ceiling no matter how much the script writes.
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `max_output_bytes` | `10485760` (10 MiB) | Maximum bytes of command output kept, applied independently to `stdout` and `stderr`. |
+
+The default is far above any legitimate observed command result, so existing
+workflows are unaffected. It falls back to the default when omitted or set to a
+non-positive value, so the bound can never be disabled by configuration. The
+value can also be set at install time with `--max-output-bytes <N>`, or changed
+later with `--update --max-output-bytes <N>`.
+
+Truncation is deliberately non-fatal:
+
+- **The command is not killed for being verbose.** It runs to completion (or to
+  its `command_timeout_seconds` deadline) with the excess output dropped, so a
+  script whose real work succeeds still reports success.
+- **The output produced before the ceiling was reached is still delivered** — a
+  truncated result is never turned into an empty or error-only one.
+- **The result says so explicitly**, so a workflow can tell a truncated result
+  from a complete one instead of silently trusting a partial one:
+
+```json
+{
+  "output": "...the first max_output_bytes of stdout...",
+  "error": "...the first max_output_bytes of stderr...",
+  "truncated": true,
+  "output_bytes_produced": 2097152000,
+  "output_bytes_kept": 20971520
+}
+```
+
+`output_bytes_produced` and `output_bytes_kept` are totals across both streams.
+All three keys are **omitted** when the output was captured in full, so a
+complete result is byte-identical to what previous releases posted back. A
+command that was both verbose and hung carries `"truncated": true` alongside
+`"timed_out": true`.
+
+Each truncation is logged **once per command** at `Warn` level with the
+`message_id`, the ceiling in effect, and both byte counts — never once per write.
+
 ### Command Result Delivery
 
 After a command runs, the agent posts its result back to the Rewst engine with

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -131,6 +131,7 @@ func runConfig(params *configContext) error {
 	)
 	response.Configuration.CommandTimeoutSeconds = tuningPtr(params.Tuning.CommandTimeoutSeconds)
 	response.Configuration.SasTokenLifetimeHours = tuningPtr(params.Tuning.SasTokenLifetimeHours)
+	response.Configuration.MaxOutputBytes = tuningPtr(params.Tuning.MaxOutputBytes)
 
 	// Create the data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -31,6 +31,7 @@ type tuningFlags struct {
 	PostbackBaseRetryBackoffSeconds int
 	CommandTimeoutSeconds           int
 	SasTokenLifetimeHours           int
+	MaxOutputBytes                  int
 	// provided records which tuning flag names the operator explicitly set. It is
 	// populated from flag.FlagSet.Visit after parsing so validation can flag an
 	// explicitly-provided non-positive value (e.g. --worker-count -1) even when it
@@ -48,6 +49,7 @@ var tuningFlagNames = []string{
 	"postback-base-retry-backoff-seconds",
 	"command-timeout-seconds",
 	"sas-token-lifetime-hours",
+	"max-output-bytes",
 }
 
 // captureProvided records which tuning flags were explicitly set on fs so that
@@ -111,6 +113,12 @@ func bindTuningFlags(fs *flag.FlagSet, t *tuningFlags) {
 		tuningFlagUnset,
 		"Azure IoT Hub SAS token lifetime in hours (positive integer)",
 	)
+	fs.IntVar(
+		&t.MaxOutputBytes,
+		"max-output-bytes",
+		tuningFlagUnset,
+		"Maximum bytes of command output kept per stream before truncation (positive integer)",
+	)
 }
 
 // validate rejects any tuning flag that was explicitly provided with a
@@ -128,6 +136,7 @@ func (t tuningFlags) validate() error {
 		{"postback-base-retry-backoff-seconds", t.PostbackBaseRetryBackoffSeconds},
 		{"command-timeout-seconds", t.CommandTimeoutSeconds},
 		{"sas-token-lifetime-hours", t.SasTokenLifetimeHours},
+		{"max-output-bytes", t.MaxOutputBytes},
 	}
 	for _, c := range checks {
 		if t.provided[c.name] && c.value <= 0 {

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -92,7 +92,8 @@ func TestNewConfigContext(t *testing.T) {
 		result.Tuning.MessageQueueSize != tuningFlagUnset ||
 		result.Tuning.PostbackMaxAttempts != tuningFlagUnset ||
 		result.Tuning.PostbackBaseRetryBackoffSeconds != tuningFlagUnset ||
-		result.Tuning.CommandTimeoutSeconds != tuningFlagUnset {
+		result.Tuning.CommandTimeoutSeconds != tuningFlagUnset ||
+		result.Tuning.MaxOutputBytes != tuningFlagUnset {
 		t.Errorf("expected tuning flags to default to unset, got %+v", result.Tuning)
 	}
 
@@ -108,6 +109,7 @@ func TestNewConfigContext(t *testing.T) {
 			"--postback-max-attempts", "5",
 			"--postback-base-retry-backoff-seconds", "2",
 			"--command-timeout-seconds", "120",
+			"--max-output-bytes", "2048",
 		},
 		nil, nil, nil, nil,
 	)
@@ -143,6 +145,9 @@ func TestNewConfigContext(t *testing.T) {
 			"expected CommandTimeoutSeconds 120, got %v",
 			resultWithTuning.Tuning.CommandTimeoutSeconds,
 		)
+	}
+	if resultWithTuning.Tuning.MaxOutputBytes != 2048 {
+		t.Errorf("expected MaxOutputBytes 2048, got %v", resultWithTuning.Tuning.MaxOutputBytes)
 	}
 
 	errorTests := []struct {
@@ -236,6 +241,15 @@ func TestNewConfigContext(t *testing.T) {
 				"--postback-base-retry-backoff-seconds", "-5",
 			},
 			"invalid postback-base-retry-backoff-seconds: must be a positive integer",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--max-output-bytes", "0",
+			},
+			"invalid max-output-bytes: must be a positive integer",
 		},
 		{
 			[]string{

--- a/cmd/agent_smith/postback_spool_test.go
+++ b/cmd/agent_smith/postback_spool_test.go
@@ -165,15 +165,22 @@ func TestSpool_AgeBoundOnFlush(t *testing.T) {
 
 // TestSpool_AgeBoundOnEnqueue verifies that a later enqueue prunes entries that
 // have aged out, bounding growth even without a flush.
+//
+// Age is decided by comparing an entry's CreatedAt against now-maxAge, so the
+// two entries are separated by backdating the old one rather than by sleeping
+// past a short maxAge. A sleep-based version has to pick a maxAge small enough to
+// keep the test quick, which then also has to outlast the directory read and
+// flush that follow - on a slow or loaded runner the fresh entry ages out too and
+// the flush delivers nothing. Backdating keeps maxAge comfortably longer than the
+// whole test while still putting the old entry unambiguously past it.
 func TestSpool_AgeBoundOnEnqueue(t *testing.T) {
-	s := newTestSpool(t, 10, 10*time.Millisecond)
+	s := newTestSpool(t, 10, time.Minute)
 
 	if err := s.enqueue(
-		spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now()},
+		spoolEntry{PostId: "old", Result: []byte("x"), CreatedAt: time.Now().Add(-time.Hour)},
 	); err != nil {
 		t.Fatalf("enqueue old: %v", err)
 	}
-	time.Sleep(30 * time.Millisecond)
 	if err := s.enqueue(
 		spoolEntry{PostId: "new", Result: []byte("y"), CreatedAt: time.Now()},
 	); err != nil {

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -117,6 +117,9 @@ func runUpdate(params *updateContext) {
 	if params.Tuning.SasTokenLifetimeHours != tuningFlagUnset {
 		device.SasTokenLifetimeHours = tuningPtr(params.Tuning.SasTokenLifetimeHours)
 	}
+	if params.Tuning.MaxOutputBytes != tuningFlagUnset {
+		device.MaxOutputBytes = tuningPtr(params.Tuning.MaxOutputBytes)
+	}
 
 	// Save the updated configuration file
 	configBytes, err := json.MarshalIndent(device, "", "  ")

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -55,6 +55,17 @@ type Device struct {
 	// a worker: the command is cancelled once the deadline elapses even if the
 	// MQTT connection stays up.
 	CommandTimeoutSeconds *int `json:"command_timeout_seconds,omitempty"`
+	// MaxOutputBytes optionally overrides how many bytes of a single command's
+	// output the agent keeps, applied independently to stdout and stderr. When
+	// unset (or non-positive) the agent falls back to DefaultMaxOutputBytes.
+	// Output past the ceiling is discarded instead of buffered, so a script that
+	// writes an unbounded volume (a full filesystem listing, a large event-log
+	// dump, an error loop printing per iteration) can no longer exhaust memory
+	// and get the agent OOM-killed; the result posted back is flagged as
+	// truncated and carries both byte counts. Raise it for a device that
+	// legitimately returns very large results, lower it to tighten the memory
+	// ceiling.
+	MaxOutputBytes *int `json:"max_output_bytes,omitempty"`
 	// SasTokenLifetimeHours optionally overrides the lifetime of the Azure IoT
 	// Hub SAS token minted for each MQTT connection, in hours. When unset (or
 	// non-positive) the agent falls back to utils.DefaultSasTokenLifetime. Azure
@@ -90,6 +101,14 @@ const (
 	// total retry window still widens with more attempts, but no single sleep can
 	// overflow, hang a worker for days, or collapse into a tight loop.
 	DefaultPostbackMaxRetryBackoff = 64 * time.Second
+	// DefaultMaxOutputBytes is the ceiling on how much of a single command's
+	// output the agent keeps, applied independently to stdout and stderr, used
+	// when MaxOutputBytes is not configured. 10 MiB per stream is far above any
+	// legitimate observed command result, so existing workflows see no
+	// behavioral change, while bounding the memory one command's output can cost
+	// the agent to a small constant multiple of it instead of tracking however
+	// much the script decides to write.
+	DefaultMaxOutputBytes = 10 * 1024 * 1024
 )
 
 // ResolvedWorkerCount returns the number of command-execution workers to start,
@@ -141,6 +160,17 @@ func (d Device) ResolvedCommandTimeout() (time.Duration, bool) {
 		return time.Duration(*d.CommandTimeoutSeconds) * time.Second, true
 	}
 	return 0, false
+}
+
+// ResolvedMaxOutputBytes returns the per-stream ceiling on captured command
+// output, honoring the per-device override when set to a positive value and
+// falling back to DefaultMaxOutputBytes otherwise. It is always positive, so the
+// bound can never be disabled (or collapsed to zero) by configuration.
+func (d Device) ResolvedMaxOutputBytes() int {
+	if d.MaxOutputBytes != nil && *d.MaxOutputBytes > 0 {
+		return *d.MaxOutputBytes
+	}
+	return DefaultMaxOutputBytes
 }
 
 // MqttConnectTimeout returns the per-attempt MQTT connect timeout, honoring the

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -102,6 +102,28 @@ func TestResolvedPostbackMaxAttempts(t *testing.T) {
 	}
 }
 
+func TestResolvedMaxOutputBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect int
+	}{
+		{"unset falls back to default", nil, DefaultMaxOutputBytes},
+		{"zero falls back to default", intPtr(0), DefaultMaxOutputBytes},
+		{"negative falls back to default", intPtr(-1024), DefaultMaxOutputBytes},
+		{"positive override honored", intPtr(1024), 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{MaxOutputBytes: tt.value}
+			if got := d.ResolvedMaxOutputBytes(); got != tt.expect {
+				t.Errorf("ResolvedMaxOutputBytes() = %d, want %d", got, tt.expect)
+			}
+		})
+	}
+}
+
 func TestSasTokenLifetime(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/interpreter/base_executor.go
+++ b/internal/interpreter/base_executor.go
@@ -1,7 +1,6 @@
 package interpreter
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -169,7 +168,15 @@ func (e *baseExecutor) Execute(
 		return errorResultBytes(logger, err)
 	}
 
-	var stdoutBuf, stderrBuf bytes.Buffer
+	// Capture stdout and stderr through independently bounded writers so a script
+	// that writes an unbounded volume of output cannot grow the agent's heap until
+	// the service is OOM-killed and the endpoint drops offline. Output past the
+	// ceiling is discarded rather than accumulated, which is invisible to the
+	// command itself: it still runs to completion (or to its deadline) and
+	// everything it produced up to the ceiling is still delivered.
+	maxOutputBytes := device.ResolvedMaxOutputBytes()
+	stdoutBuf := newBoundedWriter(maxOutputBytes)
+	stderrBuf := newBoundedWriter(maxOutputBytes)
 
 	// Bound the command to the configured per-command timeout when one is set, so
 	// a hung or interactive script (infinite loop, blocked on stdin, stuck network
@@ -185,14 +192,14 @@ func (e *baseExecutor) Execute(
 
 	// #nosec G204
 	cmd := exec.CommandContext(execCtx, e.Shell, e.BuildExecuteFileArgs(tempfile.Name())...)
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
+	cmd.Stdout = stdoutBuf
+	cmd.Stderr = stderrBuf
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("AGENT_SMITH_VERSION=%s", version.Version[1:]))
 
 	// Kill the whole process group on cancellation (see configureProcessGroup) so
 	// a shell that spawned children is fully torn down, and bound how long Run may
-	// block on output pipes afterward. Because stdout/stderr are in-memory buffers
+	// block on output pipes afterward. Because stdout/stderr are in-memory writers
 	// (not *os.File), the runtime copies them through a pipe a killed child can
 	// still hold open; WaitDelay guarantees Run returns and the worker is released
 	// even then. This only takes effect when the context is cancelled, so commands
@@ -201,6 +208,24 @@ func (e *baseExecutor) Execute(
 	cmd.WaitDelay = commandWaitDelay
 
 	err = cmd.Run()
+
+	// Report discarded output once per command — never per write — and before any
+	// result is built, so every return path below carries the same signal.
+	trunc := truncationOf(stdoutBuf, stderrBuf)
+	if trunc.Truncated {
+		logger.Warn(
+			"Command output truncated",
+			"message_id",
+			message.PostId,
+			"max_output_bytes",
+			maxOutputBytes,
+			"output_bytes_produced",
+			trunc.Produced,
+			"output_bytes_kept",
+			trunc.Kept,
+		)
+	}
+
 	if err != nil {
 		// Distinguish a command killed by the per-command timeout from a normal
 		// non-zero exit. execCtx exceeding its deadline while the parent ctx is
@@ -226,7 +251,7 @@ func (e *baseExecutor) Execute(
 			if stderrBuf.Len() > 0 {
 				errMsg = fmt.Sprintf("%s: %s", errMsg, stderrBuf.String())
 			}
-			return timeoutResultBytes(logger, errMsg, stdoutBuf.String())
+			return timeoutResultBytes(logger, errMsg, stdoutBuf.String(), trunc)
 		}
 
 		logger.Error("Command failed", "error", err)
@@ -237,7 +262,7 @@ func (e *baseExecutor) Execute(
 			"info",
 			stdoutBuf.String(),
 		)
-		return resultBytes(logger, stderrBuf.String(), stdoutBuf.String())
+		return resultBytes(logger, stderrBuf.String(), stdoutBuf.String(), trunc)
 	}
 
 	logger.Info(
@@ -255,7 +280,7 @@ func (e *baseExecutor) Execute(
 		stdoutBuf.String(),
 	)
 
-	return resultBytes(logger, stderrBuf.String(), stdoutBuf.String())
+	return resultBytes(logger, stderrBuf.String(), stdoutBuf.String(), trunc)
 }
 
 func (e *baseExecutor) AlwaysPostback() bool {

--- a/internal/interpreter/base_executor_unix_test.go
+++ b/internal/interpreter/base_executor_unix_test.go
@@ -182,6 +182,230 @@ func TestBaseExecutor_CommandTimeout_UnboundedByDefault(t *testing.T) {
 	}
 }
 
+// TestBaseExecutor_OutputBelowCeiling_Unchanged pins the no-regression case: a
+// command whose output fits under the ceiling produces exactly the result it
+// produced before the bound existed, with no truncation keys on the wire.
+func TestBaseExecutor_OutputBelowCeiling_Unchanged(t *testing.T) {
+	executor := newBashExecutor()
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Warn})
+	device := agent.Device{RewstOrgId: "test-org-below-ceiling"}
+
+	msg := Message{
+		PostId:   "test:below-ceiling",
+		Commands: encodeCommand("printf 'hello\\n'; printf 'oops\\n' >&2"),
+	}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	if want := `{"error":"oops\n","output":"hello\n"}`; string(resultJSON) != want {
+		t.Errorf("result = %s, want %s", resultJSON, want)
+	}
+}
+
+// TestBaseExecutor_OutputAboveCeiling_TruncatedAndFlagged covers the OOM case: a
+// script writing far more than the ceiling must not be buffered in full, the
+// command must still succeed, and the result must say what was dropped.
+func TestBaseExecutor_OutputAboveCeiling_TruncatedAndFlagged(t *testing.T) {
+	executor := newBashExecutor()
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Warn})
+	maxOutput := 1024
+	device := agent.Device{RewstOrgId: "test-org-truncate", MaxOutputBytes: &maxOutput}
+
+	// ~100 KB of stdout against a 1 KB ceiling, then a successful exit.
+	msg := Message{
+		PostId:   "test:truncate",
+		Commands: encodeCommand("for i in $(seq 1 100); do printf 'x%.0s' $(seq 1 1024); done"),
+	}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if !r.Truncated {
+		t.Errorf("expected truncated=true, got %s", resultJSON)
+	}
+	if got := len(r.Output); got != maxOutput {
+		t.Errorf("kept %d bytes of output, want the %d-byte ceiling", got, maxOutput)
+	}
+	if r.Output != strings.Repeat("x", maxOutput) {
+		t.Error("kept output is not the leading bytes the command produced")
+	}
+	if r.OutputBytesKept != int64(maxOutput) {
+		t.Errorf("output_bytes_kept = %d, want %d", r.OutputBytesKept, maxOutput)
+	}
+	if want := int64(100 * 1024); r.OutputBytesProduced != want {
+		t.Errorf("output_bytes_produced = %d, want %d", r.OutputBytesProduced, want)
+	}
+	// A verbose command is not a failed command: it ran to completion, so no
+	// timeout flag and no error.
+	if r.TimedOut {
+		t.Errorf("verbose command flagged as timed out: %s", resultJSON)
+	}
+	if r.Error != "" {
+		t.Errorf("expected no error for a successful verbose command, got %q", r.Error)
+	}
+
+	// Exactly one Warn for the command, carrying the message id and both counts.
+	logs := buf.String()
+	if got := strings.Count(logs, "Command output truncated"); got != 1 {
+		t.Errorf("expected exactly 1 truncation warning, got %d in %q", got, logs)
+	}
+	if !strings.Contains(logs, "[WARN]") {
+		t.Errorf("expected the truncation log at Warn level, got %q", logs)
+	}
+	for _, want := range []string{
+		"test:truncate",
+		"output_bytes_produced=102400",
+		"output_bytes_kept=1024",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("expected truncation log to contain %q, got %q", want, logs)
+		}
+	}
+}
+
+// TestBaseExecutor_StderrBoundedIndependently proves one flooding stream cannot
+// consume the other's budget, and that the result still tells them apart.
+func TestBaseExecutor_StderrBoundedIndependently(t *testing.T) {
+	executor := newBashExecutor()
+
+	logger := hclog.New(&hclog.LoggerOptions{Output: &bytes.Buffer{}, Level: hclog.Warn})
+	maxOutput := 512
+	device := agent.Device{RewstOrgId: "test-org-stderr-bound", MaxOutputBytes: &maxOutput}
+
+	// ~50 KB to stderr, a short line to stdout.
+	msg := Message{
+		PostId: "test:stderr-bound",
+		Commands: encodeCommand(
+			"for i in $(seq 1 50); do printf 'e%.0s' $(seq 1 1024) >&2; done; printf 'kept-stdout'",
+		),
+	}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if !r.Truncated {
+		t.Errorf("expected truncated=true, got %s", resultJSON)
+	}
+	// stdout kept its own (small) output despite stderr blowing past the ceiling.
+	if r.Output != "kept-stdout" {
+		t.Errorf("output = %q, want %q", r.Output, "kept-stdout")
+	}
+	if got := len(r.Error); got != maxOutput {
+		t.Errorf("kept %d bytes of stderr, want the %d-byte ceiling", got, maxOutput)
+	}
+	if r.Error != strings.Repeat("e", maxOutput) {
+		t.Error("kept stderr is not the leading bytes the command produced")
+	}
+	if want := int64(50*1024 + len("kept-stdout")); r.OutputBytesProduced != want {
+		t.Errorf("output_bytes_produced = %d, want %d (both streams)", r.OutputBytesProduced, want)
+	}
+	if want := int64(maxOutput + len("kept-stdout")); r.OutputBytesKept != want {
+		t.Errorf("output_bytes_kept = %d, want %d (both streams)", r.OutputBytesKept, want)
+	}
+}
+
+// TestBaseExecutor_TruncationComposesWithTimeout covers the interaction of the two
+// bounds: a script that floods output and then hangs must be killed at its
+// deadline and report both flags, with its worker released.
+func TestBaseExecutor_TruncationComposesWithTimeout(t *testing.T) {
+	executor := newBashExecutor()
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Warn})
+	timeout := 1
+	maxOutput := 1024
+	device := agent.Device{
+		RewstOrgId:            "test-org-truncate-timeout",
+		CommandTimeoutSeconds: &timeout,
+		MaxOutputBytes:        &maxOutput,
+	}
+
+	msg := Message{
+		PostId: "test:truncate-timeout",
+		Commands: encodeCommand(
+			"for i in $(seq 1 20); do printf 'x%.0s' $(seq 1 1024); done; sleep 30",
+		),
+	}
+
+	done := make(chan []byte, 1)
+	go func() {
+		done <- executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+	}()
+
+	var resultJSON []byte
+	select {
+	case resultJSON = <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("Execute did not return; the worker was not released")
+	}
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if !r.TimedOut {
+		t.Errorf("expected timed_out=true, got %s", resultJSON)
+	}
+	if !r.Truncated {
+		t.Errorf("expected truncated=true, got %s", resultJSON)
+	}
+	if got := len(r.Output); got != maxOutput {
+		t.Errorf("kept %d bytes of output, want the %d-byte ceiling", got, maxOutput)
+	}
+	if r.OutputBytesProduced <= int64(maxOutput) {
+		t.Errorf(
+			"output_bytes_produced = %d, want more than the %d-byte ceiling",
+			r.OutputBytesProduced,
+			maxOutput,
+		)
+	}
+	if got := strings.Count(buf.String(), "Command output truncated"); got != 1 {
+		t.Errorf("expected exactly 1 truncation warning, got %d in %q", got, buf.String())
+	}
+}
+
+// TestBaseExecutor_DefaultCeilingKeepsLargeLegitimateOutput checks the default is
+// permissive enough that output a real workflow might return is kept in full when
+// max_output_bytes is left unset.
+func TestBaseExecutor_DefaultCeilingKeepsLargeLegitimateOutput(t *testing.T) {
+	executor := newBashExecutor()
+
+	var buf bytes.Buffer
+	logger := hclog.New(&hclog.LoggerOptions{Output: &buf, Level: hclog.Warn})
+	device := agent.Device{RewstOrgId: "test-org-default-ceiling"}
+
+	// 1 MB, well under the 10 MiB default.
+	msg := Message{
+		PostId:   "test:default-ceiling",
+		Commands: encodeCommand("for i in $(seq 1 1024); do printf 'x%.0s' $(seq 1 1024); done"),
+	}
+	resultJSON := executor.Execute(context.Background(), &msg, device, logger, nil, nil)
+
+	var r result
+	if err := json.Unmarshal(resultJSON, &r); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if r.Truncated {
+		t.Errorf("1 MB of output was truncated under the default ceiling: %s", resultJSON[:64])
+	}
+	if got, want := len(r.Output), 1024*1024; got != want {
+		t.Errorf("kept %d bytes, want all %d", got, want)
+	}
+	if strings.Contains(buf.String(), "Command output truncated") {
+		t.Errorf("unexpected truncation warning: %q", buf.String())
+	}
+}
+
 func TestBaseExecutor_Diagnostics_DisabledAtInfoLevel(t *testing.T) {
 	counterFile := filepath.Join(t.TempDir(), "version-runs")
 	executor := newCountingExecutor(counterFile)

--- a/internal/interpreter/bounded_writer.go
+++ b/internal/interpreter/bounded_writer.go
@@ -1,0 +1,117 @@
+package interpreter
+
+import "sync"
+
+// boundedWriter is an io.Writer that keeps at most limit bytes of what is written
+// to it, discards the rest, and counts every byte the writer produced either way.
+// It backs a command's stdout and stderr so that a script writing an unbounded
+// volume of output cannot grow the agent's heap until the service is OOM-killed:
+// the bytes retained for one stream never exceed limit (plus the transient copy
+// made while the backing array grows), no matter how much the command writes.
+//
+// Write never reports an error or a short write, so a command is never killed —
+// nor handed a broken pipe — merely for being verbose: it runs to completion (or
+// to its execution deadline) with the excess output dropped on the floor, and
+// whatever it produced up to the ceiling is still delivered.
+//
+// Writes arrive on the goroutine os/exec starts to drain the command's output
+// pipe, while the kept bytes are read on the goroutine that called cmd.Run.
+// cmd.Wait normally joins that copier before returning, but an expired
+// cmd.WaitDelay lets Wait return while the copier is still draining, so every
+// access is guarded by the mutex.
+type boundedWriter struct {
+	mu       sync.Mutex
+	limit    int
+	kept     []byte
+	produced int64
+}
+
+// newBoundedWriter returns a writer that keeps at most limit bytes. Callers pass
+// a resolved, positive limit (see agent.Device.ResolvedMaxOutputBytes); a
+// non-positive limit degenerates to keeping nothing.
+func newBoundedWriter(limit int) *boundedWriter {
+	return &boundedWriter{limit: limit}
+}
+
+func (w *boundedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// n is captured before p is trimmed: the caller must always be told the whole
+	// write was accepted, otherwise io.Copy stops draining the pipe with
+	// ErrShortWrite and the command sees its output fail.
+	n := len(p)
+	w.produced += int64(n)
+
+	if remaining := w.limit - len(w.kept); remaining > 0 {
+		if len(p) > remaining {
+			p = p[:remaining]
+		}
+		w.appendLocked(p)
+	}
+
+	return n, nil
+}
+
+// appendLocked appends p to the kept bytes, growing the backing array by doubling
+// but never past limit. Capping the capacity — rather than letting append double
+// past the limit on the write that fills it — is what keeps both the retained
+// bytes and the transient copy made while growing a small constant multiple of
+// the limit. p is always short enough that the total stays within limit.
+func (w *boundedWriter) appendLocked(p []byte) {
+	if need := len(w.kept) + len(p); cap(w.kept) < need {
+		grown := 2 * cap(w.kept)
+		if grown < need {
+			grown = need
+		}
+		if grown > w.limit {
+			grown = w.limit
+		}
+		next := make([]byte, len(w.kept), grown)
+		copy(next, w.kept)
+		w.kept = next
+	}
+	w.kept = append(w.kept, p...)
+}
+
+// String returns the bytes that were kept, which for output below the ceiling is
+// everything the command wrote.
+func (w *boundedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return string(w.kept)
+}
+
+// Len returns how many bytes were kept.
+func (w *boundedWriter) Len() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.kept)
+}
+
+// Produced returns the total number of bytes written to the stream, including the
+// bytes that were discarded once the ceiling was reached.
+func (w *boundedWriter) Produced() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.produced
+}
+
+// Truncated reports whether any output was discarded.
+func (w *boundedWriter) Truncated() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.produced > int64(len(w.kept))
+}
+
+// truncationOf summarizes the truncation state of a command's two output streams.
+// The byte counts are totals across stdout and stderr (each of which is bounded
+// independently) so a single pair of numbers describes how much output the
+// command produced and how much of it survived into the result.
+func truncationOf(stdout, stderr *boundedWriter) outputTruncation {
+	return outputTruncation{
+		Truncated: stdout.Truncated() || stderr.Truncated(),
+		Produced:  stdout.Produced() + stderr.Produced(),
+		Kept:      int64(stdout.Len() + stderr.Len()),
+	}
+}

--- a/internal/interpreter/bounded_writer_test.go
+++ b/internal/interpreter/bounded_writer_test.go
@@ -1,0 +1,213 @@
+package interpreter
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestBoundedWriter_BelowLimitKeepsEverything(t *testing.T) {
+	w := newBoundedWriter(1024)
+
+	if _, err := io.WriteString(w, "hello "); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if _, err := io.WriteString(w, "world"); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+
+	if got := w.String(); got != "hello world" {
+		t.Errorf("String() = %q, want %q", got, "hello world")
+	}
+	if got := w.Len(); got != len("hello world") {
+		t.Errorf("Len() = %d, want %d", got, len("hello world"))
+	}
+	if got := w.Produced(); got != int64(len("hello world")) {
+		t.Errorf("Produced() = %d, want %d", got, len("hello world"))
+	}
+	if w.Truncated() {
+		t.Error("Truncated() = true for output below the limit")
+	}
+}
+
+// TestBoundedWriter_ExactlyAtLimitIsNotTruncated guards the boundary: filling the
+// ceiling precisely must not be reported as a loss of output.
+func TestBoundedWriter_ExactlyAtLimitIsNotTruncated(t *testing.T) {
+	w := newBoundedWriter(10)
+
+	if _, err := io.WriteString(w, strings.Repeat("a", 10)); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+
+	if w.Truncated() {
+		t.Error("Truncated() = true when output exactly filled the limit")
+	}
+	if got := w.Len(); got != 10 {
+		t.Errorf("Len() = %d, want 10", got)
+	}
+}
+
+func TestBoundedWriter_AboveLimitTruncatesAndCounts(t *testing.T) {
+	const limit = 8
+	w := newBoundedWriter(limit)
+
+	// Split across writes so the ceiling is crossed mid-write, not at a boundary.
+	n, err := io.WriteString(w, "12345")
+	if err != nil || n != 5 {
+		t.Fatalf("first write = (%d, %v), want (5, nil)", n, err)
+	}
+	n, err = io.WriteString(w, "6789ABCDEF")
+	if err != nil || n != 10 {
+		t.Fatalf("second write = (%d, %v), want (10, nil)", n, err)
+	}
+
+	if got := w.String(); got != "12345678" {
+		t.Errorf("String() = %q, want %q (the first %d bytes)", got, "12345678", limit)
+	}
+	if got := w.Len(); got != limit {
+		t.Errorf("Len() = %d, want %d", got, limit)
+	}
+	if got := w.Produced(); got != 15 {
+		t.Errorf("Produced() = %d, want 15", got)
+	}
+	if !w.Truncated() {
+		t.Error("Truncated() = false after output exceeded the limit")
+	}
+}
+
+// TestBoundedWriter_NeverShortWrites is the property that keeps a verbose command
+// alive: io.Copy aborts with ErrShortWrite if a writer reports fewer bytes than it
+// was given, which would surface to the command as a failed/severed stream. The
+// writer must therefore claim every byte even while discarding most of them.
+func TestBoundedWriter_NeverShortWrites(t *testing.T) {
+	w := newBoundedWriter(16)
+
+	// 1 MiB copied through a 16-byte ceiling: io.Copy must run to completion.
+	src := bytes.NewReader(bytes.Repeat([]byte("x"), 1<<20))
+	copied, err := io.Copy(w, src)
+	if err != nil {
+		t.Fatalf("io.Copy through a bounded writer failed: %v", err)
+	}
+	if copied != 1<<20 {
+		t.Errorf("io.Copy copied %d bytes, want %d", copied, 1<<20)
+	}
+	if got := w.Len(); got != 16 {
+		t.Errorf("Len() = %d, want 16", got)
+	}
+	if got := w.Produced(); got != 1<<20 {
+		t.Errorf("Produced() = %d, want %d", got, 1<<20)
+	}
+}
+
+// TestBoundedWriter_MemoryIsBounded asserts the property the OOM fix rests on: the
+// backing array never grows past the ceiling, so retained memory is a function of
+// the limit rather than of how much the command wrote.
+func TestBoundedWriter_MemoryIsBounded(t *testing.T) {
+	const limit = 1000
+	w := newBoundedWriter(limit)
+
+	// Many writes whose total is orders of magnitude above the ceiling, sized so
+	// several land mid-growth rather than on a power-of-two boundary.
+	chunk := bytes.Repeat([]byte("y"), 333)
+	for i := 0; i < 10000; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+	}
+
+	if got := len(w.kept); got != limit {
+		t.Errorf("kept %d bytes, want the %d-byte ceiling", got, limit)
+	}
+	if got := cap(w.kept); got > limit {
+		t.Errorf("backing array grew to cap %d, past the %d-byte ceiling", got, limit)
+	}
+	if got, want := w.Produced(), int64(333*10000); got != want {
+		t.Errorf("Produced() = %d, want %d", got, want)
+	}
+}
+
+// TestBoundedWriter_ConcurrentAccessIsSafe exercises the mutex under -race: an
+// expired cmd.WaitDelay lets cmd.Wait return while os/exec's pipe copier is still
+// writing, so reads of the kept bytes can genuinely overlap writes.
+func TestBoundedWriter_ConcurrentAccessIsSafe(t *testing.T) {
+	w := newBoundedWriter(64)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_, _ = io.WriteString(w, "abcdefgh")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = w.String()
+			_ = w.Len()
+			_ = w.Produced()
+			_ = w.Truncated()
+		}
+	}()
+	wg.Wait()
+}
+
+// TestTruncationOf_StreamsAreIndependent verifies stdout and stderr each get their
+// own ceiling (one flooding stream does not steal the other's budget) while the
+// reported counts are the totals across both.
+func TestTruncationOf_StreamsAreIndependent(t *testing.T) {
+	const limit = 4
+	stdout := newBoundedWriter(limit)
+	stderr := newBoundedWriter(limit)
+
+	if _, err := io.WriteString(stdout, "out"); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if _, err := io.WriteString(stderr, strings.Repeat("e", 100)); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+
+	// stdout stayed under its own ceiling even though stderr blew through its.
+	if stdout.Truncated() {
+		t.Error("stdout was truncated by stderr's volume; ceilings are not independent")
+	}
+	if got := stdout.String(); got != "out" {
+		t.Errorf("stdout String() = %q, want %q", got, "out")
+	}
+	if !stderr.Truncated() {
+		t.Error("stderr was not truncated despite exceeding its ceiling")
+	}
+	if got := stderr.Len(); got != limit {
+		t.Errorf("stderr kept %d bytes, want %d", got, limit)
+	}
+
+	trunc := truncationOf(stdout, stderr)
+	if !trunc.Truncated {
+		t.Error("truncationOf reported Truncated=false when stderr was truncated")
+	}
+	if want := int64(3 + 100); trunc.Produced != want {
+		t.Errorf("Produced = %d, want %d (both streams)", trunc.Produced, want)
+	}
+	if want := int64(3 + limit); trunc.Kept != want {
+		t.Errorf("Kept = %d, want %d (both streams)", trunc.Kept, want)
+	}
+}
+
+func TestTruncationOf_NoTruncation(t *testing.T) {
+	stdout := newBoundedWriter(1024)
+	stderr := newBoundedWriter(1024)
+
+	if _, err := io.WriteString(stdout, "fine"); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+
+	trunc := truncationOf(stdout, stderr)
+	if trunc.Truncated {
+		t.Error("truncationOf reported Truncated=true for complete output")
+	}
+	if trunc.Produced != 4 || trunc.Kept != 4 {
+		t.Errorf("Produced/Kept = %d/%d, want 4/4", trunc.Produced, trunc.Kept)
+	}
+}

--- a/internal/interpreter/result.go
+++ b/internal/interpreter/result.go
@@ -18,6 +18,38 @@ type result struct {
 	// distinguish a timeout from a normal non-zero exit. Omitted for commands
 	// that finished on their own.
 	TimedOut bool `json:"timed_out,omitempty"`
+	// Truncated is set when the command produced more output than the configured
+	// per-command ceiling (see agent.Device.ResolvedMaxOutputBytes) and the
+	// excess was discarded rather than buffered, so the receiving workflow can
+	// tell a truncated result from a complete one instead of silently trusting a
+	// partial one. OutputBytesProduced and OutputBytesKept carry the totals
+	// across stdout and stderr, so the workflow can also see how much was
+	// dropped. All three are omitted for output captured in full, leaving those
+	// results byte-identical to previous releases.
+	Truncated           bool  `json:"truncated,omitempty"`
+	OutputBytesProduced int64 `json:"output_bytes_produced,omitempty"`
+	OutputBytesKept     int64 `json:"output_bytes_kept,omitempty"`
+}
+
+// outputTruncation reports whether a command's captured output was cut short by
+// the per-command output ceiling, along with how many bytes the command produced
+// across stdout and stderr and how many of those were kept.
+type outputTruncation struct {
+	Truncated bool
+	Produced  int64
+	Kept      int64
+}
+
+// applyTo copies the truncation signal onto a result. Nothing is set when the
+// output was captured in full, so an untruncated result marshals exactly as it
+// did before the output ceiling existed.
+func (t outputTruncation) applyTo(r *result) {
+	if !t.Truncated {
+		return
+	}
+	r.Truncated = true
+	r.OutputBytesProduced = t.Produced
+	r.OutputBytesKept = t.Kept
 }
 
 func errorResultBytes(logger hclog.Logger, err error) []byte {
@@ -32,11 +64,12 @@ func errorResultBytes(logger hclog.Logger, err error) []byte {
 	return b
 }
 
-func resultBytes(logger hclog.Logger, err string, out string) []byte {
+func resultBytes(logger hclog.Logger, err string, out string, trunc outputTruncation) []byte {
 	r := &result{
 		Error:  err,
 		Output: out,
 	}
+	trunc.applyTo(r)
 	b, marshalErr := json.Marshal(r)
 	if marshalErr != nil {
 		logger.Error("Failed to marshal result", "error", marshalErr)
@@ -48,13 +81,21 @@ func resultBytes(logger hclog.Logger, err string, out string) []byte {
 // timeoutResultBytes marshals the result of a command that was killed because it
 // exceeded the configured per-command execution timeout. It carries whatever
 // output the command produced before it was cancelled and sets TimedOut so the
-// receiving workflow can tell a timeout apart from a normal non-zero exit.
-func timeoutResultBytes(logger hclog.Logger, errMsg string, out string) []byte {
+// receiving workflow can tell a timeout apart from a normal non-zero exit. A
+// command that was both verbose and hung carries the truncation signal alongside
+// the timeout flag.
+func timeoutResultBytes(
+	logger hclog.Logger,
+	errMsg string,
+	out string,
+	trunc outputTruncation,
+) []byte {
 	r := &result{
 		Error:    errMsg,
 		Output:   out,
 		TimedOut: true,
 	}
+	trunc.applyTo(r)
 	b, marshalErr := json.Marshal(r)
 	if marshalErr != nil {
 		logger.Error("Failed to marshal timeout result", "error", marshalErr)

--- a/internal/interpreter/result_test.go
+++ b/internal/interpreter/result_test.go
@@ -41,7 +41,7 @@ func TestErrorResultBytes(t *testing.T) {
 
 func TestResultBytes(t *testing.T) {
 	logger := hclog.NewNullLogger()
-	b := resultBytes(logger, "some error", "some output")
+	b := resultBytes(logger, "some error", "some output", outputTruncation{})
 
 	if b == nil {
 		t.Fatal("expected non-nil bytes")
@@ -77,11 +77,108 @@ func TestErrorResultBytesNeverNil(t *testing.T) {
 
 func TestResultBytesNeverNil(t *testing.T) {
 	logger := hclog.NewNullLogger()
-	b := resultBytes(logger, "", "")
+	b := resultBytes(logger, "", "", outputTruncation{})
 	if len(b) == 0 {
 		t.Fatal("expected non-empty bytes")
 	}
 	if !json.Valid(b) {
 		t.Errorf("expected valid JSON, got %s", b)
+	}
+}
+
+// TestResultBytesOmitsTruncationWhenComplete pins the wire format for output that
+// fit under the ceiling: no truncation keys at all, so a complete postback is
+// byte-identical to what previous releases sent.
+func TestResultBytesOmitsTruncationWhenComplete(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	b := resultBytes(logger, "some error", "some output", outputTruncation{})
+
+	if got, want := string(b), `{"error":"some error","output":"some output"}`; got != want {
+		t.Errorf("resultBytes() = %s, want %s", got, want)
+	}
+}
+
+func TestResultBytesCarriesTruncationSignal(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	trunc := outputTruncation{Truncated: true, Produced: 2_000_000, Kept: 1024}
+	b := resultBytes(logger, "some error", "some output", trunc)
+
+	assertCompactJSON(t, b)
+
+	var out result
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if !out.Truncated {
+		t.Errorf("expected truncated=true, got %s", b)
+	}
+	if out.OutputBytesProduced != 2_000_000 {
+		t.Errorf("output_bytes_produced = %d, want 2000000", out.OutputBytesProduced)
+	}
+	if out.OutputBytesKept != 1024 {
+		t.Errorf("output_bytes_kept = %d, want 1024", out.OutputBytesKept)
+	}
+	// Truncation must never swallow the output that was captured.
+	if out.Output != "some output" {
+		t.Errorf("output = %q, want %q", out.Output, "some output")
+	}
+	if out.Error != "some error" {
+		t.Errorf("error = %q, want %q", out.Error, "some error")
+	}
+	if out.TimedOut {
+		t.Errorf("timed_out set on a result that did not time out: %s", b)
+	}
+}
+
+// TestTimeoutResultBytesComposesWithTruncation covers a command that was both
+// verbose and hung: the workflow must see both flags, not one masking the other.
+func TestTimeoutResultBytesComposesWithTruncation(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	trunc := outputTruncation{Truncated: true, Produced: 5000, Kept: 100}
+	b := timeoutResultBytes(logger, "command timed out after 1s", "partial", trunc)
+
+	assertCompactJSON(t, b)
+
+	var out result
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if !out.TimedOut {
+		t.Errorf("expected timed_out=true, got %s", b)
+	}
+	if !out.Truncated {
+		t.Errorf("expected truncated=true, got %s", b)
+	}
+	if out.OutputBytesProduced != 5000 || out.OutputBytesKept != 100 {
+		t.Errorf(
+			"byte counts = %d/%d, want 5000/100",
+			out.OutputBytesProduced,
+			out.OutputBytesKept,
+		)
+	}
+	if out.Output != "partial" {
+		t.Errorf("output = %q, want %q", out.Output, "partial")
+	}
+}
+
+func TestTimeoutResultBytesOmitsTruncationWhenComplete(t *testing.T) {
+	logger := hclog.NewNullLogger()
+	b := timeoutResultBytes(logger, "command timed out after 1s", "partial", outputTruncation{})
+
+	var out result
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+
+	if !out.TimedOut {
+		t.Errorf("expected timed_out=true, got %s", b)
+	}
+	if out.Truncated {
+		t.Errorf("truncated set on a timeout whose output fit the ceiling: %s", b)
+	}
+	if bytes.Contains(b, []byte("output_bytes")) {
+		t.Errorf("byte counts emitted for untruncated output: %s", b)
 	}
 }


### PR DESCRIPTION
## Problem

`baseExecutor` buffered a command's entire stdout and stderr in unbounded in-memory `bytes.Buffer`s, then copied each again into a string and again into the marshalled JSON result. Peak agent memory tracked the command's output size at roughly 3-4x with no ceiling at any layer.

Any script that writes a large volume — a full filesystem listing, a big event-log dump, a `--verbose` diagnostic run, an error loop printing per iteration — could OOM-kill the agent service on every device it ran on. Because an OOM kill is a hard termination, the deferred temp-script cleanup never ran either, and on Windows the service does not auto-restart the failed run, so one badly-behaved script took remote management offline for that endpoint until service recovery or reboot.

Latent in all released versions through v1.5.0 and current `main`, on all platforms (the buffering is in the shared `baseExecutor`). No customer reports to date; found via a reliability audit of the execution path.

## Fix

Stdout and stderr are each captured through an independently bounded writer. Once a stream reaches its ceiling, further bytes from it are discarded instead of accumulated, keeping the memory one command's output costs the agent a small constant multiple of the ceiling no matter how much the script writes.

Measured: a command writing **500 MB** against a 1 MiB ceiling now allocates **~7 MB in total** for the whole run (2 MB resident), against ~1.5 GB before.

Three details in `boundedWriter` carry the weight:

- **It always reports the full write length.** A short write makes `io.Copy` abort with `ErrShortWrite`, which would sever the command's output stream — so the discard has to be invisible to the command. It runs to completion (or to its `command_timeout_seconds` deadline) with the excess dropped, and a script whose real work succeeds still reports success.
- **It caps the backing array's capacity at the ceiling** rather than letting `append` double past it on the write that fills it, which is what bounds both the retained bytes and the transient copy made while growing.
- **Accesses are mutex-guarded**, because an expired `cmd.WaitDelay` lets `cmd.Wait` return while os/exec's pipe copier is still writing.

### Configuration

`max_output_bytes` follows the existing `Resolved*` pattern and is wired through the shared tuning-flag pipeline as `--max-output-bytes`. It falls back to a **10 MiB per-stream** default when unset or non-positive, so the bound can never be disabled by configuration; the default is far above any legitimate observed result, so existing workflows see no behavioral change.

### Truncation is surfaced, not silent

The postback carries `truncated: true` plus `output_bytes_produced` and `output_bytes_kept` (totals across both streams) alongside the output that *was* captured, so a workflow can tell a truncated result from a complete one instead of trusting a partial one. All three keys are omitted when output was captured in full, leaving those results byte-identical to previous releases. A command that was both verbose and hung carries the truncation signal alongside `timed_out`.

Each truncation is logged **once per command** at `Warn` with the message id, the ceiling in effect, and both byte counts — never per write.

## Testing

**Unit tests** cover output below the ceiling being byte-identical to today's behavior, output above it being truncated/flagged/bounded, stdout and stderr bounded independently, and truncation composing with the timeout path. `-race` clean, `golangci-lint` 0 issues, cross-compiles for Windows and Linux.

**Integration tests** (second commit) add a bounded-output scenario to the workflow, in the same shape as the existing timeout / SAS-renewal / sweep scenarios. It floods a deliberately small ceiling by three orders of magnitude on all three platforms and asserts the agent survives with peak RSS far below what buffering whole would cost, that a non-positive ceiling is refused, that a verbose command still succeeds, that stderr is bounded independently, that truncation and timeout compose, and that no `exec-*.ps1` files are orphaned.

The RSS assertion is what actually guards the regression: the 250 MB peak ceiling sits ~4x above the post-fix peak and ~3x below the ~650-850 MB that buffering 200 MiB whole would cost. The asserted byte windows were taken from the real implementation running the same command strings rather than assumed, and the assertion script was validated against 6 seeded defects to confirm it fails when it should.

## Docs

README gains a "Bounding per-command output size" section alongside the existing `command_timeout_seconds` guidance, documenting the key, the default, the truncation payload, and the logging behavior.

## Reviewer notes

- Adding the `--max-output-bytes` CLI flag goes slightly beyond the ticket's "config key" wording. Every other tuning key has a flag and the QA steps need a way to set it, so it seemed like the consistent call — easy to drop if you disagree.
- The integration steps assert on the agent log, which is where the byte counts are observable on the endpoint. The postback carries the same counts from one value computed once per command, but the postback body is never logged, so confirming the workflow's *received* payload stays a Rewst-side QA step.
- Other `CombinedOutput()` call sites (shell-version/whoami diagnostics, service and diagnostic-scanner commands) are still unbounded. Their output volume is fixed and not script-controlled, so they aren't the reported vector — but they're the same latent shape if a follow-up ticket is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
