### PR TITLE
fix: [sc-106107] Bound MQTT operation waits so a wedged broker cannot hang the agent

### DIFF
--- a/.github/actions/set-broker-host/action.yml
+++ b/.github/actions/set-broker-host/action.yml
@@ -1,0 +1,62 @@
+name: Set agent broker host
+description: >
+  Point the installed agent at a different MQTT broker by rewriting
+  azure_iot_hub_host in its config file, exposing the replaced value as an output
+  so a later step can restore it. Used to swap a test agent between the real
+  Azure IoT Hub and the local stub broker (sc-106107); the agent reads its config
+  only when a service cycle starts, so the change takes effect on the next
+  service restart. See fixture.ps1 for details.
+
+inputs:
+  config_dir:
+    description: "Directory containing the per-org agent config (without org id suffix)"
+    required: true
+  org_id:
+    description: "Organization id whose config should be rewritten"
+    required: true
+  host:
+    description: "Broker hostname to write into the config"
+    required: true
+
+outputs:
+  previous_host:
+    description: "The azure_iot_hub_host value that was replaced"
+    value: ${{ steps.rewrite_unix.outputs.previous_host || steps.rewrite_windows.outputs.previous_host }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set broker host (Unix)
+      id: rewrite_unix
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        CONFIG_DIR: ${{ inputs.config_dir }}
+        ORG_ID: ${{ inputs.org_id }}
+        BROKER_HOST: ${{ inputs.host }}
+      run: |
+        set -euo pipefail
+        previous_file="$RUNNER_TEMP/agent-previous-broker-host"
+        # Resolve pwsh up front: sudo resets PATH via secure_path on some runners.
+        pwsh_path="$(command -v pwsh)"
+        sudo "$pwsh_path" -NoProfile -File "$GITHUB_ACTION_PATH/fixture.ps1" \
+          -ConfigFile "$CONFIG_DIR/$ORG_ID/config.json" \
+          -BrokerHost "$BROKER_HOST" \
+          -PreviousHostFile "$previous_file"
+        echo "previous_host=$(cat "$previous_file")" >> "$GITHUB_OUTPUT"
+
+    - name: Set broker host (Windows)
+      id: rewrite_windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CONFIG_DIR: ${{ inputs.config_dir }}
+        ORG_ID: ${{ inputs.org_id }}
+        BROKER_HOST: ${{ inputs.host }}
+      run: |
+        $previousFile = Join-Path $env:RUNNER_TEMP 'agent-previous-broker-host'
+        & "$env:GITHUB_ACTION_PATH/fixture.ps1" `
+          -ConfigFile (Join-Path (Join-Path $env:CONFIG_DIR $env:ORG_ID) 'config.json') `
+          -BrokerHost $env:BROKER_HOST `
+          -PreviousHostFile $previousFile
+        "previous_host=$(Get-Content $previousFile -Raw)" >> $env:GITHUB_OUTPUT

--- a/.github/actions/set-broker-host/fixture.ps1
+++ b/.github/actions/set-broker-host/fixture.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+# Rewrites azure_iot_hub_host in the agent's config file, and records the value
+# it replaced so the caller can put the original back.
+#
+# The agent exposes no flag for the broker host - it is provisioned once from the
+# Rewst configuration endpoint - so pointing a test agent at the stub broker
+# (sc-106107) means editing the config file directly. The agent only reads the
+# config when a service cycle starts, so the edit takes effect on the next
+# service restart rather than mid-run.
+#
+# The config file belongs to the service account (root / SYSTEM), so this runs
+# elevated; the wrapping action supplies the elevation per platform. The previous
+# host is written to a file rather than to $GITHUB_OUTPUT because sudo does not
+# carry the runner's environment through by default.
+
+param(
+    [Parameter(Mandatory = $true)][string]$ConfigFile,
+    [Parameter(Mandatory = $true)][string]$BrokerHost,
+    [Parameter(Mandatory = $true)][string]$PreviousHostFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ConfigFile)) {
+    Write-Error "config file not found at $ConfigFile"
+    exit 1
+}
+
+$config = Get-Content $ConfigFile -Raw | ConvertFrom-Json
+$previous = $config.azure_iot_hub_host
+
+if ([string]::IsNullOrWhiteSpace($previous)) {
+    Write-Error "config file has no azure_iot_hub_host to replace"
+    exit 1
+}
+
+$config.azure_iot_hub_host = $BrokerHost
+$config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile
+
+Set-Content -Path $PreviousHostFile -Value $previous -NoNewline
+Write-Output "azure_iot_hub_host: $previous -> $BrokerHost"

--- a/.github/actions/start-service/action.yml
+++ b/.github/actions/start-service/action.yml
@@ -1,0 +1,32 @@
+name: Start service
+description: >
+  Start the agent service via the appropriate platform service manager. The
+  counterpart to stop-service, for scenarios that stop the agent mid-run and need
+  it back (e.g. verifying a stop is honored while the broker is wedged, then
+  resuming the same cycle-by-cycle recovery).
+
+inputs:
+  service:
+    description: "Service name"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Start service (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo systemctl start "${{ inputs.service }}"
+
+    - name: Start service (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        sc.exe start "${{ inputs.service }}"
+
+    - name: Start service (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        sudo launchctl start "system/${{ inputs.service }}"

--- a/.github/actions/start-service/action.yml
+++ b/.github/actions/start-service/action.yml
@@ -29,4 +29,8 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        sudo launchctl start "system/${{ inputs.service }}"
+        # Bare label, not a "system/<label>" service target: launchctl's `start`
+        # is a legacy subcommand that resolves a label in the current domain, so
+        # the target form is taken as a literal label and exits 3 (ESRCH). This
+        # mirrors what the agent's own darwinService.Start does.
+        sudo launchctl start "${{ inputs.service }}"

--- a/.github/actions/stub-broker/action.yml
+++ b/.github/actions/stub-broker/action.yml
@@ -8,13 +8,16 @@ description: >
   and takes the ordinary reconnect path - so it needs a broker that stays alive
   and simply never acknowledges.
 
+  On Windows the broker must be launched detached (via WMI), because a child
+  started with Start-Process -NoNewWindow shares the launching step's console and
+  job object and is reaped when that step ends - the broker bound port 8883,
+  logged "listening", and was gone before the next step could connect.
+
   The broker answers on 127.0.0.1 and its certificate carries the loopback
   addresses as SANs, so the agent is pointed straight at the IP. An earlier
   revision issued the certificate for a fake hostname and mapped it in the hosts
-  file; that resolved on Linux but never took effect on the Windows runner, where
-  the agent's connections never reached the broker at all. Taking name resolution
-  out of the path removes that whole class of failure, and leaves no hosts-file
-  entry a missed cleanup could strand on a runner.
+  file; taking name resolution out of the path keeps the fixture simple and
+  leaves no hosts-file entry a missed cleanup could strand on a runner.
 
   mode=start builds and launches the broker (withholding SUBACK), installs its
   freshly minted CA into the host trust store, and verifies with a real TLS
@@ -92,11 +95,15 @@ runs:
         # The broker binds a high port and reads only files it owns, so it runs
         # unprivileged; the agent reaches it over loopback regardless of the
         # service account it runs as.
+        # The broker writes its own log (-log) rather than having the shell
+        # redirect it, so both platforms capture output the same way; see the
+        # Windows launch for why that flag has to exist at all.
         nohup "$WORKDIR/stubbroker" \
           -listen ":$PORT" \
           -host "$HOST" \
           -ca-out "$CA_FILE" \
-          -mode-file "$MODE_FILE" > "$LOG_FILE" 2>&1 &
+          -mode-file "$MODE_FILE" \
+          -log "$LOG_FILE" > /dev/null 2>&1 &
         echo $! > "$PID_FILE"
 
         for _ in $(seq 1 30); do
@@ -151,17 +158,28 @@ runs:
         go build -tags integration -o $exe ./test/stubbroker
         if ($LASTEXITCODE -ne 0) { throw "failed to build stub broker" }
 
-        # Go's log package writes to stderr, so both streams are captured.
-        $proc = Start-Process -FilePath $exe -PassThru -NoNewWindow `
-          -ArgumentList @(
-            '-listen', ":$($env:PORT)",
-            '-host', $env:HOST,
-            '-ca-out', $env:CA_FILE,
-            '-mode-file', $env:MODE_FILE
-          ) `
-          -RedirectStandardOutput $env:LOG_FILE `
-          -RedirectStandardError "$($env:LOG_FILE).err"
-        Set-Content -Path $env:PID_FILE -Value $proc.Id
+        # Launched through WMI rather than Start-Process. A process started with
+        # Start-Process -NoNewWindow shares this step's console and job object,
+        # so the runner reaps it the moment the step ends: the broker bound port
+        # 8883, logged "listening", and was gone by the time the next step
+        # connected - which surfaced as "the target machine actively refused it".
+        # Win32_Process.Create parents the process to WmiPrvSE instead, outside
+        # both, so it survives to the end of the job. It offers no stream
+        # redirection, which is why the broker takes -log and writes its own.
+        $arguments = @(
+          "`"$exe`"",
+          "-listen", "`":$($env:PORT)`"",
+          "-host", $env:HOST,
+          "-ca-out", "`"$($env:CA_FILE)`"",
+          "-mode-file", "`"$($env:MODE_FILE)`"",
+          "-log", "`"$($env:LOG_FILE)`""
+        ) -join ' '
+        $created = Invoke-CimMethod -ClassName Win32_Process -MethodName Create `
+          -Arguments @{ CommandLine = $arguments }
+        if ($created.ReturnValue -ne 0) {
+          throw "Win32_Process.Create failed with return value $($created.ReturnValue)"
+        }
+        Set-Content -Path $env:PID_FILE -Value $created.ProcessId
 
         for ($i = 0; $i -lt 30; $i++) {
           if ((Test-Path $env:CA_FILE) -and (Get-Item $env:CA_FILE).Length -gt 0) { break }
@@ -169,12 +187,12 @@ runs:
         }
         if (-not (Test-Path $env:CA_FILE) -or (Get-Item $env:CA_FILE).Length -eq 0) {
           Write-Output "Stub broker never wrote its CA certificate; log follows:"
-          Get-Content "$($env:LOG_FILE).err" -ErrorAction SilentlyContinue
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
           throw "stub broker failed to start"
         }
 
         Import-Certificate -FilePath $env:CA_FILE -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
-        Write-Output "Stub broker started (pid $($proc.Id))"
+        Write-Output "Stub broker started (pid $($created.ProcessId))"
 
     # Proves TCP reachability and that the CA landed in the machine trust store,
     # under default certificate validation - the same verdict the agent reaches.
@@ -187,6 +205,7 @@ runs:
         HOST: ${{ inputs.host }}
         PORT: ${{ inputs.port }}
         LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
       run: |
         $lastError = $null
         for ($i = 1; $i -le 15; $i++) {
@@ -208,11 +227,19 @@ runs:
           } finally { $tcp.Dispose() }
         }
 
-        Write-Output "Broker log follows:"
-        foreach ($path in @($env:LOG_FILE, "$($env:LOG_FILE).err")) {
-          if (Test-Path $path) { Get-Content $path -ErrorAction SilentlyContinue }
+        # Distinguishes the two ways this fails. A broker that logged "listening"
+        # but is no longer running was reaped after its launching step (the
+        # original Windows failure); one still running means TCP reached it and
+        # the certificate was rejected, i.e. the trust-store install did not take.
+        $alive = $false
+        if (Test-Path $env:PID_FILE) {
+          $brokerPid = (Get-Content $env:PID_FILE).Trim()
+          $alive = $null -ne (Get-Process -Id $brokerPid -ErrorAction SilentlyContinue)
+          Write-Output "Broker process $brokerPid alive: $alive"
         }
-        Write-Error "Stub broker not reachable or not trusted: $lastError"
+        Write-Output "Broker log follows:"
+        if (Test-Path $env:LOG_FILE) { Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue }
+        Write-Error "Stub broker not reachable or not trusted (process alive: $alive): $lastError"
         exit 1
 
     - name: Set broker acknowledgement mode
@@ -233,11 +260,9 @@ runs:
       env:
         LOG_FILE: ${{ steps.paths.outputs.log_file }}
       run: |
-        foreach ($path in @($env:LOG_FILE, "$($env:LOG_FILE).err")) {
-          if (Test-Path $path) {
-            Write-Output "---- $path ----"
-            Get-Content $path -ErrorAction SilentlyContinue
-          }
+        if (Test-Path $env:LOG_FILE) {
+          Write-Output "---- $($env:LOG_FILE) ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
         }
 
     - name: Tear down broker (Unix)

--- a/.github/actions/stub-broker/action.yml
+++ b/.github/actions/stub-broker/action.yml
@@ -8,23 +8,31 @@ description: >
   and takes the ordinary reconnect path - so it needs a broker that stays alive
   and simply never acknowledges.
 
+  The broker answers on 127.0.0.1 and its certificate carries the loopback
+  addresses as SANs, so the agent is pointed straight at the IP. An earlier
+  revision issued the certificate for a fake hostname and mapped it in the hosts
+  file; that resolved on Linux but never took effect on the Windows runner, where
+  the agent's connections never reached the broker at all. Taking name resolution
+  out of the path removes that whole class of failure, and leaves no hosts-file
+  entry a missed cleanup could strand on a runner.
+
   mode=start builds and launches the broker (withholding SUBACK), installs its
-  freshly minted CA into the host trust store, and maps the broker hostname to
-  127.0.0.1 in the hosts file, so the agent verifies the connection exactly as it
-  would a real hub. mode=ack / mode=withhold flip the behavior on a live
+  freshly minted CA into the host trust store, and verifies with a real TLS
+  handshake that the broker is reachable and trusted before any agent is pointed
+  at it - so a broken fixture fails here rather than as a mystifying assertion
+  failure two minutes later. mode=ack / mode=withhold flip the behavior on a live
   connection without restarting anything. mode=stop tears all of it down and is
   idempotent and tolerant of missing state, so an always() cleanup step can run
-  it even if start never completed - a runner is never left with a stale trust
-  anchor or hosts entry.
+  it even if start never completed.
 
 inputs:
   mode:
     description: "start, ack, withhold, or stop"
     required: true
   host:
-    description: "Hostname to issue the broker certificate for and map to loopback"
+    description: "Address the broker answers on, issues its certificate for, and the agent connects to"
     required: false
-    default: "stub-broker.rewst-it.test"
+    default: "127.0.0.1"
   port:
     description: "Port to listen on (the agent reaches a hub on 8883)"
     required: false
@@ -32,7 +40,7 @@ inputs:
 
 outputs:
   host:
-    description: "Hostname the stub broker answers on"
+    description: "Address the stub broker answers on"
     value: ${{ inputs.host }}
   log_file:
     description: "Path the broker's own log is written to"
@@ -102,29 +110,25 @@ runs:
         fi
         echo "Stub broker started (pid $(cat "$PID_FILE"))"
 
-    - name: Trust broker CA and map hostname (Linux)
+    - name: Trust broker CA (Linux)
       if: inputs.mode == 'start' && runner.os == 'Linux'
       shell: bash
       env:
         CA_FILE: ${{ steps.paths.outputs.ca_file }}
-        HOST: ${{ inputs.host }}
       run: |
         set -euo pipefail
         sudo cp "$CA_FILE" /usr/local/share/ca-certificates/rewst-it-stub-broker.crt
         sudo update-ca-certificates
-        echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts
 
-    - name: Trust broker CA and map hostname (macOS)
+    - name: Trust broker CA (macOS)
       if: inputs.mode == 'start' && runner.os == 'macOS'
       shell: bash
       env:
         CA_FILE: ${{ steps.paths.outputs.ca_file }}
-        HOST: ${{ inputs.host }}
       run: |
         set -euo pipefail
         sudo security add-trusted-cert -d -r trustRoot \
           -k /Library/Keychains/System.keychain "$CA_FILE"
-        echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts
 
     - name: Launch broker and trust CA (Windows)
       if: inputs.mode == 'start' && runner.os == 'Windows'
@@ -170,8 +174,46 @@ runs:
         }
 
         Import-Certificate -FilePath $env:CA_FILE -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
-        Add-Content -Path "$env:SystemRoot\System32\drivers\etc\hosts" -Value "127.0.0.1 $($env:HOST)"
         Write-Output "Stub broker started (pid $($proc.Id))"
+
+    # Proves TCP reachability and that the CA landed in the machine trust store,
+    # under default certificate validation - the same verdict the agent reaches.
+    # Without it a fixture problem is indistinguishable from the agent failing to
+    # bound its subscribe wait, which is what the scenario's assertions measure.
+    - name: Verify the broker is reachable and trusted
+      if: inputs.mode == 'start'
+      shell: pwsh
+      env:
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+      run: |
+        $lastError = $null
+        for ($i = 1; $i -le 15; $i++) {
+          $tcp = [System.Net.Sockets.TcpClient]::new()
+          try {
+            $tcp.Connect($env:HOST, [int]$env:PORT)
+            $ssl = [System.Net.Security.SslStream]::new($tcp.GetStream(), $false)
+            try {
+              # No custom validation callback: the handshake succeeds only if the
+              # certificate chains to a root the machine already trusts and
+              # matches the address being connected to.
+              $ssl.AuthenticateAsClient($env:HOST)
+              Write-Output "Stub broker reachable and trusted at $($env:HOST):$($env:PORT) after $i attempt(s)"
+              exit 0
+            } finally { $ssl.Dispose() }
+          } catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+          } finally { $tcp.Dispose() }
+        }
+
+        Write-Output "Broker log follows:"
+        foreach ($path in @($env:LOG_FILE, "$($env:LOG_FILE).err")) {
+          if (Test-Path $path) { Get-Content $path -ErrorAction SilentlyContinue }
+        }
+        Write-Error "Stub broker not reachable or not trusted: $lastError"
+        exit 1
 
     - name: Set broker acknowledgement mode
       if: inputs.mode == 'ack' || inputs.mode == 'withhold'
@@ -203,7 +245,6 @@ runs:
       shell: bash
       env:
         PID_FILE: ${{ steps.paths.outputs.pid_file }}
-        HOST: ${{ inputs.host }}
       run: |
         # Every step tolerates missing state so this can run from an always()
         # cleanup even when start never got far.
@@ -211,7 +252,6 @@ runs:
           kill "$(cat "$PID_FILE")" 2>/dev/null || true
           rm -f "$PID_FILE"
         fi
-        sudo sed -i.bak "/[[:space:]]$HOST\$/d" /etc/hosts || true
         if [ "$RUNNER_OS" = "Linux" ]; then
           sudo rm -f /usr/local/share/ca-certificates/rewst-it-stub-broker.crt
           sudo update-ca-certificates --fresh || true
@@ -227,19 +267,11 @@ runs:
       shell: pwsh
       env:
         PID_FILE: ${{ steps.paths.outputs.pid_file }}
-        HOST: ${{ inputs.host }}
       run: |
         if (Test-Path $env:PID_FILE) {
           $brokerPid = Get-Content $env:PID_FILE
           Stop-Process -Id $brokerPid -Force -ErrorAction SilentlyContinue
           Remove-Item $env:PID_FILE -ErrorAction SilentlyContinue
-        }
-
-        $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
-        if (Test-Path $hosts) {
-          (Get-Content $hosts) |
-            Where-Object { $_ -notmatch "\s$([regex]::Escape($env:HOST))\s*$" } |
-            Set-Content $hosts
         }
 
         Get-ChildItem Cert:\LocalMachine\Root |

--- a/.github/actions/stub-broker/action.yml
+++ b/.github/actions/stub-broker/action.yml
@@ -1,0 +1,249 @@
+name: Stub MQTT broker
+description: >
+  Run the test/stubbroker fixture on the loopback interface as a stand-in Azure
+  IoT Hub, so the agent can be pointed at a broker that completes the TLS
+  handshake, answers CONNECT with CONNACK, keeps answering PINGREQ, and withholds
+  SUBACK for the device's SUBSCRIBE (sc-106107). That combination cannot be
+  produced by cutting the network - a severed connection is detected by keepalive
+  and takes the ordinary reconnect path - so it needs a broker that stays alive
+  and simply never acknowledges.
+
+  mode=start builds and launches the broker (withholding SUBACK), installs its
+  freshly minted CA into the host trust store, and maps the broker hostname to
+  127.0.0.1 in the hosts file, so the agent verifies the connection exactly as it
+  would a real hub. mode=ack / mode=withhold flip the behavior on a live
+  connection without restarting anything. mode=stop tears all of it down and is
+  idempotent and tolerant of missing state, so an always() cleanup step can run
+  it even if start never completed - a runner is never left with a stale trust
+  anchor or hosts entry.
+
+inputs:
+  mode:
+    description: "start, ack, withhold, or stop"
+    required: true
+  host:
+    description: "Hostname to issue the broker certificate for and map to loopback"
+    required: false
+    default: "stub-broker.rewst-it.test"
+  port:
+    description: "Port to listen on (the agent reaches a hub on 8883)"
+    required: false
+    default: "8883"
+
+outputs:
+  host:
+    description: "Hostname the stub broker answers on"
+    value: ${{ inputs.host }}
+  log_file:
+    description: "Path the broker's own log is written to"
+    value: ${{ steps.paths.outputs.log_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve working paths
+      id: paths
+      shell: pwsh
+      env:
+        RUNNER_TEMP_DIR: ${{ runner.temp }}
+      run: |
+        $workdir = Join-Path $env:RUNNER_TEMP_DIR 'stub-broker'
+        New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+        "workdir=$workdir"                                   >> $env:GITHUB_OUTPUT
+        "log_file=$(Join-Path $workdir 'broker.log')"        >> $env:GITHUB_OUTPUT
+        "mode_file=$(Join-Path $workdir 'mode')"             >> $env:GITHUB_OUTPUT
+        "ca_file=$(Join-Path $workdir 'ca.pem')"             >> $env:GITHUB_OUTPUT
+        "pid_file=$(Join-Path $workdir 'broker.pid')"        >> $env:GITHUB_OUTPUT
+
+    - name: Setup go
+      if: inputs.mode == 'start'
+      uses: actions/setup-go@v6
+      with:
+        go-version: "1.25.0"
+        cache: true
+
+    # The broker starts in the withholding mode so a harness that forgets to set
+    # a mode reproduces the bug rather than silently passing.
+    - name: Launch broker (Unix)
+      if: inputs.mode == 'start' && runner.os != 'Windows'
+      shell: bash
+      env:
+        WORKDIR: ${{ steps.paths.outputs.workdir }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+        CA_FILE: ${{ steps.paths.outputs.ca_file }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+        printf 'withhold' > "$MODE_FILE"
+        rm -f "$CA_FILE"
+        # The fixture is behind the `integration` build tag; see its package doc.
+        go build -tags integration -o "$WORKDIR/stubbroker" ./test/stubbroker
+        # The broker binds a high port and reads only files it owns, so it runs
+        # unprivileged; the agent reaches it over loopback regardless of the
+        # service account it runs as.
+        nohup "$WORKDIR/stubbroker" \
+          -listen ":$PORT" \
+          -host "$HOST" \
+          -ca-out "$CA_FILE" \
+          -mode-file "$MODE_FILE" > "$LOG_FILE" 2>&1 &
+        echo $! > "$PID_FILE"
+
+        for _ in $(seq 1 30); do
+          if [ -s "$CA_FILE" ]; then break; fi
+          sleep 1
+        done
+        if [ ! -s "$CA_FILE" ]; then
+          echo "Stub broker never wrote its CA certificate; log follows:"
+          cat "$LOG_FILE" || true
+          exit 1
+        fi
+        echo "Stub broker started (pid $(cat "$PID_FILE"))"
+
+    - name: Trust broker CA and map hostname (Linux)
+      if: inputs.mode == 'start' && runner.os == 'Linux'
+      shell: bash
+      env:
+        CA_FILE: ${{ steps.paths.outputs.ca_file }}
+        HOST: ${{ inputs.host }}
+      run: |
+        set -euo pipefail
+        sudo cp "$CA_FILE" /usr/local/share/ca-certificates/rewst-it-stub-broker.crt
+        sudo update-ca-certificates
+        echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts
+
+    - name: Trust broker CA and map hostname (macOS)
+      if: inputs.mode == 'start' && runner.os == 'macOS'
+      shell: bash
+      env:
+        CA_FILE: ${{ steps.paths.outputs.ca_file }}
+        HOST: ${{ inputs.host }}
+      run: |
+        set -euo pipefail
+        sudo security add-trusted-cert -d -r trustRoot \
+          -k /Library/Keychains/System.keychain "$CA_FILE"
+        echo "127.0.0.1 $HOST" | sudo tee -a /etc/hosts
+
+    - name: Launch broker and trust CA (Windows)
+      if: inputs.mode == 'start' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        WORKDIR: ${{ steps.paths.outputs.workdir }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+        CA_FILE: ${{ steps.paths.outputs.ca_file }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        Set-Content -Path $env:MODE_FILE -Value 'withhold' -NoNewline
+        Remove-Item -Path $env:CA_FILE -ErrorAction SilentlyContinue
+
+        $exe = Join-Path $env:WORKDIR 'stubbroker.exe'
+        # The fixture is behind the `integration` build tag; see its package doc.
+        go build -tags integration -o $exe ./test/stubbroker
+        if ($LASTEXITCODE -ne 0) { throw "failed to build stub broker" }
+
+        # Go's log package writes to stderr, so both streams are captured.
+        $proc = Start-Process -FilePath $exe -PassThru -NoNewWindow `
+          -ArgumentList @(
+            '-listen', ":$($env:PORT)",
+            '-host', $env:HOST,
+            '-ca-out', $env:CA_FILE,
+            '-mode-file', $env:MODE_FILE
+          ) `
+          -RedirectStandardOutput $env:LOG_FILE `
+          -RedirectStandardError "$($env:LOG_FILE).err"
+        Set-Content -Path $env:PID_FILE -Value $proc.Id
+
+        for ($i = 0; $i -lt 30; $i++) {
+          if ((Test-Path $env:CA_FILE) -and (Get-Item $env:CA_FILE).Length -gt 0) { break }
+          Start-Sleep -Seconds 1
+        }
+        if (-not (Test-Path $env:CA_FILE) -or (Get-Item $env:CA_FILE).Length -eq 0) {
+          Write-Output "Stub broker never wrote its CA certificate; log follows:"
+          Get-Content "$($env:LOG_FILE).err" -ErrorAction SilentlyContinue
+          throw "stub broker failed to start"
+        }
+
+        Import-Certificate -FilePath $env:CA_FILE -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+        Add-Content -Path "$env:SystemRoot\System32\drivers\etc\hosts" -Value "127.0.0.1 $($env:HOST)"
+        Write-Output "Stub broker started (pid $($proc.Id))"
+
+    - name: Set broker acknowledgement mode
+      if: inputs.mode == 'ack' || inputs.mode == 'withhold'
+      shell: pwsh
+      env:
+        MODE: ${{ inputs.mode }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+      run: |
+        # The broker re-reads this file per packet, so the change applies to the
+        # live connection without a reconnect.
+        Set-Content -Path $env:MODE_FILE -Value $env:MODE -NoNewline
+        Write-Output "Stub broker mode set to $($env:MODE)"
+
+    - name: Report broker log
+      if: inputs.mode == 'stop'
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+      run: |
+        foreach ($path in @($env:LOG_FILE, "$($env:LOG_FILE).err")) {
+          if (Test-Path $path) {
+            Write-Output "---- $path ----"
+            Get-Content $path -ErrorAction SilentlyContinue
+          }
+        }
+
+    - name: Tear down broker (Unix)
+      if: inputs.mode == 'stop' && runner.os != 'Windows'
+      shell: bash
+      env:
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+      run: |
+        # Every step tolerates missing state so this can run from an always()
+        # cleanup even when start never got far.
+        if [ -f "$PID_FILE" ]; then
+          kill "$(cat "$PID_FILE")" 2>/dev/null || true
+          rm -f "$PID_FILE"
+        fi
+        sudo sed -i.bak "/[[:space:]]$HOST\$/d" /etc/hosts || true
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          sudo rm -f /usr/local/share/ca-certificates/rewst-it-stub-broker.crt
+          sudo update-ca-certificates --fresh || true
+        else
+          sudo security delete-certificate \
+            -c "Rewst Integration Test Stub Broker CA" \
+            /Library/Keychains/System.keychain 2>/dev/null || true
+        fi
+        echo "Stub broker torn down"
+
+    - name: Tear down broker (Windows)
+      if: inputs.mode == 'stop' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+      run: |
+        if (Test-Path $env:PID_FILE) {
+          $brokerPid = Get-Content $env:PID_FILE
+          Stop-Process -Id $brokerPid -Force -ErrorAction SilentlyContinue
+          Remove-Item $env:PID_FILE -ErrorAction SilentlyContinue
+        }
+
+        $hosts = "$env:SystemRoot\System32\drivers\etc\hosts"
+        if (Test-Path $hosts) {
+          (Get-Content $hosts) |
+            Where-Object { $_ -notmatch "\s$([regex]::Escape($env:HOST))\s*$" } |
+            Set-Content $hosts
+        }
+
+        Get-ChildItem Cert:\LocalMachine\Root |
+          Where-Object { $_.Subject -like '*Rewst Integration Test Stub Broker CA*' } |
+          Remove-Item -ErrorAction SilentlyContinue
+
+        Write-Output "Stub broker torn down"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -575,6 +575,7 @@ jobs:
           args: --update --org-id ${{ vars.IT_ORG_ID }} --mqtt-subscribe-timeout-seconds 10 --github-token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Assert bounded subscribe failure and growing backoff
+        id: assert_suback_withheld
         shell: pwsh
         env:
           LOG_FILE: ${{ matrix.log_file }}
@@ -646,6 +647,20 @@ jobs:
             exit 1
           }
           Write-Output "Confirmed the reconnect backoff grows after a withheld SUBACK"
+
+      # What the agent actually did against the stub is only visible in its own
+      # log, and the assertion above deliberately reads counts rather than lines.
+      # Dumping the tail on failure makes a fixture problem (never reached the
+      # broker at all) distinguishable from a real regression (reached it and
+      # blocked) without re-running the job.
+      - name: Dump agent log on withheld-SUBACK failure
+        if: failure() && steps.assert_suback_withheld.outcome == 'failure'
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          Write-Output "---- last 100 lines of $($env:LOG_FILE) ----"
+          Get-Content $env:LOG_FILE -Tail 100 -ErrorAction SilentlyContinue
 
       # The original defect made this impossible: with the cycle parked in
       # token.Wait() the stop signal was never reached, the platform waited out

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -690,7 +690,13 @@ jobs:
           } elseif ($IsLinux) {
             sudo systemctl stop $env:SERVICE
           } else {
-            sudo launchctl stop "system/$($env:SERVICE)"
+            # Bare label, not a "system/<label>" service target. launchctl's
+            # `stop` is a legacy subcommand that resolves a label in the current
+            # domain, so the target form is taken as a literal label, matches
+            # nothing, and exits 3 (ESRCH) without ever signalling the agent.
+            # This mirrors what the agent's own darwinService.Stop does. `stop`
+            # leaves the job loaded, so the later start-service can run it again.
+            sudo launchctl stop $env:SERVICE
           }
 
           # launchctl exits non-zero in situations that are not failures here -
@@ -713,6 +719,22 @@ jobs:
           $sw.Stop()
 
           if (-not $stopped) {
+            # Both halves matter when this fails: the agent log says whether the
+            # stop was received and ignored, and the service manager says whether
+            # it was ever delivered.
+            Write-Output "---- last 60 lines of the agent log ----"
+            Get-Content $env:LOG_FILE -Tail 60 -ErrorAction SilentlyContinue
+            Write-Output "---- service manager state ----"
+            if ($IsWindows) {
+              sc.exe query $env:SERVICE
+            } elseif ($IsLinux) {
+              sudo systemctl status $env:SERVICE --no-pager
+            } else {
+              # print, unlike stop, is a modern subcommand and does take the
+              # system/<label> service target.
+              sudo launchctl print "system/$($env:SERVICE)"
+            }
+            $global:LASTEXITCODE = 0
             Write-Error "Service did not log a clean stop within 30s while wedged on a withholding broker"
             exit 1
           }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -494,6 +494,273 @@ jobs:
           }
           Write-Output "Confirmed exactly one post-reconnect command execution"
 
+      # ---- Withheld-SUBACK scenario (sc-106107) ----
+      # The reconnection scenario above severs the connection, which keepalive
+      # detects and the agent handles as an ordinary reconnect. This one covers
+      # the harder case it cannot reach: a broker that stays alive - completing
+      # the TLS handshake, answering CONNECT with CONNACK, and answering every
+      # PINGREQ - while never sending SUBACK. That is what Azure IoT Hub does when
+      # it throttles a device, and what a middlebox that half-opens a connection
+      # produces. Before the fix it left the agent connected but never subscribed,
+      # silently running no commands and unable to honor a stop; now the subscribe
+      # wait is bounded and stop-interruptible, so the agent fails cleanly, backs
+      # off, and recovers on a later cycle once the broker starts acknowledging.
+      # Counts are compared as deltas because the log already carries lines from
+      # earlier cycles.
+      - name: Capture SUBACK-withheld baseline counts
+        id: suback_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          function Get-PatternCount($text, $needle) {
+            if ($text) { ([regex]::Matches($text, [regex]::Escape($needle))).Count } else { 0 }
+          }
+          $subscribed = Get-PatternCount $content "Subscribed to messages"
+          $timedOut   = Get-PatternCount $content "Failed to subscribe: timed out waiting for broker acknowledgement"
+          $backoffs   = Get-PatternCount $content "Reconnecting in"
+          $stops      = Get-PatternCount $content "Service stopped"
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          "timed_out=$timedOut"    >> $env:GITHUB_OUTPUT
+          "backoffs=$backoffs"     >> $env:GITHUB_OUTPUT
+          "stops=$stops"           >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline -> subscribed=$subscribed timed_out=$timedOut backoffs=$backoffs stops=$stops"
+
+      # Read off a logged path rather than re-deriving the platform path; see the
+      # fuller note on the bounded-output scenario's copy of this step.
+      - name: Resolve the scripts directory (SUBACK scenario)
+        id: suback_scripts_dir
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $found = if ($content) { [regex]::Matches($content, 'Command saved to[^\r\n]*path=(?<p>\S+)') } else { @() }
+          if ($found.Count -eq 0) {
+            Write-Error "No 'Command saved to' line in the log; cannot resolve the scripts directory"
+            exit 1
+          }
+          $dir = Split-Path -Parent $found[$found.Count - 1].Groups['p'].Value.Trim('"')
+          "path=$dir" >> $env:GITHUB_OUTPUT
+          Write-Output "Scripts directory: $dir"
+
+      - name: Snapshot temp script files before the withheld-SUBACK scenario
+        uses: ./.github/actions/assert-no-orphaned-scripts
+        with:
+          mode: snapshot
+          scripts_dir: ${{ steps.suback_scripts_dir.outputs.path }}
+
+      - name: Start stub broker withholding SUBACK
+        id: stub_broker
+        uses: ./.github/actions/stub-broker
+        with:
+          mode: start
+
+      - name: Point agent at the stub broker
+        id: stub_host
+        uses: ./.github/actions/set-broker-host
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          host: ${{ steps.stub_broker.outputs.host }}
+
+      # --update restarts the service, so the rewritten broker host takes effect.
+      # The short subscribe timeout keeps each wedged cycle to ~10s so several
+      # backoff slots are observable inside the job.
+      - name: Restart agent against the stub broker
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --mqtt-subscribe-timeout-seconds 10 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert bounded subscribe failure and growing backoff
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASE_TIMED_OUT: ${{ steps.suback_baseline.outputs.timed_out }}
+          BASE_BACKOFFS: ${{ steps.suback_baseline.outputs.backoffs }}
+          BASE_SUBSCRIBED: ${{ steps.suback_baseline.outputs.subscribed }}
+        run: |
+          $baseTimedOut   = [int]$env:BASE_TIMED_OUT
+          $baseBackoffs   = [int]$env:BASE_BACKOFFS
+          $baseSubscribed = [int]$env:BASE_SUBSCRIBED
+          $needle = "Failed to subscribe: timed out waiting for broker acknowledgement"
+
+          # Two wedged cycles plus their backoff waits take roughly 10+2+10+4s.
+          $content = ""
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $timedOut = if ($content) { ([regex]::Matches($content, [regex]::Escape($needle))).Count } else { 0 }
+            $backoffs = if ($content) { ([regex]::Matches($content, [regex]::Escape("Reconnecting in"))).Count } else { 0 }
+            if (($timedOut - $baseTimedOut) -ge 2 -and ($backoffs - $baseBackoffs) -ge 2) { break }
+            Start-Sleep -Seconds 2
+          }
+
+          $timedOut = if ($content) { ([regex]::Matches($content, [regex]::Escape($needle))).Count } else { 0 }
+          if (($timedOut - $baseTimedOut) -lt 2) {
+            Write-Error "Expected at least two bounded subscribe timeouts, got $($timedOut - $baseTimedOut)"
+            exit 1
+          }
+          Write-Output "Bounded subscribe timeouts observed: $($timedOut - $baseTimedOut)"
+
+          # The agent must not have subscribed: a withheld SUBACK means no
+          # subscription, and a "Subscribed to messages" line here would mean the
+          # stub broker is not the broker the agent reached.
+          $subscribed = ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count
+          if ($subscribed -ne $baseSubscribed) {
+            Write-Error "Agent reported a subscription against a broker that withholds SUBACK"
+            exit 1
+          }
+
+          # The backoff must not be cleared by a timed-out subscribe: a throttling
+          # broker needs progressively longer waits, not a tight reconnect loop.
+          # Go renders a duration as concatenated unit components ("4.1s",
+          # "1m4s"), so each component is summed rather than parsed as one number.
+          function ConvertTo-Seconds([string]$value) {
+            $total = 0.0
+            foreach ($m in [regex]::Matches($value, '(?<n>[0-9.]+)(?<u>ms|us|ns|h|m|s)')) {
+              $n = [double]$m.Groups['n'].Value
+              switch ($m.Groups['u'].Value) {
+                'ns' { $total += $n / 1e9 }
+                'us' { $total += $n / 1e6 }
+                'ms' { $total += $n / 1e3 }
+                's'  { $total += $n }
+                'm'  { $total += $n * 60 }
+                'h'  { $total += $n * 3600 }
+              }
+            }
+            return $total
+          }
+
+          $waits = [regex]::Matches($content, 'Reconnecting in: timeout=(?<t>[0-9.a-z]+)') |
+            ForEach-Object { ConvertTo-Seconds $_.Groups['t'].Value }
+          $new = @($waits | Select-Object -Skip $baseBackoffs)
+          if ($new.Count -lt 2) {
+            Write-Error "Expected at least two reconnect waits after the subscribe timeouts, got $($new.Count)"
+            exit 1
+          }
+          Write-Output "Reconnect waits after the subscribe timeouts: $($new -join ', ')"
+          if ($new[1] -le $new[0]) {
+            Write-Error "Reconnect backoff did not grow ($($new[0]) then $($new[1])); a timed-out subscribe must not clear it"
+            exit 1
+          }
+          Write-Output "Confirmed the reconnect backoff grows after a withheld SUBACK"
+
+      # The original defect made this impossible: with the cycle parked in
+      # token.Wait() the stop signal was never reached, the platform waited out
+      # its stop deadline (30s on the Windows SCM) and force-killed the process.
+      - name: Assert the service stops promptly while wedged on the stub broker
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          SERVICE: ${{ matrix.service }}
+          BASE_STOPS: ${{ steps.suback_baseline.outputs.stops }}
+        run: |
+          $baseStops = [int]$env:BASE_STOPS
+          $sw = [System.Diagnostics.Stopwatch]::StartNew()
+
+          if ($IsWindows) {
+            sc.exe stop $env:SERVICE | Out-Null
+          } elseif ($IsLinux) {
+            sudo systemctl stop $env:SERVICE
+          } else {
+            sudo launchctl stop "system/$($env:SERVICE)"
+          }
+
+          # A clean exit runs the agent's deferred teardown, whose last act is the
+          # "Service stopped" line; a force-kill past the stop deadline never
+          # produces one.
+          $stopped = $false
+          while ($sw.Elapsed.TotalSeconds -lt 30) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $stops = if ($content) { ([regex]::Matches($content, [regex]::Escape("Service stopped"))).Count } else { 0 }
+            if ($stops -gt $baseStops) { $stopped = $true; break }
+            Start-Sleep -Milliseconds 500
+          }
+          $sw.Stop()
+
+          if (-not $stopped) {
+            Write-Error "Service did not log a clean stop within 30s while wedged on a withholding broker"
+            exit 1
+          }
+          Write-Output "Service stopped cleanly after $([math]::Round($sw.Elapsed.TotalSeconds, 1))s while wedged"
+
+      - name: Assert no orphaned scripts after the wedged stop
+        uses: ./.github/actions/assert-no-orphaned-scripts
+        with:
+          mode: assert
+          scripts_dir: ${{ steps.suback_scripts_dir.outputs.path }}
+
+      - name: Restart the service against the still-withholding broker
+        uses: ./.github/actions/start-service
+        with:
+          service: ${{ matrix.service }}
+
+      - name: Wait for the agent to wedge on the stub broker again
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: "Failed to subscribe: timed out waiting for broker acknowledgement"
+          max_attempts: "60"
+          interval_seconds: "2"
+
+      # Flipped on the live connection - the stub re-reads its mode per packet -
+      # so recovery is the agent's own next reconnect cycle, not a restart.
+      - name: Switch stub broker to acknowledge SUBACK
+        uses: ./.github/actions/stub-broker
+        with:
+          mode: ack
+
+      - name: Assert the agent recovers on a later cycle
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.suback_baseline.outputs.subscribed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent subscribed on a later cycle once SUBACK arrived (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent never subscribed after the stub broker started acknowledging"
+          exit 1
+
+      - name: Restore the real broker host
+        if: always() && steps.stub_host.outputs.previous_host != ''
+        uses: ./.github/actions/set-broker-host
+        with:
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          host: ${{ steps.stub_host.outputs.previous_host }}
+
+      - name: Stop stub broker
+        if: always()
+        uses: ./.github/actions/stub-broker
+        with:
+          mode: stop
+
+      - name: Restart agent against the real broker
+        if: always() && steps.stub_host.outputs.previous_host != ''
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --mqtt-subscribe-timeout-seconds 30 --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for resubscription to the real broker
+        if: always() && steps.stub_host.outputs.previous_host != ''
+        uses: ./.github/actions/wait-for-log-line
+        with:
+          log_file: ${{ matrix.log_file }}
+          pattern: Subscribed to messages
+          max_attempts: "60"
+          interval_seconds: "2"
+
       # ---- Per-command execution timeout scenario (sc-103835) ----
       # Configure a short per-command timeout, dispatch a script that sleeps well
       # beyond it, and confirm the agent kills the command (logging a timeout) and

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -520,12 +520,10 @@ jobs:
           $subscribed = Get-PatternCount $content "Subscribed to messages"
           $timedOut   = Get-PatternCount $content "Failed to subscribe: timed out waiting for broker acknowledgement"
           $backoffs   = Get-PatternCount $content "Reconnecting in"
-          $stops      = Get-PatternCount $content "Service stopped"
           "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
           "timed_out=$timedOut"    >> $env:GITHUB_OUTPUT
           "backoffs=$backoffs"     >> $env:GITHUB_OUTPUT
-          "stops=$stops"           >> $env:GITHUB_OUTPUT
-          Write-Output "Baseline -> subscribed=$subscribed timed_out=$timedOut backoffs=$backoffs stops=$stops"
+          Write-Output "Baseline -> subscribed=$subscribed timed_out=$timedOut backoffs=$backoffs"
 
       # Read off a logged path rather than re-deriving the platform path; see the
       # fuller note on the bounded-output scenario's copy of this step.
@@ -670,9 +668,21 @@ jobs:
         env:
           LOG_FILE: ${{ matrix.log_file }}
           SERVICE: ${{ matrix.service }}
-          BASE_STOPS: ${{ steps.suback_baseline.outputs.stops }}
         run: |
-          $baseStops = [int]$env:BASE_STOPS
+          function Get-StopCount {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            if ($content) { ([regex]::Matches($content, [regex]::Escape("Service stopped"))).Count } else { 0 }
+          }
+
+          # Counted here rather than reusing the scenario-wide baseline: the
+          # --update that pointed the agent at the stub broker restarts the
+          # service, and that restart logs its own "Service stopped". Measured
+          # against the older baseline the delta was already satisfied before this
+          # stop was even issued, so the assertion "passed" in 0.2s without
+          # observing the stop it exists to test.
+          $before = Get-StopCount
+          Write-Output "Service stopped lines before issuing the stop: $before"
+
           $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
           if ($IsWindows) {
@@ -683,14 +693,21 @@ jobs:
             sudo launchctl stop "system/$($env:SERVICE)"
           }
 
+          # launchctl exits non-zero in situations that are not failures here -
+          # the repo's own stop-service action already guards it with `|| true` -
+          # and the pwsh shell ends by exiting with $LASTEXITCODE, which failed
+          # this step on macOS even after the assertion below had passed. Report
+          # the code and clear it; whether the stop was honored is decided by the
+          # agent's log, not by the service manager's exit status.
+          Write-Output "Stop command exit code: $LASTEXITCODE"
+          $global:LASTEXITCODE = 0
+
           # A clean exit runs the agent's deferred teardown, whose last act is the
           # "Service stopped" line; a force-kill past the stop deadline never
           # produces one.
           $stopped = $false
           while ($sw.Elapsed.TotalSeconds -lt 30) {
-            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
-            $stops = if ($content) { ([regex]::Matches($content, [regex]::Escape("Service stopped"))).Count } else { 0 }
-            if ($stops -gt $baseStops) { $stopped = $true; break }
+            if ((Get-StopCount) -gt $before) { $stopped = $true; break }
             Start-Sleep -Milliseconds 500
           }
           $sw.Stop()
@@ -700,6 +717,7 @@ jobs:
             exit 1
           }
           Write-Output "Service stopped cleanly after $([math]::Round($sw.Elapsed.TotalSeconds, 1))s while wedged"
+          exit 0
 
       - name: Assert no orphaned scripts after the wedged stop
         uses: ./.github/actions/assert-no-orphaned-scripts

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,10 @@
 version: "2"
+run:
+  # The integration-test fixtures (test/stubbroker) are excluded from
+  # `go test ./...` by this tag so they cannot count uncovered statements
+  # against the coverage threshold; listing it here keeps them linted.
+  build-tags:
+    - integration
 linters:
   enable:
     - errcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Loaded plugins are supervised: a subprocess that exits or crashes is detected (b
 
 ### Message Processing Flow
 
-1. Agent connects to Azure IoT Hub via MQTT on topic `devices/{device_id}/messages/devicebound/#`
+1. Agent connects to Azure IoT Hub via MQTT on topic `devices/{device_id}/messages/devicebound/#`. Every MQTT operation waits with a deadline rather than an open-ended `token.Wait()`, and the connect/subscribe waits are additionally interruptible by the service stop signal, so a broker that keeps the connection open but stops acknowledging control packets (a throttling hub, a half-open middlebox) produces a logged failure and a backed-off reconnect instead of a device that is connected but never subscribed and cannot be stopped. See the README's "Bounded MQTT Operations" section.
 2. Receives JSON messages containing either `commands` (shell scripts) or `get_installation` (system info requests)
 3. Executes commands using platform-appropriate interpreter (PowerShell on Windows, Bash on Unix). Stdout and stderr are each captured through an independently bounded writer (`max_output_bytes`, default 10 MiB per stream) so a verbose script cannot OOM the agent; output past the ceiling is discarded and the result is flagged `truncated` with both byte counts. See the README's "Bounding per-command output size" section.
 4. Posts results back to Rewst engine at `https://{rewst_engine_host}/webhooks/custom/action/{post_id}`

--- a/README.md
+++ b/README.md
@@ -353,6 +353,62 @@ value. Example snippet:
 }
 ```
 
+### Bounded MQTT Operations
+
+Every MQTT operation in the connection cycle waits with a deadline, and the
+subscribe wait is additionally interruptible by a service stop. Without that, a
+broker which holds the connection open and answers keepalive pings but stops
+responding to control packets — exactly what Azure IoT Hub does when it throttles
+a device, and what a stateful firewall, VPN idle-timeout, captive portal, or
+SD-WAN appliance that half-opens a connection produces — left the agent parked
+mid-operation forever. It looked healthy (connected, keepalive fine, no errors
+logged) while silently never subscribing, so every command sent to it was queued
+at the broker and never ran, and a stop, upgrade, or uninstall hung until the
+platform's stop deadline expired and force-killed the process.
+
+With bounded waits, a broker in that state produces a clean, logged failure and a
+normal reconnect instead:
+
+- **Subscribe** — a SUBACK that does not arrive within the timeout is logged at
+  `Error` as **`Failed to subscribe: timed out waiting for broker
+  acknowledgement`** (with the timeout and elapsed wait), ends the cycle, and is
+  retried on the reconnect backoff schedule. The backoff is deliberately **not**
+  cleared, so a throttling broker gets progressively longer waits rather than
+  being hammered. A stop arriving during the wait is honored immediately rather
+  than after the timeout.
+- **Connect** — bounded as a backstop above paho's own connect timeout, and
+  likewise stop-interruptible.
+- **Unsubscribe (teardown)** — bounded by a short fixed timeout so total teardown
+  stays inside the Windows SCM stop window and systemd's `TimeoutStopSec`.
+  Exceeding it logs a `Warn` and proceeds to disconnect; against a black-holed
+  connection an unbounded wait would otherwise block until keepalive plus ping
+  timeout elapsed, which alone exceeds the Windows default.
+- **Device-twin reported properties** — bounded so the informational version
+  report cannot wedge the cycle before the agent has subscribed. Its failure
+  stays non-fatal (`Warn`).
+
+Because the service now always exits through its own teardown rather than being
+force-killed, deferred cleanup still runs: temp script files are removed, and the
+spooled-postback and plugin subprocesses are shut down rather than orphaned.
+
+| Config key | Default | Description |
+|------------|---------|-------------|
+| `mqtt_connect_timeout_seconds` | `30` | Bounds a single MQTT connect attempt. |
+| `mqtt_subscribe_timeout_seconds` | `30` | How long to wait for the broker's SUBACK before treating the connection attempt as failed. |
+
+Both fall back to their defaults when omitted or set to a non-positive value, and
+can also be set at install or update time with `--mqtt-connect-timeout-seconds`
+and `--mqtt-subscribe-timeout-seconds`. The teardown-side timeouts (unsubscribe,
+device-twin publish) are fixed constants rather than per-device knobs, because a
+tunable value there could push total teardown past a platform stop deadline the
+operator cannot see. Example snippet:
+
+```json
+{
+  "mqtt_subscribe_timeout_seconds": 45
+}
+```
+
 ### Notification Plugin Supervision
 
 Notification plugins run as separate subprocesses reached over RPC, and every

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -123,6 +123,9 @@ func runConfig(params *configContext) error {
 	response.Configuration.MqttConnectTimeoutSeconds = tuningPtr(
 		params.Tuning.MqttConnectTimeoutSeconds,
 	)
+	response.Configuration.MqttSubscribeTimeoutSeconds = tuningPtr(
+		params.Tuning.MqttSubscribeTimeoutSeconds,
+	)
 	response.Configuration.WorkerCount = tuningPtr(params.Tuning.WorkerCount)
 	response.Configuration.MessageQueueSize = tuningPtr(params.Tuning.MessageQueueSize)
 	response.Configuration.PostbackMaxAttempts = tuningPtr(params.Tuning.PostbackMaxAttempts)

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -25,6 +25,7 @@ const tuningFlagUnset = -1
 // the corresponding configuration field alone.
 type tuningFlags struct {
 	MqttConnectTimeoutSeconds       int
+	MqttSubscribeTimeoutSeconds     int
 	WorkerCount                     int
 	MessageQueueSize                int
 	PostbackMaxAttempts             int
@@ -43,6 +44,7 @@ type tuningFlags struct {
 // they appear in usage output.
 var tuningFlagNames = []string{
 	"mqtt-connect-timeout-seconds",
+	"mqtt-subscribe-timeout-seconds",
 	"worker-count",
 	"message-queue-size",
 	"postback-max-attempts",
@@ -76,6 +78,12 @@ func bindTuningFlags(fs *flag.FlagSet, t *tuningFlags) {
 		"mqtt-connect-timeout-seconds",
 		tuningFlagUnset,
 		"MQTT connect timeout in seconds (positive integer)",
+	)
+	fs.IntVar(
+		&t.MqttSubscribeTimeoutSeconds,
+		"mqtt-subscribe-timeout-seconds",
+		tuningFlagUnset,
+		"MQTT subscribe acknowledgement timeout in seconds (positive integer)",
 	)
 	fs.IntVar(
 		&t.WorkerCount,
@@ -130,6 +138,7 @@ func (t tuningFlags) validate() error {
 		value int
 	}{
 		{"mqtt-connect-timeout-seconds", t.MqttConnectTimeoutSeconds},
+		{"mqtt-subscribe-timeout-seconds", t.MqttSubscribeTimeoutSeconds},
 		{"worker-count", t.WorkerCount},
 		{"message-queue-size", t.MessageQueueSize},
 		{"postback-max-attempts", t.PostbackMaxAttempts},

--- a/cmd/agent_smith/config_context_test.go
+++ b/cmd/agent_smith/config_context_test.go
@@ -88,6 +88,7 @@ func TestNewConfigContext(t *testing.T) {
 
 	// Tuning flags default to the unset sentinel when omitted.
 	if result.Tuning.MqttConnectTimeoutSeconds != tuningFlagUnset ||
+		result.Tuning.MqttSubscribeTimeoutSeconds != tuningFlagUnset ||
 		result.Tuning.WorkerCount != tuningFlagUnset ||
 		result.Tuning.MessageQueueSize != tuningFlagUnset ||
 		result.Tuning.PostbackMaxAttempts != tuningFlagUnset ||
@@ -104,6 +105,7 @@ func TestNewConfigContext(t *testing.T) {
 			"--config-url", configUrl,
 			"--config-secret", configSecret,
 			"--mqtt-connect-timeout-seconds", "45",
+			"--mqtt-subscribe-timeout-seconds", "60",
 			"--worker-count", "20",
 			"--message-queue-size", "250",
 			"--postback-max-attempts", "5",
@@ -120,6 +122,12 @@ func TestNewConfigContext(t *testing.T) {
 		t.Errorf(
 			"expected MqttConnectTimeoutSeconds 45, got %v",
 			resultWithTuning.Tuning.MqttConnectTimeoutSeconds,
+		)
+	}
+	if resultWithTuning.Tuning.MqttSubscribeTimeoutSeconds != 60 {
+		t.Errorf(
+			"expected MqttSubscribeTimeoutSeconds 60, got %v",
+			resultWithTuning.Tuning.MqttSubscribeTimeoutSeconds,
 		)
 	}
 	if resultWithTuning.Tuning.WorkerCount != 20 {
@@ -223,6 +231,15 @@ func TestNewConfigContext(t *testing.T) {
 				"--postback-max-attempts", "abc",
 			},
 			"invalid value",
+		},
+		{
+			[]string{
+				"--org-id", orgId,
+				"--config-url", configUrl,
+				"--config-secret", configSecret,
+				"--mqtt-subscribe-timeout-seconds", "0",
+			},
+			"invalid mqtt-subscribe-timeout-seconds: must be a positive integer",
 		},
 		{
 			[]string{

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -505,6 +505,7 @@ func TestRunConfig_AppliesTuningFlags(t *testing.T) {
 	}
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       45,
+		MqttSubscribeTimeoutSeconds:     60,
 		WorkerCount:                     20,
 		MessageQueueSize:                250,
 		PostbackMaxAttempts:             5,
@@ -519,6 +520,12 @@ func TestRunConfig_AppliesTuningFlags(t *testing.T) {
 	device := findWrittenConfig(t, writtenFiles)
 	if device.MqttConnectTimeoutSeconds == nil || *device.MqttConnectTimeoutSeconds != 45 {
 		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", device.MqttConnectTimeoutSeconds)
+	}
+	if device.MqttSubscribeTimeoutSeconds == nil || *device.MqttSubscribeTimeoutSeconds != 60 {
+		t.Errorf(
+			"expected MqttSubscribeTimeoutSeconds 60, got %v",
+			device.MqttSubscribeTimeoutSeconds,
+		)
 	}
 	if device.WorkerCount == nil || *device.WorkerCount != 20 {
 		t.Errorf("expected WorkerCount 20, got %v", device.WorkerCount)
@@ -559,6 +566,7 @@ func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
 	// Mirror the sentinel defaults a real invocation would carry.
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       tuningFlagUnset,
+		MqttSubscribeTimeoutSeconds:     tuningFlagUnset,
 		WorkerCount:                     tuningFlagUnset,
 		MessageQueueSize:                tuningFlagUnset,
 		PostbackMaxAttempts:             tuningFlagUnset,
@@ -572,6 +580,7 @@ func TestRunConfig_OmittedTuningFlagsFallBackToDefault(t *testing.T) {
 
 	device := findWrittenConfig(t, writtenFiles)
 	if device.MqttConnectTimeoutSeconds != nil ||
+		device.MqttSubscribeTimeoutSeconds != nil ||
 		device.WorkerCount != nil ||
 		device.MessageQueueSize != nil ||
 		device.PostbackMaxAttempts != nil ||

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -414,22 +414,55 @@ func (svc *serviceContext) runCycle(
 	subscribed := false
 	defer func() {
 		if subscribed && client.IsConnected() {
-			if token := client.Unsubscribe(topic); token.Wait() && token.Error() != nil {
+			// Bounded rather than an open-ended Wait: against a black-holed
+			// connection (packets dropped with no RST) the UNSUBACK never arrives
+			// and an unbounded wait would hold teardown until keepalive plus ping
+			// timeout elapsed, blowing the platform's stop deadline. The
+			// unsubscribe is only an optimization against persistent sessions, so
+			// exceeding the bound warns and falls through to Disconnect.
+			token := client.Unsubscribe(topic)
+			switch {
+			case !token.WaitTimeout(utils.MqttUnsubscribeTimeout):
+				logger.Warn(
+					"Timed out waiting for unsubscribe; disconnecting anyway",
+					"topic", topic,
+					"timeout", utils.MqttUnsubscribeTimeout,
+				)
+			case token.Error() != nil:
 				logger.Warn("Failed to unsubscribe", "topic", topic, "error", token.Error())
 			}
 		}
 		client.Disconnect(disconnectQuiesce)
 	}()
 
+	// Bound the CONNACK wait as a backstop against a token that never resolves,
+	// and make it interruptible so a stop issued mid-handshake is honored at once
+	// instead of after the timeout. See utils.MqttConnectWaitMargin for why the
+	// bound sits above paho's own ConnectTimeout.
+	connectTimeout := device.MqttConnectTimeout() + utils.MqttConnectWaitMargin
+	connectStarted := time.Now()
 	token := client.Connect()
-	if token.Wait() && token.Error() != nil {
+	switch mqtt.WaitToken(token, connectTimeout, stopped) {
+	case mqtt.TokenTimedOut:
+		logger.Error(
+			"Failed to connect: timed out waiting for broker",
+			"timeout", connectTimeout,
+			"elapsed", time.Since(connectStarted),
+		)
+		return false, false, 0
+	case mqtt.TokenInterrupted:
+		logger.Info("Connect abandoned: service is stopping")
+		_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
+		return true, false, 0
+	}
+	if token.Error() != nil {
 		logger.Error("Failed to connect", "error", token.Error())
 		return false, false, 0
 	}
 
 	err = mqtt.UpdateReportedProperties(client, mqtt.ReportedProperties{
 		AgentVersion: version.Version,
-	})
+	}, utils.MqttPublishTimeout)
 	if err != nil {
 		logger.Warn("Failed to update device twin reported properties", "error", err)
 	} else {
@@ -446,7 +479,34 @@ func (svc *serviceContext) runCycle(
 		svc.enqueueMessage(msg.Payload(), msgQueue, draining, resolvedQueueSize, logger, notifier)
 	})
 
-	if token.Wait() && token.Error() != nil {
+	// paho puts no deadline on a subscribe token, so a broker that keeps the
+	// connection open and answers PINGREQ but never sends SUBACK — a throttling
+	// Azure IoT Hub, or a middlebox that half-opens the connection — used to park
+	// the cycle here forever: connected, never subscribed, executing nothing, and
+	// unable to reach the stop select below. The wait is now bounded and
+	// stop-interruptible. A timeout is handled exactly like a subscribe error:
+	// the cycle ends and the caller's reconnect backoff (deliberately not
+	// cleared) governs the retry, so a throttling broker is backed off from
+	// rather than hammered. subscribed stays false on both failure paths, so
+	// teardown skips the unsubscribe a broker in this state would not answer
+	// either.
+	subscribeTimeout := device.MqttSubscribeTimeout()
+	subscribeStarted := time.Now()
+	switch mqtt.WaitToken(token, subscribeTimeout, stopped) {
+	case mqtt.TokenTimedOut:
+		logger.Error(
+			"Failed to subscribe: timed out waiting for broker acknowledgement",
+			"topic", topic,
+			"timeout", subscribeTimeout,
+			"elapsed", time.Since(subscribeStarted),
+		)
+		return false, false, 0
+	case mqtt.TokenInterrupted:
+		logger.Info("Subscribe abandoned: service is stopping", "topic", topic)
+		_ = notifier.Notify("AgentStatus:Stopped") // Best effort notification
+		return true, false, 0
+	}
+	if token.Error() != nil {
 		logger.Error("Failed to subscribe", "error", token.Error())
 		return false, false, 0
 	}

--- a/cmd/agent_smith/service_mqtt_timeout_test.go
+++ b/cmd/agent_smith/service_mqtt_timeout_test.go
@@ -1,0 +1,490 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/agent"
+	inmqtt "github.com/RewstApp/agent-smith-go/internal/mqtt"
+	"github.com/RewstApp/agent-smith-go/internal/service"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// Regression tests for sc-106107: every paho token wait in the connection cycle
+// must be bounded, and the subscribe wait must additionally be interruptible by
+// the stop signal. Before the fix a broker that accepted CONNECT and withheld
+// SUBACK — what Azure IoT Hub does when it throttles a device, and what a
+// middlebox that half-opens a connection produces — parked the cycle in
+// token.Wait() forever: the agent logged a successful connect, never subscribed,
+// executed nothing, and could not be stopped because it never reached its select
+// on the stop signal.
+
+// hangingSubscribeClient returns a token that never resolves from Subscribe,
+// simulating a broker that accepts the SUBSCRIBE and never sends SUBACK while
+// keeping the connection otherwise healthy. Each Subscribe call gets its own
+// token so successive connection cycles hang independently.
+type hangingSubscribeClient struct {
+	mockMQTTClient
+
+	mu          sync.Mutex
+	tokens      []*blockingToken
+	subscribed  chan struct{}
+	disconnects chan struct{}
+}
+
+func (m *hangingSubscribeClient) Subscribe(
+	_ string,
+	_ byte,
+	_ pahomqtt.MessageHandler,
+) pahomqtt.Token {
+	token := &blockingToken{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+
+	m.mu.Lock()
+	m.tokens = append(m.tokens, token)
+	m.mu.Unlock()
+
+	select {
+	case m.subscribed <- struct{}{}:
+	default:
+	}
+
+	return token
+}
+
+func (m *hangingSubscribeClient) Disconnect(_ uint) {
+	select {
+	case m.disconnects <- struct{}{}:
+	default:
+	}
+}
+
+// releaseAll unblocks every token handed out so no goroutine parked on one
+// outlives the test.
+func (m *hangingSubscribeClient) releaseAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, token := range m.tokens {
+		close(token.release)
+	}
+	m.tokens = nil
+}
+
+// hangingUnsubscribeClient acknowledges the subscribe normally but returns a
+// token that never resolves from Unsubscribe, simulating a connection that has
+// been black-holed (packets dropped with no RST) by the time teardown runs.
+type hangingUnsubscribeClient struct {
+	mockMQTTClient
+	unsubscribeToken *blockingToken
+	disconnected     chan struct{}
+}
+
+func (m *hangingUnsubscribeClient) Unsubscribe(_ ...string) pahomqtt.Token {
+	return m.unsubscribeToken
+}
+
+func (m *hangingUnsubscribeClient) Disconnect(_ uint) {
+	select {
+	case m.disconnected <- struct{}{}:
+	default:
+	}
+}
+
+// writeDeviceConfig writes device to a config file in a fresh temp directory and
+// returns the config and log paths.
+func writeDeviceConfig(t *testing.T, device agent.Device) (string, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	configBytes, err := json.Marshal(device)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, configBytes, utils.DefaultFileMod); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	return configPath, logPath
+}
+
+// timeoutTestDevice is the minimal device config these tests drive Execute with.
+func timeoutTestDevice() agent.Device {
+	return agent.Device{
+		DeviceId:             "test-device",
+		SharedAccessKey:      "dGVzdC1zaGFyZWQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWJhc2U2NC1kZWNvZGluZw==",
+		AzureIotHubHost:      "test.azure-devices.net",
+		LoggingLevel:         "info",
+		DisableAutoUpdates:   true,
+		DisableAgentPostback: true,
+	}
+}
+
+// installMockClient points the MQTT client factory at newClient for the duration
+// of the test.
+func installMockClient(t *testing.T, newClient func() pahomqtt.Client) {
+	t.Helper()
+
+	orig := inmqtt.NewClient
+	inmqtt.NewClient = func(_ *pahomqtt.ClientOptions) pahomqtt.Client { return newClient() }
+	t.Cleanup(func() { inmqtt.NewClient = orig })
+}
+
+// waitForLog polls the log file until match reports satisfied or the deadline
+// elapses, returning the log content it last read.
+func waitForLog(
+	t *testing.T,
+	logPath string,
+	timeout time.Duration,
+	match func(string) bool,
+) string {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var content string
+	for {
+		if b, err := os.ReadFile(logPath); err == nil {
+			content = string(b)
+			if match(content) {
+				return content
+			}
+		}
+		if time.Now().After(deadline) {
+			return content
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+var reconnectTimeoutPattern = regexp.MustCompile(`Reconnecting in: timeout=([0-9a-z.µ]+)`)
+
+// reconnectTimeouts extracts the backoff interval from every "Reconnecting in"
+// line in the log, in order.
+func reconnectTimeouts(t *testing.T, log string) []time.Duration {
+	t.Helper()
+
+	var out []time.Duration
+	for _, m := range reconnectTimeoutPattern.FindAllStringSubmatch(log, -1) {
+		d, err := time.ParseDuration(m[1])
+		if err != nil {
+			t.Fatalf("failed to parse reconnect timeout %q: %v", m[1], err)
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// TestExecute_SubscribeTimeoutEndsCycleAndBacksOff verifies that a broker which
+// never acknowledges the SUBSCRIBE ends the connection cycle within the
+// configured timeout, logs the failure at Error with the elapsed timeout,
+// disconnects, and hands the retry to the reconnect backoff schedule. The
+// backoff must *not* be cleared: a throttling broker needs the agent to back
+// off, not reconnect in a tight loop, so successive reconnect waits must grow.
+func TestExecute_SubscribeTimeoutEndsCycleAndBacksOff(t *testing.T) {
+	subscribeTimeoutSeconds := 1
+	device := timeoutTestDevice()
+	device.MqttSubscribeTimeoutSeconds = &subscribeTimeoutSeconds
+	configPath, logPath := writeDeviceConfig(t, device)
+
+	client := &hangingSubscribeClient{
+		subscribed:  make(chan struct{}, 1),
+		disconnects: make(chan struct{}, 4),
+	}
+	t.Cleanup(client.releaseAll)
+	installMockClient(t, func() pahomqtt.Client { return client })
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	// Two failed cycles are needed to observe the backoff growing. Each costs the
+	// 1s subscribe timeout plus its reconnect wait (~2s then ~4s).
+	logged := waitForLog(t, logPath, 20*time.Second, func(s string) bool {
+		return len(reconnectTimeouts(t, s)) >= 2
+	})
+
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout after subscribe timeouts")
+	}
+
+	if !strings.Contains(
+		logged,
+		"Failed to subscribe: timed out waiting for broker acknowledgement",
+	) {
+		t.Fatalf("expected a bounded subscribe failure to be logged, log was:\n%s", logged)
+	}
+	if !strings.Contains(logged, "timeout=1s") {
+		t.Errorf("expected the subscribe timeout to be logged, log was:\n%s", logged)
+	}
+	if !strings.Contains(logged, "elapsed=") {
+		t.Errorf("expected the elapsed wait to be logged, log was:\n%s", logged)
+	}
+	if strings.Contains(logged, "Subscribed to messages") {
+		t.Errorf("expected no successful subscription, log was:\n%s", logged)
+	}
+
+	// The cycle must have torn down its client rather than leaking a connected
+	// but unsubscribed one.
+	select {
+	case <-client.disconnects:
+	default:
+		t.Error("expected the timed-out cycle to disconnect its client")
+	}
+
+	timeouts := reconnectTimeouts(t, logged)
+	if len(timeouts) < 2 {
+		t.Fatalf("expected at least two reconnect waits, got %v; log was:\n%s", timeouts, logged)
+	}
+	if timeouts[1] <= timeouts[0] {
+		t.Errorf(
+			"expected the reconnect backoff to grow after a subscribe timeout "+
+				"(it must not be cleared), got %v then %v",
+			timeouts[0],
+			timeouts[1],
+		)
+	}
+}
+
+// TestExecute_StopHonoredDuringHangingSubscribe verifies that a stop issued
+// while the agent is waiting for SUBACK returns from Execute promptly rather
+// than after the subscribe timeout. The device uses the default 30s subscribe
+// timeout, so a prompt return can only come from the wait being interruptible.
+func TestExecute_StopHonoredDuringHangingSubscribe(t *testing.T) {
+	device := timeoutTestDevice()
+	configPath, logPath := writeDeviceConfig(t, device)
+
+	client := &hangingSubscribeClient{
+		subscribed:  make(chan struct{}, 1),
+		disconnects: make(chan struct{}, 4),
+	}
+	t.Cleanup(client.releaseAll)
+	installMockClient(t, func() pahomqtt.Client { return client })
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	// Wait until the cycle is actually parked waiting for SUBACK.
+	select {
+	case <-client.subscribed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Subscribe was never called")
+	}
+
+	start := time.Now()
+	close(stop)
+
+	select {
+	case code := <-done:
+		elapsed := time.Since(start)
+		// Comfortably inside the Windows SCM 30s stop window and far short of the
+		// 30s default subscribe timeout, proving the wait was interrupted rather
+		// than timed out.
+		if elapsed > 2*time.Second {
+			t.Fatalf(
+				"stop during a hanging subscribe not honored promptly: returned after %v",
+				elapsed,
+			)
+		}
+		if code != 0 {
+			t.Errorf("expected exit code 0 on stop, got %d", code)
+		}
+	case <-time.After(utils.DefaultMqttSubscribeTimeout):
+		t.Fatal("Execute never returned after a stop during a hanging subscribe")
+	}
+
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log: %v", err)
+	}
+	if !strings.Contains(string(logged), "Subscribe abandoned: service is stopping") {
+		t.Errorf("expected the abandoned subscribe to be logged, log was:\n%s", logged)
+	}
+
+	select {
+	case <-client.disconnects:
+	default:
+		t.Error("expected the abandoned cycle to disconnect its client")
+	}
+}
+
+// TestExecute_HangingUnsubscribeStillDisconnects verifies that an UNSUBACK that
+// never arrives during teardown is bounded: it warns and proceeds to Disconnect
+// instead of holding the service past the platform's stop deadline.
+func TestExecute_HangingUnsubscribeStillDisconnects(t *testing.T) {
+	device := timeoutTestDevice()
+	configPath, logPath := writeDeviceConfig(t, device)
+
+	unsubscribeToken := &blockingToken{
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(unsubscribeToken.release) })
+
+	client := &hangingUnsubscribeClient{
+		unsubscribeToken: unsubscribeToken,
+		disconnected:     make(chan struct{}, 1),
+	}
+	installMockClient(t, func() pahomqtt.Client { return client })
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	// Let the cycle subscribe and settle on its stop select before stopping, so
+	// teardown genuinely reaches the unsubscribe.
+	waitForLog(t, logPath, 5*time.Second, func(s string) bool {
+		return strings.Contains(s, "Subscribed to messages")
+	})
+
+	start := time.Now()
+	close(stop)
+
+	select {
+	case code := <-done:
+		elapsed := time.Since(start)
+		// The unsubscribe alone is bounded at utils.MqttUnsubscribeTimeout; the
+		// rest of teardown is prompt. A generous ceiling still proves the wait is
+		// bounded rather than open-ended.
+		if elapsed > utils.MqttUnsubscribeTimeout+5*time.Second {
+			t.Fatalf("teardown with a hanging unsubscribe took %v", elapsed)
+		}
+		if code != 0 {
+			t.Errorf("expected exit code 0 on stop, got %d", code)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Execute never returned with a hanging unsubscribe")
+	}
+
+	select {
+	case <-client.disconnected:
+	default:
+		t.Fatal("expected Disconnect to run even though the unsubscribe never completed")
+	}
+
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log: %v", err)
+	}
+	if !strings.Contains(
+		string(logged),
+		"Timed out waiting for unsubscribe; disconnecting anyway",
+	) {
+		t.Errorf("expected the unsubscribe timeout to be warned about, log was:\n%s", logged)
+	}
+}
+
+// TestExecute_FastAckSubscribeUnchanged verifies the happy path is untouched: a
+// broker that acknowledges promptly still produces a normal subscription with no
+// timeout diagnostics, and the cycle proceeds to its stop select.
+func TestExecute_FastAckSubscribeUnchanged(t *testing.T) {
+	device := timeoutTestDevice()
+	configPath, logPath := writeDeviceConfig(t, device)
+
+	installMockClient(t, func() pahomqtt.Client { return &mockMQTTClient{} })
+
+	svc := &serviceContext{
+		ConfigFile: configPath,
+		LogFile:    logPath,
+		OrgId:      "test-org",
+		Executor:   &mockExecutor{},
+	}
+
+	stop := make(chan struct{})
+	running := make(chan struct{}, 1)
+	done := make(chan service.ServiceExitCode, 1)
+	go func() { done <- svc.Execute(stop, running) }()
+
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not signal running within timeout")
+	}
+
+	logged := waitForLog(t, logPath, 5*time.Second, func(s string) bool {
+		return strings.Contains(s, "Subscribed to messages")
+	})
+
+	start := time.Now()
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not exit within timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("expected a prompt stop on the happy path, took %v", elapsed)
+	}
+
+	if !strings.Contains(logged, "Subscribed to messages") {
+		t.Fatalf("expected a normal subscription, log was:\n%s", logged)
+	}
+	for _, unexpected := range []string{
+		"Failed to subscribe",
+		"Failed to connect",
+		"Timed out waiting for unsubscribe",
+		"Subscribe abandoned",
+		"Connect abandoned",
+		"Reconnecting in",
+	} {
+		if strings.Contains(logged, unexpected) {
+			t.Errorf("unexpected %q on the fast-ACK path, log was:\n%s", unexpected, logged)
+		}
+	}
+}

--- a/cmd/agent_smith/service_test.go
+++ b/cmd/agent_smith/service_test.go
@@ -660,23 +660,42 @@ func (m *teardownTrackingClient) Disconnect(_ uint) {
 	*m.calls = append(*m.calls, "disconnect")
 }
 
-// blockingToken is a mock MQTT token whose Wait blocks until release is closed.
-// started is a buffered channel that receives one item when Wait is first called.
+// blockingToken is a mock MQTT token whose waits block until release is closed.
+// started is a buffered channel that receives one item when a wait is first
+// entered. WaitTimeout honors its deadline (returning false when it elapses
+// first) so callers that bound their wait behave as they would against paho.
 type blockingToken struct {
 	started chan struct{}
 	release chan struct{}
 }
 
-func (t *blockingToken) Wait() bool {
+func (t *blockingToken) signalStarted() {
 	select {
 	case t.started <- struct{}{}:
 	default:
 	}
+}
+
+func (t *blockingToken) Wait() bool {
+	t.signalStarted()
 	<-t.release
 	return true
 }
-func (t *blockingToken) WaitTimeout(_ time.Duration) bool { return true }
+
+func (t *blockingToken) WaitTimeout(d time.Duration) bool {
+	t.signalStarted()
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-t.release:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
 func (t *blockingToken) Done() <-chan struct{} {
+	t.signalStarted()
 	ch := make(chan struct{})
 	go func() { <-t.release; close(ch) }()
 	return ch

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -97,6 +97,9 @@ func runUpdate(params *updateContext) {
 	if params.Tuning.MqttConnectTimeoutSeconds != tuningFlagUnset {
 		device.MqttConnectTimeoutSeconds = tuningPtr(params.Tuning.MqttConnectTimeoutSeconds)
 	}
+	if params.Tuning.MqttSubscribeTimeoutSeconds != tuningFlagUnset {
+		device.MqttSubscribeTimeoutSeconds = tuningPtr(params.Tuning.MqttSubscribeTimeoutSeconds)
+	}
 	if params.Tuning.WorkerCount != tuningFlagUnset {
 		device.WorkerCount = tuningPtr(params.Tuning.WorkerCount)
 	}

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -112,6 +112,7 @@ func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
 	params.FS = captureUpdateFS(deviceWithTuningJSON("test-org", 10, 1, 10, 1, 1, 1), &written)
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       45,
+		MqttSubscribeTimeoutSeconds:     60,
 		WorkerCount:                     20,
 		MessageQueueSize:                250,
 		PostbackMaxAttempts:             5,
@@ -123,6 +124,12 @@ func TestRunUpdate_AppliesProvidedTuningFlags(t *testing.T) {
 
 	if written.MqttConnectTimeoutSeconds == nil || *written.MqttConnectTimeoutSeconds != 45 {
 		t.Errorf("expected MqttConnectTimeoutSeconds 45, got %v", written.MqttConnectTimeoutSeconds)
+	}
+	if written.MqttSubscribeTimeoutSeconds == nil || *written.MqttSubscribeTimeoutSeconds != 60 {
+		t.Errorf(
+			"expected MqttSubscribeTimeoutSeconds 60, got %v",
+			written.MqttSubscribeTimeoutSeconds,
+		)
 	}
 	if written.WorkerCount == nil || *written.WorkerCount != 20 {
 		t.Errorf("expected WorkerCount 20, got %v", written.WorkerCount)
@@ -152,6 +159,7 @@ func TestRunUpdate_OmittedTuningFlagsPreserveExistingValues(t *testing.T) {
 	// Only overwrite one field; the others must be preserved as-is.
 	params.Tuning = tuningFlags{
 		MqttConnectTimeoutSeconds:       tuningFlagUnset,
+		MqttSubscribeTimeoutSeconds:     tuningFlagUnset,
 		WorkerCount:                     15,
 		MessageQueueSize:                tuningFlagUnset,
 		PostbackMaxAttempts:             tuningFlagUnset,

--- a/internal/agent/device.go
+++ b/internal/agent/device.go
@@ -25,6 +25,13 @@ type Device struct {
 	// utils.DefaultMqttConnectTimeout. Useful for endpoints with slow TLS
 	// handshakes that need more than the default.
 	MqttConnectTimeoutSeconds *int `json:"mqtt_connect_timeout_seconds,omitempty"`
+	// MqttSubscribeTimeoutSeconds optionally overrides how long the agent waits
+	// for the broker to acknowledge its SUBSCRIBE before treating the connection
+	// attempt as failed. When unset (or non-positive) the agent falls back to
+	// utils.DefaultMqttSubscribeTimeout. Raising it suits an endpoint whose
+	// broker legitimately acknowledges slowly; lowering it makes a throttling or
+	// half-open broker be abandoned (and retried on the reconnect backoff) sooner.
+	MqttSubscribeTimeoutSeconds *int `json:"mqtt_subscribe_timeout_seconds,omitempty"`
 	// WorkerCount optionally overrides how many concurrent command-execution
 	// workers drain the inbound message queue. When unset (or non-positive) the
 	// agent falls back to DefaultWorkerCount. Deployments that expect a high
@@ -180,6 +187,17 @@ func (d Device) MqttConnectTimeout() time.Duration {
 		return time.Duration(*d.MqttConnectTimeoutSeconds) * time.Second
 	}
 	return utils.DefaultMqttConnectTimeout
+}
+
+// MqttSubscribeTimeout returns how long to wait for the broker's SUBACK before
+// treating the connection attempt as failed, honoring the per-device override
+// when set to a positive value and falling back to the documented default. It is
+// always positive, so the bound can never be disabled by configuration.
+func (d Device) MqttSubscribeTimeout() time.Duration {
+	if d.MqttSubscribeTimeoutSeconds != nil && *d.MqttSubscribeTimeoutSeconds > 0 {
+		return time.Duration(*d.MqttSubscribeTimeoutSeconds) * time.Second
+	}
+	return utils.DefaultMqttSubscribeTimeout
 }
 
 // sasTokenLifetimeOverrideStr is overridable via -ldflags for integration

--- a/internal/agent/device_test.go
+++ b/internal/agent/device_test.go
@@ -203,3 +203,47 @@ func TestResolvedPostbackBaseRetryBackoff(t *testing.T) {
 		})
 	}
 }
+
+func TestMqttSubscribeTimeout(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect time.Duration
+	}{
+		{"unset falls back to default", nil, utils.DefaultMqttSubscribeTimeout},
+		{"zero falls back to default", intPtr(0), utils.DefaultMqttSubscribeTimeout},
+		{"negative falls back to default", intPtr(-5), utils.DefaultMqttSubscribeTimeout},
+		{"positive override honored", intPtr(45), 45 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{MqttSubscribeTimeoutSeconds: tt.value}
+			if got := d.MqttSubscribeTimeout(); got != tt.expect {
+				t.Errorf("MqttSubscribeTimeout() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestMqttConnectTimeout(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  *int
+		expect time.Duration
+	}{
+		{"unset falls back to default", nil, utils.DefaultMqttConnectTimeout},
+		{"zero falls back to default", intPtr(0), utils.DefaultMqttConnectTimeout},
+		{"negative falls back to default", intPtr(-5), utils.DefaultMqttConnectTimeout},
+		{"positive override honored", intPtr(45), 45 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Device{MqttConnectTimeoutSeconds: tt.value}
+			if got := d.MqttConnectTimeout(); got != tt.expect {
+				t.Errorf("MqttConnectTimeout() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}

--- a/internal/mqtt/common.go
+++ b/internal/mqtt/common.go
@@ -13,11 +13,68 @@ import (
 type (
 	Client  = mqtt.Client
 	Message = mqtt.Message
+	Token   = mqtt.Token
 )
 
 var NewClient = mqtt.NewClient
 
 const DefaultDisconnectQuiesce time.Duration = 250 * time.Millisecond
+
+// TokenWaitResult reports how a bounded wait on an MQTT token ended.
+type TokenWaitResult int
+
+const (
+	// TokenCompleted means the broker answered (or the operation otherwise
+	// resolved) before the deadline. The caller must still inspect Token.Error.
+	TokenCompleted TokenWaitResult = iota
+	// TokenTimedOut means the deadline elapsed with the token unresolved.
+	TokenTimedOut
+	// TokenInterrupted means the caller's interrupt channel fired first.
+	TokenInterrupted
+)
+
+// WaitToken waits for an MQTT token to resolve, bounded by timeout and
+// interruptible by the interrupt channel.
+//
+// paho's Token.Wait blocks until the broker responds or the TCP connection
+// breaks, with no deadline and no way to abort. A broker that keeps the socket
+// open and answers PINGREQ but stops responding to control packets — a
+// throttling Azure IoT Hub, or a middlebox that half-opens the connection —
+// therefore parks the caller indefinitely. Selecting on Token.Done alongside a
+// timer and the caller's interrupt channel gives both a hard ceiling and prompt
+// cancellation, so a wedged broker can never outlive the timeout and a service
+// stop is never queued behind one.
+//
+// interrupt may be nil, in which case the wait is bounded but not interruptible.
+//
+// An already-resolved token deterministically wins over an already-pending
+// interrupt: it is checked on its own first, before the blocking select. Leaving
+// both to the same select would let Go pick a ready case at random, so a
+// connection cycle racing a stop would abandon a completed operation only some
+// of the time. Preferring the resolved token costs nothing — there is nothing to
+// wait for, so the stop is not delayed, and the caller honors it at its next
+// wait or at its select on the stop signal.
+func WaitToken(token Token, timeout time.Duration, interrupt <-chan struct{}) TokenWaitResult {
+	done := token.Done()
+
+	select {
+	case <-done:
+		return TokenCompleted
+	default:
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		return TokenCompleted
+	case <-interrupt:
+		return TokenInterrupted
+	case <-timer.C:
+		return TokenTimedOut
+	}
+}
 
 func NewClientOptions(device agent.Device) (*mqtt.ClientOptions, error) {
 	var (
@@ -58,16 +115,35 @@ type ReportedProperties struct {
 	AgentVersion string `json:"agent_version"`
 }
 
-// UpdateReportedProperties publishes reported properties to the Azure IoT Hub device twin.
-func UpdateReportedProperties(client mqtt.Client, props ReportedProperties) error {
+// UpdateReportedProperties publishes reported properties to the Azure IoT Hub
+// device twin, waiting at most timeout for the publish to resolve.
+//
+// The wait is bounded because this publish sits between connect and subscribe on
+// the connection path: a broker that accepts the connection but stops answering
+// control packets would otherwise wedge the cycle here, before the agent has
+// subscribed to anything. A timeout is reported as an error like any other
+// publish failure; the caller already treats a failed twin update as non-fatal.
+// A non-positive timeout falls back to utils.MqttPublishTimeout so the wait can
+// never be unbounded.
+func UpdateReportedProperties(
+	client mqtt.Client,
+	props ReportedProperties,
+	timeout time.Duration,
+) error {
 	payload, err := json.Marshal(props)
 	if err != nil {
 		return fmt.Errorf("failed to marshal reported properties: %w", err)
 	}
 
+	if timeout <= 0 {
+		timeout = utils.MqttPublishTimeout
+	}
+
 	topic := "$iothub/twin/PATCH/properties/reported/?$rid=1"
 	token := client.Publish(topic, 0, false, payload)
-	token.Wait()
+	if !token.WaitTimeout(timeout) {
+		return fmt.Errorf("timed out after %v waiting to publish reported properties", timeout)
+	}
 	if token.Error() != nil {
 		return fmt.Errorf("failed to publish reported properties: %w", token.Error())
 	}

--- a/internal/mqtt/token_test.go
+++ b/internal/mqtt/token_test.go
@@ -1,0 +1,198 @@
+package mqtt
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// fakeToken is a minimal paho Token whose completion is driven by the test.
+// done is closed to resolve it; a token whose done is never closed models a
+// broker that accepts a control packet and never acknowledges it.
+type fakeToken struct {
+	done chan struct{}
+	err  error
+}
+
+func newFakeToken() *fakeToken { return &fakeToken{done: make(chan struct{})} }
+
+func (t *fakeToken) resolve(err error) {
+	t.err = err
+	close(t.done)
+}
+
+func (t *fakeToken) Wait() bool {
+	<-t.done
+	return true
+}
+
+func (t *fakeToken) WaitTimeout(d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-t.done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func (t *fakeToken) Done() <-chan struct{} { return t.done }
+func (t *fakeToken) Error() error          { return t.err }
+
+func TestWaitToken_CompletedBeforeTimeout(t *testing.T) {
+	token := newFakeToken()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		token.resolve(nil)
+	}()
+
+	if got := WaitToken(token, 5*time.Second, nil); got != TokenCompleted {
+		t.Errorf("expected TokenCompleted, got %v", got)
+	}
+}
+
+func TestWaitToken_TimesOutOnUnresolvedToken(t *testing.T) {
+	token := newFakeToken()
+	defer token.resolve(nil)
+
+	start := time.Now()
+	if got := WaitToken(token, 50*time.Millisecond, nil); got != TokenTimedOut {
+		t.Fatalf("expected TokenTimedOut, got %v", got)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("wait was not bounded by the timeout: took %v", elapsed)
+	}
+}
+
+func TestWaitToken_InterruptedByStop(t *testing.T) {
+	token := newFakeToken()
+	defer token.resolve(nil)
+
+	interrupt := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(interrupt)
+	}()
+
+	start := time.Now()
+	// A long timeout, so returning promptly can only come from the interrupt.
+	if got := WaitToken(token, time.Hour, interrupt); got != TokenInterrupted {
+		t.Fatalf("expected TokenInterrupted, got %v", got)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("interrupt was not honored promptly: took %v", elapsed)
+	}
+}
+
+// TestWaitToken_ResolvedTokenWinsOverPendingInterrupt pins the deterministic
+// tie-break: when the token has already resolved and the interrupt is already
+// pending, the result is the token's. Leaving both to one select would make a
+// connection cycle racing a stop abandon completed work at random.
+func TestWaitToken_ResolvedTokenWinsOverPendingInterrupt(t *testing.T) {
+	token := newFakeToken()
+	token.resolve(nil)
+
+	interrupt := make(chan struct{})
+	close(interrupt)
+
+	for range 50 {
+		if got := WaitToken(token, time.Hour, interrupt); got != TokenCompleted {
+			t.Fatalf("expected a resolved token to win over a pending interrupt, got %v", got)
+		}
+	}
+}
+
+// TestWaitToken_ReportsCompletedOnTokenError confirms an operation that failed
+// (rather than hung) is still reported as completed, leaving the error for the
+// caller to inspect — the same split paho's Wait/Error pair has.
+func TestWaitToken_ReportsCompletedOnTokenError(t *testing.T) {
+	token := newFakeToken()
+	token.resolve(errors.New("subscribe rejected"))
+
+	if got := WaitToken(token, time.Second, nil); got != TokenCompleted {
+		t.Fatalf("expected TokenCompleted for a resolved-with-error token, got %v", got)
+	}
+	if token.Error() == nil {
+		t.Error("expected the token error to survive the wait")
+	}
+}
+
+// publishStubClient is a paho Client that only implements Publish, returning the
+// token the test supplies. Every other method panics so an unexpected call is
+// loud rather than silently passing.
+type publishStubClient struct {
+	pahomqtt.Client
+	token pahomqtt.Token
+}
+
+func (c *publishStubClient) Publish(_ string, _ byte, _ bool, _ interface{}) pahomqtt.Token {
+	return c.token
+}
+
+func TestUpdateReportedProperties_BoundedByTimeout(t *testing.T) {
+	token := newFakeToken()
+	defer token.resolve(nil)
+
+	start := time.Now()
+	err := UpdateReportedProperties(
+		&publishStubClient{token: token},
+		ReportedProperties{AgentVersion: "1.2.3"},
+		50*time.Millisecond,
+	)
+	if err == nil {
+		t.Fatal("expected an error when the publish never resolves")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("publish wait was not bounded: took %v", elapsed)
+	}
+}
+
+func TestUpdateReportedProperties_SucceedsOnFastAck(t *testing.T) {
+	token := newFakeToken()
+	token.resolve(nil)
+
+	err := UpdateReportedProperties(
+		&publishStubClient{token: token},
+		ReportedProperties{AgentVersion: "1.2.3"},
+		time.Second,
+	)
+	if err != nil {
+		t.Fatalf("expected no error on a fast-acknowledged publish, got %v", err)
+	}
+}
+
+func TestUpdateReportedProperties_SurfacesPublishError(t *testing.T) {
+	token := newFakeToken()
+	token.resolve(errors.New("not authorized"))
+
+	err := UpdateReportedProperties(
+		&publishStubClient{token: token},
+		ReportedProperties{AgentVersion: "1.2.3"},
+		time.Second,
+	)
+	if err == nil {
+		t.Fatal("expected the publish error to be surfaced")
+	}
+}
+
+// TestUpdateReportedProperties_NonPositiveTimeoutFallsBack confirms the wait can
+// never be made unbounded by passing a zero or negative timeout.
+func TestUpdateReportedProperties_NonPositiveTimeoutFallsBack(t *testing.T) {
+	token := newFakeToken()
+	token.resolve(nil)
+
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		if err := UpdateReportedProperties(
+			&publishStubClient{token: token},
+			ReportedProperties{AgentVersion: "1.2.3"},
+			timeout,
+		); err != nil {
+			t.Errorf("expected timeout %v to fall back to %v, got %v",
+				timeout, utils.MqttPublishTimeout, err)
+		}
+	}
+}

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -35,6 +35,77 @@ const InitialReconnectInterval time.Duration = time.Second
 // via the device config (mqtt_connect_timeout_seconds).
 const DefaultMqttConnectTimeout time.Duration = 30 * time.Second
 
+// MqttConnectWaitMargin is added to the configured connect timeout to size the
+// agent's own bounded wait on the CONNACK token.
+//
+// paho already bounds a connect attempt internally with the ConnectTimeout we
+// set from DefaultMqttConnectTimeout, so under normal operation the connect
+// token always completes on its own. The agent's wait is a backstop against a
+// token that never resolves at all, so it is deliberately set slightly longer
+// than paho's own deadline: sizing it equal to (or shorter than) ConnectTimeout
+// would make the agent give up on a handshake paho was about to complete, which
+// is exactly the premature-abort mistake DefaultMqttConnectTimeout documents.
+const MqttConnectWaitMargin time.Duration = 5 * time.Second
+
+// DefaultMqttSubscribeTimeout bounds how long the agent waits for the broker's
+// SUBACK after sending SUBSCRIBE.
+//
+// paho applies no deadline of its own to a subscribe token — it resolves only
+// when the broker answers or the TCP connection breaks. A broker that holds the
+// connection open, answers PINGREQ, and simply never sends SUBACK (exactly what
+// Azure IoT Hub does when it throttles a device, and what a middlebox that
+// half-opens a connection produces) therefore parked the connection cycle
+// forever: the agent logged a successful connect, never logged "Subscribed to
+// messages", silently processed no commands, and could not even be stopped
+// because the cycle never reached its select on the stop signal.
+//
+// The value mirrors DefaultMqttConnectTimeout for the same reason: SUBSCRIBE is
+// a single round trip over an already-established connection, so 30s is far
+// beyond any healthy broker's response time on a slow, high-latency, or lossy
+// link, while still ending a wedged attempt in bounded time. A timeout is
+// treated exactly like a subscribe error — the cycle ends and the reconnect
+// backoff schedule governs the retry, so a throttling broker is backed off from
+// rather than hammered. The wait is additionally interruptible by the stop
+// signal, so this timeout never delays a service stop. Endpoints that need a
+// different bound can override it per-device via
+// mqtt_subscribe_timeout_seconds.
+const DefaultMqttSubscribeTimeout time.Duration = 30 * time.Second
+
+// MqttUnsubscribeTimeout bounds the UNSUBACK wait during cycle teardown.
+//
+// Unlike the subscribe wait, this one runs while the service is already on its
+// way out, so it is sized against the platform's stop deadline rather than
+// against broker latency: Windows' SCM defaults to a 30s stop window and
+// systemd's TimeoutStopSec to 90s. Teardown must also cancel in-flight commands,
+// drain the worker pool, disconnect, and shut down the plugin subprocesses, so
+// the unsubscribe gets only a small slice of that budget. Against a black-holed
+// connection (packets dropped with no RST) an unbounded wait would instead block
+// until keepalive plus ping timeout elapsed — roughly DefaultMqttKeepAlive +
+// DefaultMqttPingTimeout, already past the Windows window on its own.
+//
+// Exceeding it is not an error worth failing teardown over: the unsubscribe is
+// only an optimization that keeps a persistent Azure IoT Hub session from
+// retaining a server-side subscription, and disconnecting drops the session's
+// delivery path anyway. It is therefore logged at Warn and teardown proceeds
+// straight to Disconnect. It is intentionally not configurable — a per-device
+// override could push total teardown past a platform stop deadline the operator
+// cannot see.
+const MqttUnsubscribeTimeout time.Duration = 5 * time.Second
+
+// MqttPublishTimeout bounds the wait for a published message's token, used for
+// the device-twin reported-properties publish.
+//
+// That publish is informational (it reports the running agent version) and its
+// failure is already non-fatal, but it sits on the connection path between
+// connect and subscribe: an unbounded wait there wedges the cycle just as
+// thoroughly as a withheld SUBACK, and does so before the agent has subscribed
+// to anything. 10s is generous for a QoS-0 publish on a freshly established
+// connection while keeping the pre-subscribe window short. Like the unsubscribe
+// timeout it is a fixed constant rather than a per-device knob, because the
+// operation it bounds is not one a slow endpoint has a legitimate reason to
+// extend.
+const MqttPublishTimeout time.Duration = 10 * time.Second
+
 // DefaultMqttKeepAlive is the interval at which the client sends MQTT PING
 // requests to the broker while otherwise idle. It is configured explicitly
 // rather than relying on paho's implicit default so the liveness behavior of a

--- a/test/stubbroker/main.go
+++ b/test/stubbroker/main.go
@@ -89,7 +89,28 @@ func main() {
 		fmt.Sprintf("path to a file containing %q to acknowledge subscriptions; "+
 			"any other content withholds SUBACK", modeAck),
 	)
+	logPath := flag.String(
+		"log",
+		"",
+		"path to write this broker's log to (defaults to stderr)",
+	)
 	flag.Parse()
+
+	// Redirected here rather than by the launching shell because on Windows the
+	// broker has to be started detached from the step that launches it (a child
+	// tied to that step's console is reaped when the step ends), and a detached
+	// launch has nowhere to attach a redirect. Set up before anything else so a
+	// startup failure - a port already in use, say - lands in the file the
+	// harness reports rather than on a stderr nobody is reading.
+	if *logPath != "" {
+		logFile, err := os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open log file %s: %v\n", *logPath, err)
+			os.Exit(1)
+		}
+		defer func() { _ = logFile.Close() }()
+		log.SetOutput(logFile)
+	}
 
 	if *host == "" || *caOut == "" {
 		log.Fatal("both -host and -ca-out are required")

--- a/test/stubbroker/main.go
+++ b/test/stubbroker/main.go
@@ -1,0 +1,387 @@
+//go:build integration
+
+// Command stubbroker is a deliberately minimal MQTT 3.1.1 broker used by the
+// integration test suite to reproduce the failure mode sc-106107 fixed: a broker
+// that completes the TLS handshake, answers CONNECT with a normal CONNACK, and
+// keeps answering PINGREQ so keepalive stays healthy — while never sending
+// SUBACK for the client's SUBSCRIBE.
+//
+// That combination is what Azure IoT Hub produces when it throttles a device,
+// and what a middlebox that half-opens a connection (stateful firewall or VPN
+// idle-timeout, captive portal, some SD-WAN appliances) produces incidentally.
+// It cannot be simulated by cutting the network — a severed connection is
+// detected by keepalive and surfaces as a normal reconnect. It has to be a
+// broker that stays alive and simply withholds the acknowledgement.
+//
+// The broker implements only the packet types the agent exercises and keeps no
+// session state; it is a test fixture, not a usable MQTT server.
+//
+// It mints its own certificate chain on startup and writes the CA certificate to
+// -ca-out so the caller can install it into the host trust store, since the agent
+// verifies the broker's TLS certificate against the system roots like any other
+// Azure IoT Hub connection.
+//
+// Whether a SUBSCRIBE is acknowledged is read from -mode-file on every packet,
+// so the harness can flip the broker between withholding and acknowledging
+// without restarting it or disturbing the live connection.
+//
+// It sits behind the `integration` build tag so it stays out of
+// `go test ./...`: as an untested CI fixture its statements would otherwise
+// count against the repository coverage threshold. It is still linted, because
+// the tag is listed in .golangci.yml. Build it with
+// `go build -tags integration ./test/stubbroker`.
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// MQTT 3.1.1 control packet types, in the high nibble of the fixed header.
+const (
+	pktConnect     byte = 1
+	pktConnack     byte = 2
+	pktPublish     byte = 3
+	pktPuback      byte = 4
+	pktSubscribe   byte = 8
+	pktSuback      byte = 9
+	pktUnsubscribe byte = 10
+	pktUnsuback    byte = 11
+	pktPingreq     byte = 12
+	pktPingresp    byte = 13
+	pktDisconnect  byte = 14
+)
+
+// modeAck is the -mode-file content that makes the broker acknowledge
+// subscriptions normally. Any other content (including a missing file) withholds
+// the acknowledgement, so the default — and the failure mode on a misconfigured
+// harness — is the one the scenario is built around.
+const modeAck = "ack"
+
+// certValidity is deliberately short. macOS rejects TLS server certificates with
+// an excessive lifetime even when the issuing root is locally trusted, so a
+// long-lived fixture certificate would fail verification on one of the three
+// platforms only.
+const certValidity = 30 * 24 * time.Hour
+
+func main() {
+	listen := flag.String("listen", ":8883", "address to listen on")
+	host := flag.String("host", "", "DNS name to issue the server certificate for (required)")
+	caOut := flag.String("ca-out", "", "path to write the CA certificate PEM to (required)")
+	modeFile := flag.String(
+		"mode-file",
+		"",
+		fmt.Sprintf("path to a file containing %q to acknowledge subscriptions; "+
+			"any other content withholds SUBACK", modeAck),
+	)
+	flag.Parse()
+
+	if *host == "" || *caOut == "" {
+		log.Fatal("both -host and -ca-out are required")
+	}
+
+	tlsConfig, caPEM, err := newTLSConfig(*host)
+	if err != nil {
+		log.Fatalf("failed to mint certificate chain: %v", err)
+	}
+	if err := os.WriteFile(*caOut, caPEM, 0o644); err != nil {
+		log.Fatalf("failed to write CA certificate: %v", err)
+	}
+
+	listener, err := tls.Listen("tcp", *listen, tlsConfig)
+	if err != nil {
+		log.Fatalf("failed to listen on %s: %v", *listen, err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	log.Printf("stub broker listening on %s for %s (mode file %q)", *listen, *host, *modeFile)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Printf("accept failed: %v", err)
+			continue
+		}
+		go serve(conn, *modeFile)
+	}
+}
+
+// newTLSConfig mints a throwaway CA and a leaf certificate for host, returning a
+// server TLS config using the leaf and the CA certificate in PEM form. A real
+// two-level chain is used rather than a single self-signed certificate because
+// the platform verifiers differ in how willingly they accept a certificate that
+// is simultaneously its own root and the TLS leaf.
+func newTLSConfig(host string) (*tls.Config, []byte, error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Rewst Integration Test Stub Broker CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(certValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(
+		rand.Reader,
+		caTemplate,
+		caTemplate,
+		&caKey.PublicKey,
+		caKey,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(certValidity),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		// The verifiers on all three platforms match the name against the SAN,
+		// not the common name.
+		DNSNames:              []string{host},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		BasicConstraintsValid: true,
+	}
+	leafDER, err := x509.CreateCertificate(
+		rand.Reader,
+		leafTemplate,
+		caCert,
+		&leafKey.PublicKey,
+		caKey,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{leafDER, caDER},
+		PrivateKey:  leafKey,
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, caPEM, nil
+}
+
+// acknowledgesSubscriptions reports whether the broker should currently answer a
+// SUBSCRIBE. It is re-read per packet so the harness can flip the behavior on a
+// live connection.
+func acknowledgesSubscriptions(modeFile string) bool {
+	if modeFile == "" {
+		return false
+	}
+	content, err := os.ReadFile(modeFile)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(content)) == modeAck
+}
+
+func serve(conn net.Conn, modeFile string) {
+	defer func() { _ = conn.Close() }()
+
+	remote := conn.RemoteAddr().String()
+	log.Printf("[%s] connection accepted", remote)
+
+	for {
+		packetType, flags, payload, err := readPacket(conn)
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("[%s] read failed: %v", remote, err)
+			}
+			log.Printf("[%s] connection closed", remote)
+			return
+		}
+
+		switch packetType {
+		case pktConnect:
+			log.Printf("[%s] CONNECT -> CONNACK", remote)
+			// Variable header: session-present flag 0, return code 0 (accepted).
+			if err := writePacket(conn, pktConnack, 0, []byte{0x00, 0x00}); err != nil {
+				log.Printf("[%s] failed to send CONNACK: %v", remote, err)
+				return
+			}
+
+		case pktPingreq:
+			// Answered unconditionally, including while withholding SUBACK: a
+			// healthy keepalive is what makes the reproduction faithful. Without
+			// it the client would tear the connection down on ping timeout and
+			// exercise the ordinary connection-lost path instead.
+			log.Printf("[%s] PINGREQ -> PINGRESP", remote)
+			if err := writePacket(conn, pktPingresp, 0, nil); err != nil {
+				log.Printf("[%s] failed to send PINGRESP: %v", remote, err)
+				return
+			}
+
+		case pktSubscribe:
+			if len(payload) < 2 {
+				log.Printf("[%s] malformed SUBSCRIBE", remote)
+				return
+			}
+			packetID := payload[:2]
+			if !acknowledgesSubscriptions(modeFile) {
+				log.Printf("[%s] SUBSCRIBE -> withholding SUBACK", remote)
+				break
+			}
+			log.Printf("[%s] SUBSCRIBE -> SUBACK", remote)
+			// One granted-QoS byte per requested topic filter; the agent
+			// subscribes to exactly one, and QoS 1 is granted regardless of what
+			// it asked for (a broker may grant lower, never higher).
+			if err := writePacket(
+				conn,
+				pktSuback,
+				0,
+				[]byte{packetID[0], packetID[1], 0x01},
+			); err != nil {
+				log.Printf("[%s] failed to send SUBACK: %v", remote, err)
+				return
+			}
+
+		case pktUnsubscribe:
+			if len(payload) < 2 {
+				log.Printf("[%s] malformed UNSUBSCRIBE", remote)
+				return
+			}
+			packetID := payload[:2]
+			if !acknowledgesSubscriptions(modeFile) {
+				log.Printf("[%s] UNSUBSCRIBE -> withholding UNSUBACK", remote)
+				break
+			}
+			log.Printf("[%s] UNSUBSCRIBE -> UNSUBACK", remote)
+			if err := writePacket(conn, pktUnsuback, 0, packetID); err != nil {
+				log.Printf("[%s] failed to send UNSUBACK: %v", remote, err)
+				return
+			}
+
+		case pktPublish:
+			// The agent's device-twin reported-properties publish is QoS 0 and
+			// needs no response. A QoS 1 publish is acknowledged so the fixture
+			// stays correct if that ever changes; its packet id follows the topic.
+			qos := (flags >> 1) & 0x03
+			if qos != 1 {
+				log.Printf("[%s] PUBLISH (qos %d) -> no response required", remote, qos)
+				break
+			}
+			if len(payload) < 2 {
+				log.Printf("[%s] malformed PUBLISH", remote)
+				return
+			}
+			topicLen := int(payload[0])<<8 | int(payload[1])
+			if len(payload) < 2+topicLen+2 {
+				log.Printf("[%s] malformed PUBLISH", remote)
+				return
+			}
+			packetID := payload[2+topicLen : 2+topicLen+2]
+			log.Printf("[%s] PUBLISH (qos 1) -> PUBACK", remote)
+			if err := writePacket(conn, pktPuback, 0, packetID); err != nil {
+				log.Printf("[%s] failed to send PUBACK: %v", remote, err)
+				return
+			}
+
+		case pktDisconnect:
+			log.Printf("[%s] DISCONNECT", remote)
+			return
+
+		default:
+			log.Printf("[%s] ignoring packet type %d", remote, packetType)
+		}
+	}
+}
+
+// readPacket reads one MQTT control packet, returning its type, its fixed-header
+// flags, and the remaining bytes (variable header plus payload).
+func readPacket(conn net.Conn) (byte, byte, []byte, error) {
+	var header [1]byte
+	if _, err := io.ReadFull(conn, header[:]); err != nil {
+		return 0, 0, nil, err
+	}
+
+	remaining, err := readRemainingLength(conn)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	payload := make([]byte, remaining)
+	if remaining > 0 {
+		if _, err := io.ReadFull(conn, payload); err != nil {
+			return 0, 0, nil, err
+		}
+	}
+
+	return header[0] >> 4, header[0] & 0x0F, payload, nil
+}
+
+// readRemainingLength decodes MQTT's variable-length integer encoding: seven
+// bits per byte, with the top bit signalling that another byte follows, up to
+// four bytes.
+func readRemainingLength(conn net.Conn) (int, error) {
+	var (
+		value      int
+		multiplier = 1
+	)
+	for i := 0; i < 4; i++ {
+		var b [1]byte
+		if _, err := io.ReadFull(conn, b[:]); err != nil {
+			return 0, err
+		}
+		value += int(b[0]&0x7F) * multiplier
+		if b[0]&0x80 == 0 {
+			return value, nil
+		}
+		multiplier *= 128
+	}
+	return 0, fmt.Errorf("malformed remaining length")
+}
+
+func writePacket(conn net.Conn, packetType, flags byte, payload []byte) error {
+	packet := []byte{packetType<<4 | flags}
+	packet = append(packet, encodeRemainingLength(len(payload))...)
+	packet = append(packet, payload...)
+	_, err := conn.Write(packet)
+	return err
+}
+
+func encodeRemainingLength(length int) []byte {
+	var encoded []byte
+	for {
+		b := byte(length % 128)
+		length /= 128
+		if length > 0 {
+			b |= 0x80
+		}
+		encoded = append(encoded, b)
+		if length == 0 {
+			return encoded
+		}
+	}
+}

--- a/test/stubbroker/main.go
+++ b/test/stubbroker/main.go
@@ -19,7 +19,9 @@
 // It mints its own certificate chain on startup and writes the CA certificate to
 // -ca-out so the caller can install it into the host trust store, since the agent
 // verifies the broker's TLS certificate against the system roots like any other
-// Azure IoT Hub connection.
+// Azure IoT Hub connection. The certificate always carries the loopback
+// addresses as SANs, so the agent can be pointed straight at 127.0.0.1 and no
+// hosts-file entry (nor any name resolution) is involved.
 //
 // Whether a SUBSCRIBE is acknowledged is read from -mode-file on every packet,
 // so the harness can flip the broker between withholding and acknowledging
@@ -164,11 +166,20 @@ func newTLSConfig(host string) (*tls.Config, []byte, error) {
 		NotAfter:     time.Now().Add(certValidity),
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		// The verifiers on all three platforms match the name against the SAN,
-		// not the common name.
-		DNSNames:              []string{host},
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		// The loopback addresses are always present so the agent can be pointed
+		// straight at 127.0.0.1, with no hosts-file entry and therefore no name
+		// resolution involved at all. The verifiers on all three platforms match
+		// against the SAN, not the common name, so an IP host has to land in
+		// IPAddresses; putting an IP literal in DNSNames would simply never match.
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		BasicConstraintsValid: true,
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if !ip.IsLoopback() {
+			leafTemplate.IPAddresses = append(leafTemplate.IPAddresses, ip)
+		}
+	} else {
+		leafTemplate.DNSNames = []string{host}
 	}
 	leafDER, err := x509.CreateCertificate(
 		rand.Reader,


### PR DESCRIPTION
## Problem

Every paho token wait in the connection cycle blocked with no deadline and no way to be interrupted by a service stop — `client.Subscribe(...).Wait()`, `client.Unsubscribe(...).Wait()`, and the device-twin publish `token.Wait()`. There was no `WaitTimeout` call anywhere in the codebase.

A broker that holds the connection open and answers PINGREQ but stops responding to control packets — exactly what Azure IoT Hub does when it throttles a device, and what a middlebox that half-opens a connection produces (stateful firewall or VPN idle-timeout, captive portal, some SD-WAN appliances) — parked the cycle forever. The device *looked* healthy: the agent logged a successful connect, keepalive stayed up, and no error was ever logged. But it never subscribed, so every command sent to it queued at the broker and never ran. From the customer's side the endpoint is "online but ignoring us", which is far harder to diagnose than one that is plainly offline.

Worse, the agent could not be stopped. `close(stopped)` ran in the monitor goroutine, but `Execute` was parked in `Subscribe(...).Wait()` and never reached its `select`. A stop, an upgrade, or an uninstall hung until the platform's stop deadline expired and force-killed the process — skipping deferred cleanup, orphaning the temp script files sc-103967 added a sweep for, and leaving the spooled-postback and plugin subprocesses to be reaped by the OS.

Latent in all released versions through v1.5.0 and current `main`, on all platforms. No customer reports isolated to this cause; found via a reliability audit.

## Fix

A new `mqtt.WaitToken(token, timeout, interrupt)` selects on the token's `Done` channel alongside a timer and the caller's interrupt channel, returning `TokenCompleted` / `TokenTimedOut` / `TokenInterrupted`.

One detail carries weight: **an already-resolved token deterministically beats an already-pending interrupt**. It is checked on its own, before the blocking select. Leaving both to one select would let Go pick a ready case at random, so a cycle racing a stop would abandon completed work only some of the time. Preferring the resolved token costs nothing — there is nothing to wait for, so the stop is not delayed, and the caller honors it at its next wait or at its `select` on the stop signal.

Connect and subscribe use it with the stop channel; unsubscribe and the device-twin publish use `WaitTimeout`.

- **Subscribe** — a timeout is handled exactly like the existing subscribe-error path: logged at `Error` with the timeout and elapsed wait, the cycle ends, and the reconnect backoff governs the retry. The backoff is **deliberately not cleared**, so a throttling broker gets progressively longer waits rather than being hammered. `subscribed` stays false on both failure paths, so teardown skips an unsubscribe a broker in this state would not answer either.
- **Connect** — bounded as a backstop *above* paho's own `ConnectTimeout`, and likewise stop-interruptible. Sizing it equal to or below `ConnectTimeout` would abort a handshake paho was about to complete, which is the premature-abort mistake `DefaultMqttConnectTimeout` already documents.
- **Unsubscribe** — bounded by a short fixed timeout; exceeding it logs a `Warn` and proceeds to `Disconnect`. Against a black-holed connection an unbounded wait would block until keepalive + ping timeout elapsed (~40s), already past the Windows SCM's default 30s window on its own.
- **Device-twin publish** — bounded so the informational version report cannot wedge the cycle *before* the agent has subscribed. Its failure stays non-fatal (`Warn`).

`grep 'token.Wait()'` over non-test code now returns nothing.

### Configuration

Timeouts are named constants with doc comments in `internal/utils/time.go`, following the convention there. `mqtt_subscribe_timeout_seconds` follows the existing `Resolved*` pattern and is wired through the shared tuning-flag pipeline as `--mqtt-subscribe-timeout-seconds`, defaulting to 30s.

The teardown-side timeouts (unsubscribe, device-twin publish) are **fixed constants rather than per-device knobs**, because a tunable value there could push total teardown past a platform stop deadline the operator cannot see.

## Testing

**Unit tests** cover a subscribe that never ACKs ending the cycle with a *growing* backoff, a stop during a hanging subscribe returning from `Execute` in well under 2s (against the 30s default timeout), a hanging unsubscribe still reaching `Disconnect`, and an unchanged fast-ACK path — plus `WaitToken`'s timeout/interrupt/tie-break behavior and the resolver.

The two central tests were confirmed to **fail against the old `token.Wait()` code** (both hit the 30s test timeout), so they genuinely pin the regression. `golangci-lint` 0 issues; coverage 88.5% (baseline 87.8%).

**Integration tests** add a withheld-SUBACK scenario to the MQTT reconnection workflow, driven by a new `test/stubbroker` fixture: a minimal MQTT 3.1.1 broker that completes the TLS handshake, CONNACKs, keeps answering PINGREQ, and withholds SUBACK. Healthy keepalive is the key to the reproduction — cutting the network only exercises the ordinary reconnect path, so this needs a broker that stays alive and simply never acknowledges. It mints its own certificate chain and is flipped between withholding and acknowledging **on the live connection** via a mode file it re-reads per packet, so recovery is the agent's own next cycle rather than a restart.

The scenario asserts a bounded subscribe failure, a backoff that grows rather than resets, a clean stop while wedged, no orphaned `exec-*` scripts, and recovery once SUBACK arrives. Measured on the runners:

| | bounded timeouts | backoff growth | recovery |
|---|---|---|---|
| ubuntu | 2 | 1.57s → 4.75s | ~14s |
| windows | 2 | 2.32s → 3.42s | ~14s |
| macos | 2 | 2.23s → 3.67s | — |

## Docs

README gains a "Bounded MQTT Operations" section documenting the failure mode, the per-operation behavior, both config keys, and why the teardown timeouts are not tunable. `CLAUDE.md`'s message-flow section is updated to match.

## Reviewer notes

- **The last four commits are all integration-harness fixes, not agent changes.** The agent-side fix (`e6caed5`) has been unchanged since the first run. Worth reading `e6caed5` on its own; the rest is CI plumbing (Windows process lifetime, a launchd label form, an assertion that was measuring the wrong thing).
- **macOS has not yet had a green run with the final commit.** Ubuntu and Windows passed the full scenario on `60b3bc7`; macOS failed there on the `launchctl` target-form bug that `b19409c` fixes, and that fix is unverified on a runner. Please let CI confirm before merging.
- **One earlier revision of the stop assertion was vacuous** and I reported it as passing before catching it. It compared against a scenario-wide `Service stopped` baseline, but the `--update` that points the agent at the stub broker restarts the service and logs its own line, so the delta was already satisfied before the stop under test was issued. It now counts immediately before issuing the stop. The measured elapsed rounds to `0s` on Linux and Windows — consistent with the agent being parked in an interruptible `select` — but if you want a firmer number the step could print more precision and cross-check the service manager's state.
- **Pre-existing, not fixed here:** `.github/actions/stop-service` passes `system/<label>` to `launchctl stop` and guards it with `|| true`, so its macOS step has silently been a no-op. Nothing downstream noticed because later steps use `--update`, which stops the service properly via the agent binary. Left alone to keep this scoped — worth a follow-up.
- **Adding the `--mqtt-subscribe-timeout-seconds` CLI flag** goes slightly beyond the ticket's "config key" wording, but every other tuning key has a flag and the QA steps need a way to set it. Easy to drop.
- `test/stubbroker` sits behind the `integration` build tag so its statements stay out of `go test ./...` and cannot count against the coverage threshold; the tag is listed in `.golangci.yml` so it is still linted.
