### PR TITLE
fix: [sc-106108] Bound the Windows service stop wait so a wedged service cannot hang an update

### DIFF
--- a/.github/actions/wedged-service/action.yml
+++ b/.github/actions/wedged-service/action.yml
@@ -1,0 +1,283 @@
+name: Wedged Windows service
+description: >
+  Put the agent's Windows service into the state sc-106108 fixed - accepting a
+  stop control, reporting SERVICE_STOP_PENDING, and never reaching Stopped - by
+  pointing that service's binPath at the test/wedgedservice fixture and starting
+  it. The agent executable and config file on disk are never touched, so a
+  scenario can hash them before and after an update that aborts on the wedged
+  stop.
+
+  A wedge cannot be produced by killing the agent (a dead process makes the SCM
+  report Stopped almost at once, which is the happy path), and suspending its
+  threads instead is not deterministic - the SCM then fails the control request
+  outright rather than exercising the bounded wait. Rewriting binPath is
+  deterministic and reversible: the fixture reports Stopped as soon as its
+  release file appears, and mode=restore puts the real binPath back and starts
+  the agent again.
+
+  mode=wedge saves the current binPath, stops the agent, and starts the fixture
+  in its place. mode=rewedge releases the current wedged run and starts a fresh
+  one, which a scenario needs between two wedged stops: once a stop has been
+  requested the service sits in StopPending, and the agent's IsActive() reports
+  only Running as active, so a second caller would skip the stop entirely.
+  mode=restore is idempotent and tolerant of missing state, so an always()
+  cleanup step can run it even when the wedge never took.
+
+  Windows only: Linux and macOS have no equivalent state and their service
+  implementations do not poll for a stop.
+
+inputs:
+  mode:
+    description: "wedge, rewedge, or restore"
+    required: true
+  service:
+    description: "Service name to wedge (the agent's own registered service)"
+    required: true
+
+outputs:
+  log_file:
+    description: "Path the fixture's own log is written to"
+    value: ${{ steps.paths.outputs.log_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve working paths
+      id: paths
+      shell: pwsh
+      env:
+        RUNNER_TEMP_DIR: ${{ runner.temp }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        if (-not $IsWindows) {
+          throw "the wedged-service action is Windows-only"
+        }
+        $workdir = Join-Path $env:RUNNER_TEMP_DIR 'wedged-service'
+        # The fixture's binPath is assembled without quoting, because sc.exe's
+        # "keyword= value" parsing turns nested quotes into a coin toss. A
+        # working directory containing a space would therefore truncate the
+        # command line into something that fails to start, so refuse it here
+        # rather than debugging a service that will not launch.
+        if ($workdir -match '\s') {
+          throw "working directory '$workdir' contains whitespace; the fixture binPath cannot be built safely"
+        }
+        New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+        "workdir=$workdir"                                    >> $env:GITHUB_OUTPUT
+        "log_file=$(Join-Path $workdir 'wedged.log')"         >> $env:GITHUB_OUTPUT
+        "release_file=$(Join-Path $workdir 'release')"        >> $env:GITHUB_OUTPUT
+        "binpath_file=$(Join-Path $workdir 'binpath.txt')"    >> $env:GITHUB_OUTPUT
+
+    - name: Setup go
+      if: inputs.mode == 'wedge'
+      uses: actions/setup-go@v6
+      with:
+        go-version: "1.25.0"
+        cache: true
+
+    - name: Wedge the service
+      if: inputs.mode == 'wedge'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        WORKDIR: ${{ steps.paths.outputs.workdir }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        RELEASE_FILE: ${{ steps.paths.outputs.release_file }}
+        BINPATH_FILE: ${{ steps.paths.outputs.binpath_file }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $exe = Join-Path $env:WORKDIR 'wedgedservice.exe'
+
+        # The fixture is behind the `integration` build tag; see its package doc.
+        go build -tags integration -o $exe ./test/wedgedservice
+        if ($LASTEXITCODE -ne 0) { throw "failed to build the wedged service fixture" }
+
+        # The service's command line is read and written through its ImagePath
+        # registry value rather than sc.exe. It is the same value sc.exe edits,
+        # but it round-trips exactly: the agent's own command line carries quoted
+        # paths, and pushing those back through sc.exe's "keyword= value" parsing
+        # (and PowerShell's native-argument quoting on the way) is a needless way
+        # to corrupt the registration we have to restore.
+        $key = "HKLM:\SYSTEM\CurrentControlSet\Services\$($env:SERVICE)"
+
+        # Saved once and only once: a second wedge must not record the fixture's
+        # own path as the thing to restore.
+        if (-not (Test-Path $env:BINPATH_FILE)) {
+          $current = (Get-ItemProperty -Path $key -Name ImagePath).ImagePath
+          if (-not $current) { throw "could not read the ImagePath of $env:SERVICE" }
+          Set-Content -Path $env:BINPATH_FILE -Value $current -NoNewline
+        }
+        Write-Output "Original ImagePath: $(Get-Content $env:BINPATH_FILE -Raw)"
+
+        # A release file left over from an earlier run would let the fixture stop
+        # on request, which reads as a healthy stop and would pass the scenario
+        # while testing nothing. The fixture refuses to start if it finds one.
+        Remove-Item $env:RELEASE_FILE -ErrorAction SilentlyContinue
+        Remove-Item $env:LOG_FILE -ErrorAction SilentlyContinue
+
+        # Only asked for if it is actually running: sc.exe writes "the service has
+        # not been started" to stderr otherwise, which this step's stop-on-error
+        # setting would turn into a failure.
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Stopped') {
+          Write-Output "Stopping $env:SERVICE before swapping its executable"
+          sc.exe stop $env:SERVICE | Out-Null
+          $global:LASTEXITCODE = 0
+        }
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Stopped') { break }
+          Start-Sleep -Seconds 1
+        }
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Stopped') {
+          # The real agent refusing to stop here would be a finding of its own,
+          # but it also leaves nothing to swap, so report and fail.
+          sc.exe query $env:SERVICE
+          throw "$env:SERVICE did not stop; cannot install the wedged fixture"
+        }
+        # The SCM reports Stopped as soon as the service says so, which can be a
+        # moment before its process is gone; starting into that window is a
+        # needless way to fail.
+        Start-Sleep -Seconds 2
+
+        $binPath = "$exe -name $env:SERVICE -log $env:LOG_FILE -release $env:RELEASE_FILE"
+        Write-Output "Setting ImagePath to: $binPath"
+        # ExpandString because that is the type the SCM gives a service it
+        # creates; nothing here contains %VARIABLES%, so expansion is a no-op and
+        # the value is used literally either way.
+        Set-ItemProperty -Path $key -Name ImagePath -Value $binPath -Type ExpandString
+
+        sc.exe start $env:SERVICE | Out-Null
+        $global:LASTEXITCODE = 0
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Running') { break }
+          Start-Sleep -Seconds 1
+        }
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Running') {
+          Write-Output "---- fixture log ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
+          sc.exe query $env:SERVICE
+          throw "the wedged fixture did not reach Running as $env:SERVICE"
+        }
+        Write-Output "$env:SERVICE is now running the wedged fixture and will not honor a stop"
+
+    - name: Re-wedge the service
+      if: inputs.mode == 'rewedge'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        RELEASE_FILE: ${{ steps.paths.outputs.release_file }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        # Release whatever wedged run is in StopPending, then start a fresh one,
+        # so the next caller finds the service Running and actually attempts a
+        # stop.
+        New-Item -ItemType File -Force -Path $env:RELEASE_FILE | Out-Null
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Stopped') { break }
+          Start-Sleep -Seconds 1
+        }
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Stopped') {
+          Write-Output "---- fixture log ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
+          sc.exe query $env:SERVICE
+          throw "the wedged fixture did not stop after its release file appeared"
+        }
+
+        Remove-Item $env:RELEASE_FILE -ErrorAction SilentlyContinue
+        # As in mode=wedge: let the released process finish exiting before the
+        # SCM is asked to launch another one.
+        Start-Sleep -Seconds 2
+        sc.exe start $env:SERVICE | Out-Null
+        $global:LASTEXITCODE = 0
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Running') { break }
+          Start-Sleep -Seconds 1
+        }
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Running') {
+          Write-Output "---- fixture log ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
+          sc.exe query $env:SERVICE
+          throw "the wedged fixture did not restart as $env:SERVICE"
+        }
+        Write-Output "$env:SERVICE is wedged again and Running"
+
+    - name: Restore the agent service
+      if: inputs.mode == 'restore'
+      shell: pwsh
+      env:
+        SERVICE: ${{ inputs.service }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        RELEASE_FILE: ${{ steps.paths.outputs.release_file }}
+        BINPATH_FILE: ${{ steps.paths.outputs.binpath_file }}
+      run: |
+        # Deliberately not stop-on-error: this runs from an always() cleanup, so
+        # every stage tolerates state the wedge never created.
+        $ErrorActionPreference = 'Continue'
+
+        if (Test-Path $env:LOG_FILE) {
+          Write-Output "---- fixture log ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
+        }
+
+        if (-not (Test-Path $env:BINPATH_FILE)) {
+          Write-Output "No saved binPath; the service was never wedged, nothing to restore"
+          exit 0
+        }
+
+        New-Item -ItemType File -Force -Path $env:RELEASE_FILE | Out-Null
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Stopped') { break }
+          Start-Sleep -Seconds 1
+        }
+
+        # The fixture honors its release file, so this is a backstop for a run
+        # that never got as far as reading it - leaving it running would hold the
+        # service registration and defeat the restore.
+        if ((Get-Service -Name $env:SERVICE).Status -ne 'Stopped') {
+          Write-Output "Fixture still not stopped; force-killing it"
+          $query = sc.exe queryex $env:SERVICE
+          $found = $query | Select-String -Pattern 'PID\s*:\s*(\d+)'
+          if ($found) {
+            $fixturePid = [int]$found.Matches[0].Groups[1].Value
+            if ($fixturePid -gt 0) { taskkill.exe /F /T /PID $fixturePid }
+          }
+          Start-Sleep -Seconds 5
+        }
+
+        Remove-Item $env:RELEASE_FILE -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+
+        $key = "HKLM:\SYSTEM\CurrentControlSet\Services\$($env:SERVICE)"
+        $original = (Get-Content $env:BINPATH_FILE -Raw)
+        Write-Output "Restoring ImagePath to: $original"
+        Set-ItemProperty -Path $key -Name ImagePath -Value $original -Type ExpandString
+
+        # Read it back: a restore that silently failed would leave the service
+        # reaching Running as the fixture, which the check below cannot tell apart
+        # from a recovered agent - and every later step would test the fixture.
+        $restored = (Get-ItemProperty -Path $key -Name ImagePath).ImagePath
+        if ($restored -ne $original) {
+          Write-Error "ImagePath restore did not take; it is now '$restored'"
+          exit 1
+        }
+
+        sc.exe start $env:SERVICE | Out-Null
+        $global:LASTEXITCODE = 0
+        $running = $false
+        for ($i = 0; $i -lt 60; $i++) {
+          if ((Get-Service -Name $env:SERVICE).Status -eq 'Running') { $running = $true; break }
+          Start-Sleep -Seconds 1
+        }
+
+        # The saved path is dropped either way: a second restore has nothing left
+        # to do, and keeping a stale file would make it overwrite a good binPath.
+        Remove-Item $env:BINPATH_FILE -ErrorAction SilentlyContinue
+
+        if (-not $running) {
+          sc.exe query $env:SERVICE
+          $global:LASTEXITCODE = 0
+          Write-Error "restored $env:SERVICE did not reach Running; the agent is not back"
+          exit 1
+        }
+        Write-Output "$env:SERVICE restored to the real agent and Running"
+        exit 0

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1555,6 +1555,304 @@ jobs:
           scripts_dir: ${{ steps.inflight_script.outputs.scripts_dir }}
           orphan_path: ${{ steps.inflight_script.outputs.path }}
 
+      # ---- Wedged Windows service stop scenario (sc-106108) ----
+      # windowsService.Stop() polled the service state every 250ms in an
+      # unbounded loop, so a service that never reached Stopped hung its caller
+      # forever - and every caller is blocking: the unattended auto-updater, the
+      # installer, and uninstall. The symptom was a device that went offline
+      # during a routine update with no error logged anywhere.
+      #
+      # The wedge is produced by pointing the agent's own service registration at
+      # the test/wedgedservice fixture, which accepts the stop control, reports
+      # StopPending, and never stops (see the action for why killing or
+      # suspending the agent will not do). The installed agent executable and
+      # config file are left alone, so they can be hashed before and after to
+      # prove an aborted update did not touch them.
+      #
+      # Windows only: the Unix service implementations have no such polling loop.
+      - name: Capture installed file hashes before the wedge
+        if: matrix.os == 'windows-latest'
+        id: wedge_hashes
+        shell: pwsh
+        env:
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          CONFIG_DIR: ${{ matrix.config_dir }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $exe = Join-Path $env:PROGRAMFILES "RewstRemoteAgent\$($env:ORG_ID)\agent_smith.win.exe"
+          $config = Join-Path $env:CONFIG_DIR "$($env:ORG_ID)\config.json"
+          foreach ($path in @($exe, $config)) {
+            if (-not (Test-Path $path)) { throw "expected installed file is missing: $path" }
+          }
+          $exeHash = (Get-FileHash -Path $exe -Algorithm SHA256).Hash
+          $configHash = (Get-FileHash -Path $config -Algorithm SHA256).Hash
+          "exe_path=$exe"         >> $env:GITHUB_OUTPUT
+          "config_path=$config"   >> $env:GITHUB_OUTPUT
+          "exe_hash=$exeHash"     >> $env:GITHUB_OUTPUT
+          "config_hash=$configHash" >> $env:GITHUB_OUTPUT
+          Write-Output "agent executable $exe sha256=$exeHash"
+          Write-Output "config file $config sha256=$configHash"
+
+      - name: Wedge the agent service in StopPending
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/wedged-service
+        with:
+          mode: wedge
+          service: ${{ matrix.service }}
+
+      - name: Assert the update aborts on a wedged stop
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          IT_BINARY: ${{ matrix.it_binary }}
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The integration binary is the invoker because its stop deadline is
+          # overridden to 25s (see scripts/build_integration_test.ps1). The
+          # released default is five minutes; that the constant is what governs a
+          # production build is covered by unit tests rather than by keeping a
+          # runner idle for five minutes here.
+          $sw = [System.Diagnostics.Stopwatch]::StartNew()
+          $out = & "./dist/$($env:IT_BINARY)" --update --org-id $env:ORG_ID `
+            --github-token $env:GH_TOKEN 2>&1 | Out-String
+          $sw.Stop()
+          # The updater reports an aborted update through its log, not its exit
+          # status, and this step's verdict comes from the log below.
+          $global:LASTEXITCODE = 0
+          $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+          Write-Output "---- updater output after ${elapsed}s ----"
+          Write-Output $out
+
+          $failures = @()
+          # Returning at all is the headline: before the fix this call never came
+          # back. The floor proves it waited out its deadline rather than failing
+          # fast for an unrelated reason; the ceiling is far above the 25s
+          # deadline yet far below an unbounded hang.
+          if ($sw.Elapsed.TotalSeconds -lt 20) {
+            $failures += "update returned after ${elapsed}s, before its 25s stop deadline could elapse"
+          }
+          if ($sw.Elapsed.TotalSeconds -gt 180) {
+            $failures += "update took ${elapsed}s, far past its 25s stop deadline"
+          }
+          # The log has to name the service, the deadline and the last observed
+          # state, since that is the only account of why an unattended update
+          # aborted.
+          foreach ($needle in @(
+            'Failed to stop service',
+            'did not stop within',
+            'last observed state StopPending',
+            'Update aborted; existing installation left untouched'
+          )) {
+            if (-not $out.Contains($needle)) { $failures += "missing from the log: '$needle'" }
+          }
+          # And it must not have carried on as if the stop had succeeded.
+          foreach ($absent in @(
+            'Configuration successfully updated',
+            'Agent installed to',
+            'Service started'
+          )) {
+            if ($out.Contains($absent)) { $failures += "update proceeded past the failed stop: '$absent'" }
+          }
+
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Output "FAIL: $_" }
+            Write-Error "the update did not abort cleanly on a wedged stop"
+            exit 1
+          }
+          Write-Output "Update aborted on the wedged stop after ${elapsed}s, as expected"
+          exit 0
+
+      - name: Assert the aborted update left the installation untouched
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          EXE_PATH: ${{ steps.wedge_hashes.outputs.exe_path }}
+          CONFIG_PATH: ${{ steps.wedge_hashes.outputs.config_path }}
+          EXE_HASH: ${{ steps.wedge_hashes.outputs.exe_hash }}
+          CONFIG_HASH: ${{ steps.wedge_hashes.outputs.config_hash }}
+        run: |
+          # The whole point of aborting: the wedged process may still hold the
+          # executable open, so a half-written binary or a rewritten config would
+          # leave the endpoint unrecoverable without hands on it.
+          $ErrorActionPreference = 'Stop'
+          $failures = @()
+          foreach ($pair in @(
+            @{ Path = $env:EXE_PATH;    Expected = $env:EXE_HASH;    Label = 'agent executable' },
+            @{ Path = $env:CONFIG_PATH; Expected = $env:CONFIG_HASH; Label = 'config file' }
+          )) {
+            if (-not (Test-Path $pair.Path)) {
+              $failures += "$($pair.Label) was removed: $($pair.Path)"
+              continue
+            }
+            $actual = (Get-FileHash -Path $pair.Path -Algorithm SHA256).Hash
+            if ($actual -ne $pair.Expected) {
+              $failures += "$($pair.Label) changed: $($pair.Expected) -> $actual"
+            } else {
+              Write-Output "$($pair.Label) unchanged (sha256=$actual)"
+            }
+          }
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Output "FAIL: $_" }
+            Write-Error "the aborted update modified the installation"
+            exit 1
+          }
+          exit 0
+
+      # The failed stop above left the service in StopPending, and the agent
+      # treats only Running as active - so an uninstall issued now would skip the
+      # stop entirely instead of exercising it. Start a fresh wedged run so the
+      # uninstall meets a Running service, as an operator would.
+      - name: Re-wedge the service for the uninstall check
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/wedged-service
+        with:
+          mode: rewedge
+          service: ${{ matrix.service }}
+
+      - name: Assert the uninstall aborts on a wedged stop
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          IT_BINARY: ${{ matrix.it_binary }}
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          SERVICE: ${{ matrix.service }}
+          EXE_PATH: ${{ steps.wedge_hashes.outputs.exe_path }}
+          CONFIG_PATH: ${{ steps.wedge_hashes.outputs.config_path }}
+          EXE_HASH: ${{ steps.wedge_hashes.outputs.exe_hash }}
+          CONFIG_HASH: ${{ steps.wedge_hashes.outputs.config_hash }}
+          UNINSTALL_PATHS: ${{ matrix.uninstall_paths }}
+        run: |
+          $sw = [System.Diagnostics.Stopwatch]::StartNew()
+          $out = & "./dist/$($env:IT_BINARY)" --uninstall --org-id $env:ORG_ID 2>&1 | Out-String
+          $sw.Stop()
+          $global:LASTEXITCODE = 0
+          $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+          Write-Output "---- uninstaller output after ${elapsed}s ----"
+          Write-Output $out
+
+          $failures = @()
+          if ($sw.Elapsed.TotalSeconds -lt 20) {
+            $failures += "uninstall returned after ${elapsed}s, before its 25s stop deadline could elapse"
+          }
+          if ($sw.Elapsed.TotalSeconds -gt 180) {
+            $failures += "uninstall took ${elapsed}s, far past its 25s stop deadline"
+          }
+          foreach ($needle in @(
+            'Failed to stop service',
+            'did not stop within',
+            'Uninstall aborted; nothing was removed'
+          )) {
+            if (-not $out.Contains($needle)) { $failures += "missing from the log: '$needle'" }
+          }
+          foreach ($absent in @('Service deleted', 'Directory deleted')) {
+            if ($out.Contains($absent)) { $failures += "uninstall proceeded past the failed stop: '$absent'" }
+          }
+
+          # Fully intact or fully removed, never mixed: the registration, the
+          # installed directories, and both hashed files must all still be there.
+          if (-not (Get-Service -Name $env:SERVICE -ErrorAction SilentlyContinue)) {
+            $failures += "service registration $($env:SERVICE) was deleted"
+          }
+          foreach ($path in ($env:UNINSTALL_PATHS -split "`n" | ForEach-Object { $_.Trim() } |
+              Where-Object { $_ })) {
+            if (-not (Test-Path $path)) { $failures += "installed directory was removed: $path" }
+          }
+          foreach ($pair in @(
+            @{ Path = $env:EXE_PATH;    Expected = $env:EXE_HASH;    Label = 'agent executable' },
+            @{ Path = $env:CONFIG_PATH; Expected = $env:CONFIG_HASH; Label = 'config file' }
+          )) {
+            if (-not (Test-Path $pair.Path)) {
+              $failures += "$($pair.Label) was removed: $($pair.Path)"
+            } elseif ((Get-FileHash -Path $pair.Path -Algorithm SHA256).Hash -ne $pair.Expected) {
+              $failures += "$($pair.Label) changed during the aborted uninstall"
+            }
+          }
+
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Output "FAIL: $_" }
+            Write-Error "the uninstall did not abort cleanly on a wedged stop"
+            exit 1
+          }
+          Write-Output "Uninstall aborted on the wedged stop after ${elapsed}s with nothing removed"
+          exit 0
+
+      # Captured before the restore restarts the real agent, so the delta below
+      # can only come from the recovered service.
+      - name: Capture recovery baseline counts
+        if: matrix.os == 'windows-latest'
+        id: wedge_recovery_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed"
+
+      # always(): a failed assertion above must not leave the runner's service
+      # registration pointing at the fixture, or the rest of the job (and the
+      # final uninstall) would be testing the fixture instead of the agent.
+      - name: Restore the agent service after the wedge
+        if: always() && matrix.os == 'windows-latest'
+        uses: ./.github/actions/wedged-service
+        with:
+          mode: restore
+          service: ${{ matrix.service }}
+
+      - name: Assert the recovered endpoint comes back online
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.wedge_recovery_baseline.outputs.subscribed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Recovered agent subscribed again (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Recovered agent never resubscribed (count stayed at $baseline)"
+          exit 1
+
+      - name: Assert a subsequent update succeeds after recovery
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          BINARY: ${{ matrix.binary }}
+          ORG_ID: ${{ vars.IT_ORG_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NO_AUTO_UPDATES_EXTRA: ${{ matrix.no_auto_updates_extra }}
+        run: |
+          # The bound must only catch a wedge: once the endpoint is recovered, an
+          # ordinary update stops the service, replaces the binary and starts it
+          # again with no behavioral change.
+          $out = & "./dist/$($env:BINARY)" --update --org-id $env:ORG_ID --no-auto-updates `
+            $env:NO_AUTO_UPDATES_EXTRA --github-token $env:GH_TOKEN 2>&1 | Out-String
+          $global:LASTEXITCODE = 0
+          Write-Output $out
+
+          $failures = @()
+          foreach ($needle in @('Agent installed to', 'Service started')) {
+            if (-not $out.Contains($needle)) { $failures += "missing from the log: '$needle'" }
+          }
+          if ($out.Contains('Failed to stop service')) {
+            $failures += "a healthy stop was reported as a failure"
+          }
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Output "FAIL: $_" }
+            Write-Error "the post-recovery update did not complete normally"
+            exit 1
+          }
+          Write-Output "Post-recovery update completed normally"
+          exit 0
+
       - name: Uninstall agent
         uses: ./.github/actions/run-agent
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Required tools:
 - **internal/agent/**: Device configuration, installation paths, and OS-specific host information
 - **internal/interpreter/**: Command execution engine supporting both PowerShell and Bash interpreters  
 - **internal/mqtt/**: Azure IoT Hub MQTT client implementation with auto-reconnection
-- **internal/service/**: Cross-platform service management utilities
+- **internal/service/**: Cross-platform service management utilities. On Windows, `Stop()` waits a bounded, documented deadline (5 minutes) for the service to reach `Stopped` and otherwise returns an error naming the service and last observed state, so a wedged service aborts an update/install/uninstall with an actionable message instead of hanging forever. See the README's "Bounded Windows Service Stop" section.
 - **internal/syslog/**: OS-specific system logging (Linux/macOS/Windows)
 - **plugins/**: Plugin loader using HashiCorp's go-plugin framework
 - **shared/**: Plugin interfaces and RPC definitions

--- a/README.md
+++ b/README.md
@@ -409,6 +409,45 @@ operator cannot see. Example snippet:
 }
 ```
 
+### Bounded Windows Service Stop (Windows only)
+
+Update, install and uninstall all stop the running service first, and on Windows
+that means asking the Service Control Manager to stop it and then waiting for the
+service to report `Stopped`. That wait used to be unbounded: it polled the service
+state every 250 ms forever. A service that never reaches `Stopped` — a wedged
+agent process, or Windows itself holding the service in `StopPending` behind a
+stuck operation — therefore hung the caller indefinitely. Because the auto-updater
+runs unattended, the visible symptom was a device that went offline during a
+routine update with no error logged anywhere, needing hands on the endpoint to
+recover; an interactive uninstall simply hung with no output.
+
+The wait is now bounded:
+
+- The stop waits at most **5 minutes** for the service to reach `Stopped`. The
+  bound is deliberately generous — it exists to catch a wedge, not to race a
+  normal shutdown, so a healthy agent draining long-running commands is never cut
+  short.
+- A service observed in `StopPending` keeps being polled until the deadline, while
+  a state the service cannot reach `Stopped` from fails immediately rather than
+  burning the full deadline. `Running` and `StartPending` are treated as
+  still-stopping, because the SCM can report the pre-stop state before the service
+  thread picks the control up.
+- Overrunning the deadline logs at `Error` and names the service, the deadline and
+  the last observed state — for example `service rewst_agent_smith_<org> did not
+  stop within 5m0s: last observed state StopPending` — so the reason an update
+  aborted is visible in the log.
+- Callers abort instead of proceeding as if the stop succeeded. **Update** does
+  not overwrite the agent executable or the config file, since the old process may
+  still hold the executable open, leaving the existing installation intact and the
+  service recoverable. **Uninstall** does not delete the registration or any files
+  out from under a live process, and logs plainly that nothing was removed.
+  **Install** (`--config`) likewise aborts before deleting a pre-existing wedged
+  service.
+
+Recovery is the ordinary one: end the wedged agent process, start the service, and
+re-run the update or uninstall. Linux and macOS are unaffected — their service
+implementations do not use this polling loop.
+
 ### Notification Plugin Supervision
 
 Notification plugins run as separate subprocesses reached over RPC, and every

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -165,13 +165,19 @@ func runConfig(params *configContext) error {
 	if err == nil {
 		if existingService.IsActive() {
 			logger.Info("Stopping service", "service", name)
-			err = existingService.Stop()
-			if err != nil {
-				err = existingService.Close()
-				if err != nil {
-					return fmt.Errorf("failed to close service %s: %w", name, err)
+			// Abort before deleting the registration or overwriting the
+			// executable: a service that will not stop may still hold both.
+			// Report the stop failure itself, not the handle cleanup, so the
+			// reason the install aborted is visible.
+			if stopErr := existingService.Stop(); stopErr != nil {
+				if closeErr := existingService.Close(); closeErr != nil {
+					logger.Error(
+						"Failed to close service handle",
+						"service", name,
+						"error", closeErr,
+					)
 				}
-				return fmt.Errorf("failed to stop service %s: %w", name, err)
+				return fmt.Errorf("failed to stop service %s: %w", name, stopErr)
 			}
 		}
 

--- a/cmd/agent_smith/main_test.go
+++ b/cmd/agent_smith/main_test.go
@@ -100,13 +100,30 @@ type mockService struct {
 	stopErr   error
 	deleteErr error
 	startErr  error
+
+	stopCalled   bool
+	deleteCalled bool
+	startCalled  bool
 }
 
 func (m *mockService) IsActive() bool { return m.isActive }
-func (m *mockService) Stop() error    { return m.stopErr }
-func (m *mockService) Delete() error  { return m.deleteErr }
-func (m *mockService) Start() error   { return m.startErr }
-func (m *mockService) Close() error   { return nil }
+
+func (m *mockService) Stop() error {
+	m.stopCalled = true
+	return m.stopErr
+}
+
+func (m *mockService) Delete() error {
+	m.deleteCalled = true
+	return m.deleteErr
+}
+
+func (m *mockService) Start() error {
+	m.startCalled = true
+	return m.startErr
+}
+
+func (m *mockService) Close() error { return nil }
 
 type mockServiceManager struct {
 	openErr       error

--- a/cmd/agent_smith/uninstall.go
+++ b/cmd/agent_smith/uninstall.go
@@ -36,7 +36,16 @@ func runUninstall(params *uninstallContext) {
 		logger.Info("Stopping service", "service", name)
 		err = service.Stop()
 		if err != nil {
-			logger.Error("Failed to stop service", "error", err)
+			// Abort before deleting anything. Removing the registration and the
+			// files while the process is still live would leave a half-removed
+			// installation that neither runs nor uninstalls cleanly.
+			logger.Error("Failed to stop service", "service", name, "error", err)
+			logger.Error(
+				"Uninstall aborted; nothing was removed",
+				"service", name,
+				"service_registration", "intact",
+				"installed_files", "intact",
+			)
 			return
 		}
 

--- a/cmd/agent_smith/uninstall_test.go
+++ b/cmd/agent_smith/uninstall_test.go
@@ -37,6 +37,42 @@ func TestRunUninstall_StopFails(t *testing.T) {
 	runUninstall(params)
 }
 
+// A stop that fails — a wedged service that never reaches Stopped — must abort
+// the uninstall before anything is removed, so the endpoint is left either fully
+// installed or fully removed, never mixed.
+func TestRunUninstall_StopFails_RemovesNothing(t *testing.T) {
+	var removed []string
+	svc := &mockService{
+		isActive: true,
+		stopErr: errors.New(
+			"service rewst_agent_smith_test-org did not stop within 5m0s: " +
+				"last observed state StopPending",
+		),
+	}
+	params := &uninstallContext{
+		OrgId:          "test-org",
+		ServiceManager: &mockServiceManager{openService: svc},
+		FS: &mockFileSystem{
+			removeAllFunc: func(path string) error {
+				removed = append(removed, path)
+				return nil
+			},
+		},
+	}
+
+	runUninstall(params)
+
+	if !svc.stopCalled {
+		t.Error("expected Stop to be attempted")
+	}
+	if svc.deleteCalled {
+		t.Error("expected the service registration to survive a failed stop")
+	}
+	if len(removed) != 0 {
+		t.Errorf("expected no directories removed after a failed stop, got %v", removed)
+	}
+}
+
 func TestRunUninstall_ActiveService_DeleteFails(t *testing.T) {
 	params := &uninstallContext{
 		OrgId: "test-org",

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -40,7 +40,18 @@ func runUpdate(params *updateContext) {
 		logger.Info("Stopping service", "service", name)
 		err = svc.Stop()
 		if err != nil {
+			// Abort without touching the installation. The old process may still
+			// be running and holding the agent executable open, so overwriting it
+			// would either fail or leave a half-updated install behind. Leaving
+			// everything in place keeps the endpoint recoverable: stop the wedged
+			// process, start the service, and the next update succeeds.
 			logger.Error("Failed to stop service", "service", name, "error", err)
+			logger.Error(
+				"Update aborted; existing installation left untouched",
+				"service", name,
+				"agent_executable", "not modified",
+				"config_file", "not modified",
+			)
 			return
 		}
 

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -216,6 +216,48 @@ func TestRunUpdate_StopFails(t *testing.T) {
 	runUpdate(params)
 }
 
+// A stop that fails — a wedged service that never reaches Stopped — must abort
+// the update with the installation untouched: the old process may still hold the
+// executable open, and a half-updated install is unrecoverable without hands on
+// the endpoint.
+func TestRunUpdate_StopFails_LeavesInstallationUntouched(t *testing.T) {
+	var writes []string
+	params := newBaseUpdateParams()
+	params.FS = &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc:   func(string) ([]byte, error) { return validDeviceJSON("test-org"), nil },
+		writeFileFunc: func(name string, _ []byte, _ os.FileMode) error {
+			writes = append(writes, name)
+			return nil
+		},
+		mkdirAllFunc:  func(string) error { return nil },
+		removeAllFunc: func(string) error { return nil },
+	}
+	svc := &mockService{
+		isActive: true,
+		stopErr: errors.New(
+			"service rewst_agent_smith_test-org did not stop within 5m0s: " +
+				"last observed state StopPending",
+		),
+	}
+	params.ServiceManager = &mockServiceManager{openService: svc}
+
+	runUpdate(params)
+
+	if !svc.stopCalled {
+		t.Error("expected Stop to be attempted")
+	}
+	if len(writes) != 0 {
+		t.Errorf("expected no files written after a failed stop, got %v", writes)
+	}
+	if svc.startCalled {
+		t.Error("expected the service not to be started after a failed stop")
+	}
+	if svc.deleteCalled {
+		t.Error("expected the service registration to be left alone after a failed stop")
+	}
+}
+
 func TestRunUpdate_PathsDataError(t *testing.T) {
 	params := newBaseUpdateParams()
 	params.Sys = &mockSystemInfoProvider{hostPlatformErr: errors.New("platform error")}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -16,8 +16,34 @@ import (
 
 const pollingInterval = 250 * time.Millisecond
 
+// serviceStopTimeout bounds how long Stop waits for a service to report Stopped
+// after the stop control has been accepted. Every caller of Stop is a blocking,
+// user- or updater-initiated operation, so an unbounded wait turns a service
+// that will not stop into an auto-update or uninstall that never returns.
+//
+// The value is deliberately generous: it exists to catch a wedged service, not
+// to race a normal shutdown. A healthy agent finishes its own teardown in
+// seconds, but it first drains whatever commands are in flight, and an operator
+// can set command_timeout_seconds high enough that a single command legitimately
+// runs for minutes. Five minutes sits far above any healthy shutdown while still
+// being short enough that an unattended update fails with an actionable error
+// the same day it runs.
+const serviceStopTimeout = 5 * time.Minute
+
 type windowsService struct {
 	handle windowsServiceHandle
+
+	// name is the registered service name. It is only used to name the service
+	// in Stop's errors, so an aborted update or uninstall says which service
+	// would not stop.
+	name string
+
+	// Test seams for the bounded stop wait. Zero values select the package
+	// defaults, so production code never sets them.
+	stopTimeout  time.Duration
+	pollInterval time.Duration
+	now          func() time.Time
+	sleep        func(time.Duration)
 }
 
 // Replaces mgr.Service
@@ -37,19 +63,100 @@ func (winSvc *windowsService) Start() error {
 	return winSvc.handle.Start()
 }
 
+// serviceStateName renders a service state for logs and errors, so a failure
+// reads as "StopPending" rather than as a bare number.
+func serviceStateName(state svc.State) string {
+	switch state {
+	case svc.Stopped:
+		return "Stopped"
+	case svc.StartPending:
+		return "StartPending"
+	case svc.StopPending:
+		return "StopPending"
+	case svc.Running:
+		return "Running"
+	case svc.ContinuePending:
+		return "ContinuePending"
+	case svc.PausePending:
+		return "PausePending"
+	case svc.Paused:
+		return "Paused"
+	default:
+		return fmt.Sprintf("Unknown(%d)", uint32(state))
+	}
+}
+
+// stopInProgress reports whether state is one a service is expected to pass
+// through on its way to Stopped once a stop control has been accepted, and is
+// therefore worth polling until the deadline.
+//
+// StopPending is the normal case. Running and StartPending are tolerated because
+// Control reports the status the service last published, which can still be the
+// pre-stop state before the service thread picks the control up; treating those
+// as failures would break healthy stops. Any other state means the service is
+// not heading for Stopped at all, so waiting out the full deadline would only
+// delay a failure that is already certain.
+func stopInProgress(state svc.State) bool {
+	switch state {
+	case svc.StopPending, svc.Running, svc.StartPending:
+		return true
+	default:
+		return false
+	}
+}
+
+// Stop requests a stop and waits at most serviceStopTimeout for the service to
+// reach Stopped. It never waits indefinitely: overrunning the deadline, or
+// observing a state the service cannot reach Stopped from, returns an error
+// naming the service and the last observed state.
 func (winSvc *windowsService) Stop() error {
 	status, err := winSvc.handle.Control(svc.Stop)
 	if err != nil {
 		return err
 	}
 
-	// Wait for the service to stop by polling the status
+	timeout := winSvc.stopTimeout
+	if timeout <= 0 {
+		timeout = serviceStopTimeout
+	}
+	interval := winSvc.pollInterval
+	if interval <= 0 {
+		interval = pollingInterval
+	}
+	now := winSvc.now
+	if now == nil {
+		now = time.Now
+	}
+	sleep := winSvc.sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
+	// Wait for the service to stop by polling the status until the deadline
+	deadline := now().Add(timeout)
 	for {
 		if status.State == svc.Stopped {
 			return nil
 		}
 
-		time.Sleep(pollingInterval)
+		if !stopInProgress(status.State) {
+			return fmt.Errorf(
+				"service %s will not stop: unexpected state %s",
+				winSvc.name,
+				serviceStateName(status.State),
+			)
+		}
+
+		if !now().Before(deadline) {
+			return fmt.Errorf(
+				"service %s did not stop within %s: last observed state %s",
+				winSvc.name,
+				timeout,
+				serviceStateName(status.State),
+			)
+		}
+
+		sleep(interval)
 
 		status, err = winSvc.handle.Query()
 		if err != nil {
@@ -126,6 +233,7 @@ func (s *defaultServiceManager) Create(params AgentParams) (Service, error) {
 
 	return &windowsService{
 		handle: svc,
+		name:   params.Name,
 	}, nil
 }
 
@@ -143,6 +251,7 @@ func (s *defaultServiceManager) Open(name string) (Service, error) {
 
 	return &windowsService{
 		handle: svc,
+		name:   name,
 	}, nil
 }
 

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -30,6 +30,13 @@ const pollingInterval = 250 * time.Millisecond
 // the same day it runs.
 const serviceStopTimeout = 5 * time.Minute
 
+// stopTimeoutOverrideStr is overridable via -ldflags for integration testing.
+// When set to a valid, positive Go duration it replaces serviceStopTimeout, so a
+// wedged service can be observed being given up on in seconds rather than the
+// production five minutes. It is empty in production builds.
+// Example: -ldflags "-X github.com/RewstApp/agent-smith-go/internal/service.stopTimeoutOverrideStr=25s"
+var stopTimeoutOverrideStr = ""
+
 type windowsService struct {
 	handle windowsServiceHandle
 
@@ -105,6 +112,22 @@ func stopInProgress(state svc.State) bool {
 	}
 }
 
+// resolveStopTimeout returns how long Stop waits for the service to reach
+// Stopped: the per-instance value if one is set (unit tests only), then the
+// ldflags-injected override (integration builds only), otherwise the documented
+// serviceStopTimeout.
+func (winSvc *windowsService) resolveStopTimeout() time.Duration {
+	if winSvc.stopTimeout > 0 {
+		return winSvc.stopTimeout
+	}
+	if stopTimeoutOverrideStr != "" {
+		if timeout, err := time.ParseDuration(stopTimeoutOverrideStr); err == nil && timeout > 0 {
+			return timeout
+		}
+	}
+	return serviceStopTimeout
+}
+
 // Stop requests a stop and waits at most serviceStopTimeout for the service to
 // reach Stopped. It never waits indefinitely: overrunning the deadline, or
 // observing a state the service cannot reach Stopped from, returns an error
@@ -115,10 +138,7 @@ func (winSvc *windowsService) Stop() error {
 		return err
 	}
 
-	timeout := winSvc.stopTimeout
-	if timeout <= 0 {
-		timeout = serviceStopTimeout
-	}
+	timeout := winSvc.resolveStopTimeout()
 	interval := winSvc.pollInterval
 	if interval <= 0 {
 		interval = pollingInterval

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -4,11 +4,27 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
+
+// fakeClock advances only when the code under test sleeps, so the bounded stop
+// wait can be exercised deterministically and instantly.
+type fakeClock struct {
+	now   time.Time
+	slept []time.Duration
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) Sleep(d time.Duration) {
+	c.now = c.now.Add(d)
+	c.slept = append(c.slept, d)
+}
 
 // mockWindowsServiceHandle
 
@@ -21,7 +37,14 @@ type mockWindowsServiceHandle struct {
 
 	controlStatus svc.Status
 	queryStatuses []svc.Status
-	queryCallIdx  int
+	// queryFallback, when set, is returned once queryStatuses is exhausted.
+	// Without it the mock falls back to Stopped, which no bounded-wait test can
+	// use because the service would always eventually stop.
+	queryFallback *svc.Status
+	// queryHook, when set, is consulted before each Query result and can fail a
+	// specific call by its zero-based index.
+	queryHook    func(callIdx int) error
+	queryCallIdx int
 
 	closeCalled   bool
 	startCalled   bool
@@ -53,10 +76,20 @@ func (m *mockWindowsServiceHandle) Query() (svc.Status, error) {
 	if m.queryErr != nil {
 		return svc.Status{}, m.queryErr
 	}
+	if m.queryHook != nil {
+		if err := m.queryHook(m.queryCallIdx); err != nil {
+			m.queryCallIdx++
+			return svc.Status{}, err
+		}
+	}
 	if m.queryCallIdx < len(m.queryStatuses) {
 		status := m.queryStatuses[m.queryCallIdx]
 		m.queryCallIdx++
 		return status, nil
+	}
+	m.queryCallIdx++
+	if m.queryFallback != nil {
+		return *m.queryFallback, nil
 	}
 	return svc.Status{State: svc.Stopped}, nil
 }
@@ -206,13 +239,18 @@ func TestWindowsService_Stop_PollingUntilStopped(t *testing.T) {
 			{State: svc.Stopped},
 		},
 	}
-	s := &windowsService{handle: handle}
+	clock := &fakeClock{}
+	s := &windowsService{handle: handle, now: clock.Now, sleep: clock.Sleep}
 
 	if err := s.Stop(); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if handle.queryCallIdx != 2 {
 		t.Errorf("expected 2 Query calls, got %d", handle.queryCallIdx)
+	}
+	// Polls on the documented interval.
+	if len(clock.slept) != 2 || clock.slept[0] != pollingInterval {
+		t.Errorf("expected polls at %s, got %v", pollingInterval, clock.slept)
 	}
 }
 
@@ -230,10 +268,187 @@ func TestWindowsService_Stop_QueryError(t *testing.T) {
 		controlStatus: svc.Status{State: svc.StopPending},
 		queryErr:      errors.New("query failed"),
 	}
-	s := &windowsService{handle: handle}
+	clock := &fakeClock{}
+	s := &windowsService{handle: handle, now: clock.Now, sleep: clock.Sleep}
 
 	if err := s.Stop(); err == nil {
 		t.Error("expected error from Query, got nil")
+	}
+}
+
+func TestWindowsService_Stop_TimesOutWhileStopPending(t *testing.T) {
+	stopPending := svc.Status{State: svc.StopPending}
+	handle := &mockWindowsServiceHandle{
+		controlStatus: stopPending,
+		queryFallback: &stopPending,
+	}
+	clock := &fakeClock{}
+	s := &windowsService{
+		handle:       handle,
+		name:         "rewst_agent_smith_test-org",
+		stopTimeout:  10 * time.Millisecond,
+		pollInterval: time.Millisecond,
+		now:          clock.Now,
+		sleep:        clock.Sleep,
+	}
+
+	err := s.Stop()
+	if err == nil {
+		t.Fatal("expected an error when the service never leaves StopPending")
+	}
+	for _, want := range []string{"rewst_agent_smith_test-org", "10ms", "StopPending"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to mention %q, got %q", want, err.Error())
+		}
+	}
+	// Bounded: polls for the deadline and no longer.
+	if len(clock.slept) != 10 {
+		t.Errorf("expected 10 polls within the deadline, got %d", len(clock.slept))
+	}
+	if handle.queryCallIdx != 10 {
+		t.Errorf("expected 10 Query calls, got %d", handle.queryCallIdx)
+	}
+}
+
+func TestWindowsService_Stop_StoppedOnLastPollBeforeDeadline(t *testing.T) {
+	handle := &mockWindowsServiceHandle{
+		controlStatus: svc.Status{State: svc.StopPending},
+		queryStatuses: []svc.Status{
+			{State: svc.StopPending},
+			{State: svc.StopPending},
+			{State: svc.StopPending},
+			{State: svc.Stopped},
+		},
+	}
+	clock := &fakeClock{}
+	s := &windowsService{
+		handle:       handle,
+		name:         "rewst_agent_smith_test-org",
+		stopTimeout:  4 * time.Millisecond,
+		pollInterval: time.Millisecond,
+		now:          clock.Now,
+		sleep:        clock.Sleep,
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("expected no error when the service stops on the last poll, got %v", err)
+	}
+	if handle.queryCallIdx != 4 {
+		t.Errorf("expected 4 Query calls, got %d", handle.queryCallIdx)
+	}
+}
+
+func TestWindowsService_Stop_UnexpectedStateFailsFast(t *testing.T) {
+	handle := &mockWindowsServiceHandle{
+		controlStatus: svc.Status{State: svc.Paused},
+	}
+	clock := &fakeClock{}
+	s := &windowsService{
+		handle:       handle,
+		name:         "rewst_agent_smith_test-org",
+		stopTimeout:  time.Hour,
+		pollInterval: time.Millisecond,
+		now:          clock.Now,
+		sleep:        clock.Sleep,
+	}
+
+	err := s.Stop()
+	if err == nil {
+		t.Fatal("expected an error for a state the service cannot stop from")
+	}
+	if !strings.Contains(err.Error(), "Paused") {
+		t.Errorf("expected error to name the observed state, got %q", err.Error())
+	}
+	// Fails immediately rather than burning the deadline.
+	if len(clock.slept) != 0 {
+		t.Errorf("expected no polling, got %d sleeps", len(clock.slept))
+	}
+	if handle.queryCallIdx != 0 {
+		t.Errorf("expected no Query calls, got %d", handle.queryCallIdx)
+	}
+}
+
+func TestWindowsService_Stop_QueryErrorMidPoll(t *testing.T) {
+	stopPending := svc.Status{State: svc.StopPending}
+	handle := &mockWindowsServiceHandle{
+		controlStatus: stopPending,
+		queryFallback: &stopPending,
+	}
+	clock := &fakeClock{}
+	s := &windowsService{
+		handle:       handle,
+		name:         "rewst_agent_smith_test-org",
+		stopTimeout:  time.Hour,
+		pollInterval: time.Millisecond,
+		now:          clock.Now,
+		sleep:        clock.Sleep,
+	}
+
+	// Fail the third Query, after the wait is already under way.
+	handle.queryStatuses = []svc.Status{stopPending, stopPending}
+	handle.queryHook = func(callIdx int) error {
+		if callIdx >= 2 {
+			return errors.New("query failed")
+		}
+		return nil
+	}
+
+	err := s.Stop()
+	if err == nil {
+		t.Fatal("expected the Query error to be returned")
+	}
+	if err.Error() != "query failed" {
+		t.Errorf("expected 'query failed', got %q", err.Error())
+	}
+	if len(clock.slept) != 3 {
+		t.Errorf("expected 3 polls before the failure, got %d", len(clock.slept))
+	}
+}
+
+func TestWindowsService_Stop_RunningIsPolledNotRejected(t *testing.T) {
+	handle := &mockWindowsServiceHandle{
+		// Control can report the pre-stop state before the service thread picks
+		// the control up; that must not be treated as a refusal to stop.
+		controlStatus: svc.Status{State: svc.Running},
+		queryStatuses: []svc.Status{
+			{State: svc.StopPending},
+			{State: svc.Stopped},
+		},
+	}
+	clock := &fakeClock{}
+	s := &windowsService{
+		handle:       handle,
+		name:         "rewst_agent_smith_test-org",
+		stopTimeout:  time.Minute,
+		pollInterval: time.Millisecond,
+		now:          clock.Now,
+		sleep:        clock.Sleep,
+	}
+
+	if err := s.Stop(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if handle.queryCallIdx != 2 {
+		t.Errorf("expected 2 Query calls, got %d", handle.queryCallIdx)
+	}
+}
+
+func TestServiceStateName(t *testing.T) {
+	cases := map[svc.State]string{
+		svc.Stopped:         "Stopped",
+		svc.StartPending:    "StartPending",
+		svc.StopPending:     "StopPending",
+		svc.Running:         "Running",
+		svc.ContinuePending: "ContinuePending",
+		svc.PausePending:    "PausePending",
+		svc.Paused:          "Paused",
+		svc.State(99):       "Unknown(99)",
+	}
+
+	for state, want := range cases {
+		if got := serviceStateName(state); got != want {
+			t.Errorf("serviceStateName(%d) = %q, want %q", uint32(state), got, want)
+		}
 	}
 }
 

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -433,6 +433,39 @@ func TestWindowsService_Stop_RunningIsPolledNotRejected(t *testing.T) {
 	}
 }
 
+func TestWindowsService_ResolveStopTimeout(t *testing.T) {
+	orig := stopTimeoutOverrideStr
+	t.Cleanup(func() { stopTimeoutOverrideStr = orig })
+
+	// No override: the documented constant.
+	stopTimeoutOverrideStr = ""
+	s := &windowsService{}
+	if got := s.resolveStopTimeout(); got != serviceStopTimeout {
+		t.Errorf("expected %s, got %s", serviceStopTimeout, got)
+	}
+
+	// A valid, positive override wins (integration builds).
+	stopTimeoutOverrideStr = "25s"
+	if got := s.resolveStopTimeout(); got != 25*time.Second {
+		t.Errorf("expected 25s, got %s", got)
+	}
+
+	// Garbage and non-positive overrides fall back rather than disabling the bound.
+	for _, bad := range []string{"nonsense", "0s", "-5s"} {
+		stopTimeoutOverrideStr = bad
+		if got := s.resolveStopTimeout(); got != serviceStopTimeout {
+			t.Errorf("override %q: expected fallback to %s, got %s", bad, serviceStopTimeout, got)
+		}
+	}
+
+	// The per-instance value (unit tests) wins over the override.
+	stopTimeoutOverrideStr = "25s"
+	s.stopTimeout = time.Millisecond
+	if got := s.resolveStopTimeout(); got != time.Millisecond {
+		t.Errorf("expected 1ms, got %s", got)
+	}
+}
+
 func TestServiceStateName(t *testing.T) {
 	cases := map[svc.State]string{
 		svc.Stopped:         "Stopped",

--- a/scripts/build_integration_test.ps1
+++ b/scripts/build_integration_test.ps1
@@ -7,6 +7,11 @@
 # - sasTokenLifetimeOverrideStr overridden to 90s (proactive SAS token renewal
 #   fires ~30s in - lifetime minus the ~60s renew margin - so the renewal path
 #   can be exercised in seconds not hours)
+# - stopTimeoutOverrideStr overridden to 25s (the bounded wait for a Windows
+#   service to reach Stopped, so the wedged-service scenario observes the update
+#   abort in seconds instead of the production five minutes). The symbol only
+#   exists in the Windows build; -X against a missing symbol is ignored, so the
+#   same flag is harmless on Linux and macOS.
 
 $env:GOARCH = "amd64"
 
@@ -15,7 +20,8 @@ $intervalFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.updateInte
 $baseBackoffFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.baseBackoffStr=10s"
 $maxRetriesFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.maxRetriesStr=6"
 $sasTokenLifetimeFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.sasTokenLifetimeOverrideStr=90s"
-$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag"
+$stopTimeoutFlag = "-X github.com/RewstApp/agent-smith-go/internal/service.stopTimeoutOverrideStr=25s"
+$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag $stopTimeoutFlag"
 
 if ($IsWindows) {
     $buildOutput = "./dist/rewst_agent_config.win.it.exe"

--- a/test/wedgedservice/main.go
+++ b/test/wedgedservice/main.go
@@ -1,0 +1,162 @@
+//go:build integration && windows
+
+// Command wedgedservice is a deliberately unstoppable Windows service used by
+// the integration test suite to reproduce the failure mode sc-106108 fixed: a
+// service that accepts SERVICE_CONTROL_STOP, returns from its control handler,
+// reports SERVICE_STOP_PENDING — and then never reaches Stopped.
+//
+// That is the state a wedged agent leaves behind (a process parked in an
+// unbounded wait, or Windows holding the service in StopPending behind a stuck
+// operation), and it used to hang every caller of windowsService.Stop()
+// indefinitely: an unattended auto-update that never finished and an uninstall
+// that never returned. It cannot be produced by killing the agent — a dead
+// process makes the SCM report Stopped almost immediately, which is the happy
+// path — and suspending the process instead is not deterministic, because the
+// SCM then fails the control request outright rather than exercising the wait.
+// So the fixture stands in for the wedge itself: the ticket's own framing is
+// that any wedge will do, because what is under test is the bound on the wait
+// and not how the agent got stuck.
+//
+// The harness registers it under the agent's own service name by rewriting that
+// service's binPath (see .github/actions/wedged-service), so the agent binary
+// and config file on disk are untouched and can be hashed before and after the
+// aborted update.
+//
+// The wedge is escapable so the runner can be recovered without a force-kill:
+// once -release exists the fixture reports Stopped and exits, and the harness
+// restores the original binPath. Every transition is appended to -log, since a
+// service's stdout goes nowhere and that log is the only account of what the
+// fixture did.
+//
+// It sits behind the `integration` build tag so it stays out of
+// `go test ./...`: as an untested CI fixture its statements would otherwise
+// count against the repository coverage threshold. It is still linted, because
+// the tag is listed in .golangci.yml. Build it with
+// `go build -tags integration ./test/wedgedservice`.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+)
+
+// stopWaitHint is reported alongside StopPending. It is long enough to cover the
+// agent's production stop deadline, so the SCM keeps reporting StopPending for
+// the whole scenario instead of deciding the service has stopped responding.
+const stopWaitHint = 10 * time.Minute
+
+// releasePollInterval is how often the wedged handler looks for the release
+// file. The wedge only has to outlive the caller's deadline, so polling once a
+// second is ample and keeps teardown prompt.
+const releasePollInterval = time.Second
+
+type wedgedService struct {
+	releasePath string
+	logf        func(format string, args ...any)
+}
+
+func (w *wedgedService) Execute(
+	args []string,
+	requests <-chan svc.ChangeRequest,
+	responses chan<- svc.Status,
+) (bool, uint32) {
+	responses <- svc.Status{State: svc.StartPending}
+	responses <- svc.Status{
+		State:   svc.Running,
+		Accepts: svc.AcceptStop | svc.AcceptShutdown,
+	}
+	w.logf("running; awaiting a stop control")
+
+	for {
+		request := <-requests
+		switch request.Cmd {
+		case svc.Interrogate:
+			responses <- request.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			// Accept the control and report StopPending, exactly as a healthy
+			// service beginning its teardown would - then never finish it. The
+			// handler returning is what makes ControlService succeed, so the
+			// caller reaches its polling wait rather than failing outright.
+			responses <- svc.Status{
+				State:    svc.StopPending,
+				WaitHint: uint32(stopWaitHint / time.Millisecond),
+			}
+			w.logf("stop control accepted; wedged in StopPending until %s exists", w.releasePath)
+
+			for {
+				if _, err := os.Stat(w.releasePath); err == nil {
+					w.logf("release file observed; reporting Stopped")
+					responses <- svc.Status{State: svc.Stopped}
+					return false, 0
+				}
+				time.Sleep(releasePollInterval)
+			}
+		default:
+			w.logf("ignoring unexpected control %d", request.Cmd)
+		}
+	}
+}
+
+// newLogger appends timestamped lines to path. The file is reopened per line so
+// the harness can read a complete log while the fixture is still wedged, and a
+// logging failure is never fatal: the fixture's job is to stay unstoppable.
+func newLogger(path string) func(string, ...any) {
+	return func(format string, args ...any) {
+		if path == "" {
+			return
+		}
+		file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return
+		}
+		defer func() { _ = file.Close() }()
+		_, _ = fmt.Fprintf(
+			file,
+			"%s %s\n",
+			time.Now().Format(time.RFC3339),
+			fmt.Sprintf(format, args...),
+		)
+	}
+}
+
+func main() {
+	name := flag.String("name", "", "service name to register in the dispatch table")
+	logPath := flag.String("log", "", "file to append fixture log lines to")
+	releasePath := flag.String(
+		"release",
+		"",
+		"file whose existence releases the wedge and lets the service stop",
+	)
+	flag.Parse()
+
+	logf := newLogger(*logPath)
+
+	if *releasePath == "" {
+		logf(
+			"refusing to start: -release is required, an unreleasable wedge would strand the service",
+		)
+		fmt.Fprintln(os.Stderr, "-release is required")
+		os.Exit(2)
+	}
+
+	// A release file left behind by an earlier run would release the wedge
+	// immediately, which reads as "the service stopped fine" and would silently
+	// pass the scenario.
+	if _, err := os.Stat(*releasePath); err == nil {
+		logf("refusing to start: release file %s already exists", *releasePath)
+		fmt.Fprintf(os.Stderr, "release file %s already exists\n", *releasePath)
+		os.Exit(2)
+	}
+
+	logf("starting as service %q", *name)
+	if err := svc.Run(*name, &wedgedService{releasePath: *releasePath, logf: logf}); err != nil {
+		logf("svc.Run failed: %v", err)
+		fmt.Fprintf(os.Stderr, "svc.Run failed: %v\n", err)
+		os.Exit(1)
+	}
+	logf("service exited")
+}

--- a/test/wedgedservice/main_unsupported.go
+++ b/test/wedgedservice/main_unsupported.go
@@ -1,0 +1,19 @@
+//go:build integration && !windows
+
+// The wedgedservice fixture reproduces a Windows service stuck in
+// SERVICE_STOP_PENDING (sc-106108), a state with no equivalent on Linux or
+// macOS, where the service implementations do not poll for a stop at all. This
+// file exists only so the package still builds on those platforms - without it
+// `go build -tags integration ./...` and the linter fail on a package whose only
+// file is excluded by build constraints. See main.go for the fixture itself.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "wedgedservice is a Windows-only fixture")
+	os.Exit(1)
+}


### PR DESCRIPTION
## Problem

`windowsService.Stop()` polled the service state every 250 ms in an unbounded loop — no deadline, no iteration cap, no error path for "took too long":

```go
for {
    if status.State == svc.Stopped { return nil }
    time.Sleep(pollingInterval)
    status, err = winSvc.handle.Query()
    if err != nil { return err }
}
```

Every caller of `Stop()` is a blocking, user- or updater-initiated operation: `runUpdate`, `runConfig`, and `runUninstall`. So a service that never reaches `Stopped` — a wedged agent process, or Windows itself holding the service in `StopPending` behind a stuck operation — hung the caller forever.

The auto-updater runs unattended every 48 hours, which is what makes this customer-visible. If it stops a service that then fails to reach `Stopped`, the installer blocks before it logs anything further: the endpoint drops offline, the new binary is never written (`update.go` reaches the executable copy only downstream of the hung call), and the customer sees a device that went offline during a routine update with **no error anywhere**. Recovery needs hands on the endpoint. An operator running an interactive uninstall just sees the command hang with no output, and killing it can leave a partially removed installation.

Latent in all released versions through v1.5.0 and current `main`. Windows only — the Unix service implementations do not use this polling loop. No customer reports isolated to this cause; found via a reliability audit.

## Fix

`Stop()` now waits at most `serviceStopTimeout` (**5 minutes**) and otherwise returns an error naming the service, the deadline, and the last observed state:

```
service RewstRemoteAgent_<org> did not stop within 5m0s: last observed state StopPending
```

The bound is deliberately generous, and the constant's doc comment says why: **it exists to catch a wedge, not to race a normal shutdown.** A healthy agent finishes teardown in seconds, but it first drains whatever commands are in flight, and an operator can set `command_timeout_seconds` high enough that a single command legitimately runs for minutes. Five minutes sits far above any healthy shutdown while still failing an unattended update the same day it runs.

The loop distinguishes **"still stopping"** from **"will not stop"**. `StopPending` keeps being polled to the deadline; a state the service cannot reach `Stopped` from returns immediately rather than burning the full deadline. `Running` and `StartPending` count as still-stopping, because `ControlService` reports the status the service last published and can still show the pre-stop state before the service thread picks the control up — rejecting those would break healthy stops.

### Callers

All three already returned on a `Stop()` error, so the fix there is about what they *say* and one real bug:

- **`runUpdate`** aborts before any write and logs that the executable and config were not modified. This matters beyond tidiness: the old process may still hold the executable open, so overwriting it would either fail or leave a half-updated install. Leaving everything in place keeps the endpoint recoverable.
- **`runUninstall`** aborts before deleting the registration or any files, and logs `Uninstall aborted; nothing was removed` with `service_registration=intact installed_files=intact`.
- **`runConfig`** had a latent bug of exactly the kind this ticket is about. It reassigned `err` with `Close()`'s result before wrapping it, so a stop failure returned an error formatted from a `nil` wrapped error and **the actual reason vanished**. Close errors are now logged separately and the stop error is returned intact.

## Testing

**Unit tests** use a fake clock that advances only when the code under test sleeps, so bounded waits are deterministic and instant: a prompt stop (unchanged behavior), a service stuck in `StopPending` past the deadline, one that reaches `Stopped` on the *last* poll before the deadline (no spurious error), `Query` failing mid-poll, an unexpected terminal state failing with zero polls, `Running` being polled rather than rejected, and the timeout resolution order. Caller tests assert `runUpdate` writes no files and neither starts nor deletes the service after a failed stop, and that `runUninstall` removes no directories and leaves the registration.

`golangci-lint run` 0 issues. Coverage 88.4% locally (darwin, so the Windows-only lane is the one that counts — the PR's own coverage job covers it).

**Integration test** — a new Windows-only scenario, and the part worth a careful look.

The wedge is a purpose-built fixture, `test/wedgedservice`: a service that accepts the stop control, returns from its handler, reports `StopPending`, and never stops until a release file appears. It has to be purpose-built. Killing the agent makes the SCM report `Stopped` almost at once, which is the happy path; suspending its threads makes the SCM fail the control request outright rather than exercising the wait. Neither reaches the code under test. Which wedge it is does not matter — the ticket's own framing is that any wedge will do, because what is under test is the bound on the wait and not how the agent got stuck.

`.github/actions/wedged-service` registers the fixture under the agent's own service name by swapping that service's `ImagePath`, so the installed executable and config are untouched and can be hashed before and after. The swap goes through the registry rather than `sc.exe`, because the agent's command line carries quoted paths and pushing those back through `sc.exe`'s `keyword= value` parsing is a needless way to corrupt the registration the scenario has to restore. `mode=restore` reads the value back afterwards — a silently failed restore would leave the fixture reaching `Running`, which no later step could tell apart from a recovered agent.

The invoker is the integration binary, whose stop deadline is overridden to 25s by a new ldflags-injected `stopTimeoutOverrideStr`, mirroring the existing `sasTokenLifetimeOverrideStr`. Each wedged stop then costs seconds instead of five minutes; the production default is unchanged and covered by unit tests (resolution order is per-instance seam → override → constant, and a garbage or non-positive override falls back rather than disabling the bound).

Measured on `windows-latest` ([run 31451274395](https://github.com/RewstApp/agent-smith-go/actions/runs/31451274395), green first attempt, ~95s for the whole scenario):

| assertion | observed |
|---|---|
| `--update` aborts | 25.1s, `did not stop within 25s: last observed state StopPending` |
| installation untouched | exe `5AC33FB4…` and config `4B7354CA…` unchanged |
| `--uninstall` aborts | 25.1s, `nothing was removed`, registration + all 3 directories intact |
| recovery | ImagePath restored, resubscribed in ~2s |
| post-recovery update | `Agent installed to` + `Service started` — the bound only catches a wedge |

The `StopPending` result is the one I could not predict from a macOS host: it confirms `Query()` observes `StopPending`, so the polling wait is what ran, not the fast-fail branch.

## Docs

README gains a "Bounded Windows Service Stop (Windows only)" section covering the failure mode, the deadline and why it is sized as it is, the still-stopping vs will-not-stop distinction, what each caller does on abort, and the recovery procedure. `CLAUDE.md`'s `internal/service` entry points at it.

## Reviewer notes

- **The re-wedge step in the middle of the scenario is load-bearing, and it exposes an adjacent gap.** After a failed stop the service sits in `StopPending`, and `IsActive()` treats only `Running` as active — so an uninstall issued at that point skips the stop entirely and would delete files out from under a live process. The scenario starts a fresh wedged run so the uninstall meets a `Running` service, as an operator would. Fixing the underlying gap needs a state accessor on the cross-platform `Service` interface (and `IsActive`'s current meaning is the right one for diagnostic mode), so I left it out of scope. Worth its own ticket.
- **An aborted `--update` still exits 0.** The abort is reported through the log, not the exit status, so an unattended caller can only tell from the log. Not in the ACs and not changed here, but it is the kind of thing that would make the updater's own error handling possible later.
- **The 5-minute default is not exercised on a runner.** Doing so would mean five idle minutes per wedged stop, twice. The constant is unit-tested and the integration lane proves the mechanism at 25s.
- **The `runConfig` error-wrapping fix** is technically beyond the ticket's ACs, but it is the same class of defect (the reason a stop failed becoming invisible) on the third caller, and QA step 7 covers that path.
- **This ran on Windows only.** The scenario steps are all `if: matrix.os == 'windows-latest'`, and the ubuntu/macOS lanes are untouched by the agent-side change, but I have not confirmed a green `all` run if you would like one before merge.
- `test/wedgedservice` sits behind the `integration` build tag so its statements stay out of `go test ./...` and cannot count against the coverage threshold; it carries a non-Windows stub file so `go build -tags integration ./...` still works on Linux and macOS, where the package would otherwise have no buildable files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
