### PR TITLE
fix: [sc-106109] Wait for actual process exit before replacing or deleting agent files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,18 @@ Required tools:
   - Service mode: `--config-file --log-file --org-id` 
   - Uninstall mode: `--uninstall --org-id`
 
+  The install, update and uninstall paths never assume the old agent process has
+  exited: after stopping the service they wait (bounded, 2 minutes, documented)
+  for real exit signals — the service manager no longer reporting the service
+  active, no process still executing the agent binary, and the executable no
+  longer held open — and return as soon as the process is gone. Overrunning the
+  deadline aborts before writing or deleting anything, leaves the installation
+  intact, and restarts the service that was stopped so a failed update cannot
+  leave an endpoint offline. The agent executable and config file are written to a
+  temp file and atomically renamed into place, so a failed write leaves the
+  previous file byte-identical. See the README's "Waiting for the Old Agent
+  Process to Exit" section.
+
 - **internal/agent/**: Device configuration, installation paths, and OS-specific host information
 - **internal/interpreter/**: Command execution engine supporting both PowerShell and Bash interpreters  
 - **internal/mqtt/**: Azure IoT Hub MQTT client implementation with auto-reconnection

--- a/README.md
+++ b/README.md
@@ -448,6 +448,53 @@ Recovery is the ordinary one: end the wedged agent process, start the service, a
 re-run the update or uninstall. Linux and macOS are unaffected — their service
 implementations do not use this polling loop.
 
+### Waiting for the Old Agent Process to Exit
+
+Stopping the service is not the same as the old agent process being gone. Install,
+update and uninstall used to bridge that gap with a fixed `time.Sleep` of five
+seconds and then act regardless — overwriting the agent executable, or deleting
+the installation directory. On a loaded endpoint the old process is frequently
+still alive at the five second mark, because its shutdown legitimately drains the
+commands in flight, tears down MQTT and kills its plugin subprocesses one at a
+time. Windows then refuses to replace a running image, so the update failed with
+a sharing violation *after* the service was already stopped, leaving the device
+offline until someone intervened. Uninstall had the mirror-image problem: files
+deleted out from under a live process, leaving an installation that neither ran
+nor reinstalled.
+
+Nothing is written or deleted now until the process is observed to be gone:
+
+- The wait polls three **real signals**, all of which must clear: the service
+  manager no longer reports the service active, no running process is executing
+  the agent binary, and the executable is no longer held open as a running image
+  (a sharing violation on Windows, `ETXTBSY` on Linux). The three overlap on
+  purpose — the file signal is what actually blocks the write on Windows, but
+  macOS permits writing to a running image, and a service manager can report a
+  service stopped while its process is still winding down. An elapsed poll
+  interval is never by itself treated as evidence of anything.
+- It **returns as soon as the process is gone**, so a healthy update is faster
+  than the unconditional five second sleep it replaces, not slower.
+- It is bounded by a documented **2 minute** deadline, sized for a slow but
+  legitimate shutdown (many workers, long-running commands, several plugin
+  subprocesses). Overrunning it logs at `Error` what was still outstanding and for
+  how long, and the caller aborts rather than proceeding.
+- **Update** aborts before writing anything and leaves the installation fully
+  intact, then **restarts the service it stopped** so a failed update never leaves
+  the endpoint silently offline. **Uninstall** aborts before deleting the
+  registration or any files, and logs that nothing was removed. **Install**
+  (`--config`) aborts before deleting the existing registration and restarts the
+  service it stopped.
+- A probe that cannot run at all (a restrictive ACL, a process table that cannot
+  be enumerated) is logged once at `Warn` and the remaining signals are used. A
+  probe failure is not evidence a process is alive, and must not wedge every
+  update on an endpoint where it can never succeed.
+
+The agent executable and the config file are also written **atomically** — to a
+temporary file in the destination directory, then renamed into place, the same
+pattern the postback spool uses. An interrupted or failed write therefore leaves
+the previous file byte-identical rather than truncated: the endpoint keeps running
+the old agent instead of a binary that cannot start.
+
 ### Notification Plugin Supervision
 
 Notification plugins run as separate subprocesses reached over RPC, and every

--- a/cmd/agent_smith/config.go
+++ b/cmd/agent_smith/config.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
@@ -153,16 +152,20 @@ func runConfig(params *configContext) error {
 	// Got configuration
 	logger.Info("Received configuration", "configuration", string(configBytes))
 
-	err = params.FS.WriteFile(configFilePath, configBytes, utils.DefaultFileMod)
+	// Written atomically so a failed write cannot leave a truncated config file
+	// that the service is then unable to start from.
+	err = writeFileAtomic(params.FS, configFilePath, configBytes, utils.DefaultFileMod)
 	if err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
 	name := agent.GetServiceName(params.OrgId)
+	agentExecutablePath := agent.GetAgentExecutablePath(params.OrgId)
 
 	// Stop and delete the service if it already exists
 	existingService, err := params.ServiceManager.Open(name)
 	if err == nil {
+		stopped := false
 		if existingService.IsActive() {
 			logger.Info("Stopping service", "service", name)
 			// Abort before deleting the registration or overwriting the
@@ -179,6 +182,56 @@ func runConfig(params *configContext) error {
 				}
 				return fmt.Errorf("failed to stop service %s: %w", name, stopErr)
 			}
+			stopped = true
+		}
+
+		// Wait for the old process to actually exit before the registration is
+		// deleted and the executable is replaced. A process that is still running
+		// holds its own image open, so proceeding here is what fails the install
+		// with a sharing violation on Windows.
+		logger.Info(
+			"Waiting for the agent process to exit",
+			"service", name,
+			"agent_executable", agentExecutablePath,
+		)
+		if waitErr := waitForAgentProcessExit(
+			logger,
+			existingService,
+			params.FS,
+			agentExecutablePath,
+			params.exitWait,
+		); waitErr != nil {
+			// The config file was already refreshed above, so say so rather than
+			// claiming nothing changed: the installed agent and its registration are
+			// what had to be left alone while the old process is alive.
+			logger.Error(
+				"Install aborted; the existing agent and its service registration were left untouched",
+				"service",
+				name,
+				"agent_executable",
+				"not modified",
+				"service_registration",
+				"intact",
+				"config_file",
+				"updated",
+				"error",
+				waitErr,
+			)
+			// Put the endpoint back the way it was found rather than leaving a
+			// stopped service behind.
+			if stopped {
+				if startErr := existingService.Start(); startErr != nil {
+					logger.Error(
+						"Failed to restart service after aborted install; the endpoint is offline",
+						"service", name,
+						"error", startErr,
+					)
+				}
+			}
+			if closeErr := existingService.Close(); closeErr != nil {
+				logger.Error("Failed to close service handle", "service", name, "error", closeErr)
+			}
+			return fmt.Errorf("failed to wait for agent process to exit: %w", waitErr)
 		}
 
 		// Delete the service
@@ -188,13 +241,26 @@ func runConfig(params *configContext) error {
 		}
 		logger.Info("Service deleted", "service", name)
 
-		// Wait for some time for the service executable to clean up
 		err = existingService.Close()
 		if err != nil {
 			return fmt.Errorf("failed to close service %s: %w", name, err)
 		}
-		logger.Info("Waiting for service executable to stop")
-		time.Sleep(serviceExecutableTimeout)
+
+		// Wait for the deleted registration to be reaped so the name is free to
+		// register again. A registration that outlives the deadline is reported and
+		// creation is attempted anyway, which surfaces the real conflict.
+		logger.Info("Waiting for the service registration to be removed", "service", name)
+		if deregErr := waitForServiceDeregistration(
+			params.ServiceManager,
+			name,
+			params.exitWait,
+		); deregErr != nil {
+			logger.Error(
+				"Service registration outlived its deletion; registering anyway",
+				"service", name,
+				"error", deregErr,
+			)
+		}
 	}
 
 	logger.Info("Configuration saved to", "path", configFilePath)
@@ -218,8 +284,14 @@ func runConfig(params *configContext) error {
 		return fmt.Errorf("failed to read executable file: %w", err)
 	}
 
-	agentExecutablePath := agent.GetAgentExecutablePath(params.OrgId)
-	err = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
+	// Written atomically so a failure here leaves any previously installed binary
+	// byte-identical instead of truncated.
+	err = writeFileAtomic(
+		params.FS,
+		agentExecutablePath,
+		execFileBytes,
+		utils.DefaultExecutableFileMod,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create agent executable: %w", err)
 	}

--- a/cmd/agent_smith/config_context.go
+++ b/cmd/agent_smith/config_context.go
@@ -185,6 +185,11 @@ type configContext struct {
 	FS             utils.FileSystem
 	ServiceManager service.ServiceManager
 	HTTPClient     *http.Client
+
+	// exitWait holds the test seams for the bounded wait for the old agent
+	// process to exit. Zero values select the documented defaults, so nothing
+	// outside tests ever sets it.
+	exitWait exitWaitOptions
 }
 
 // newConfigFlagSet builds the flag set for config mode, binding flags to the

--- a/cmd/agent_smith/config_test.go
+++ b/cmd/agent_smith/config_test.go
@@ -74,6 +74,7 @@ func newBaseConfigParams(configURL string) *configContext {
 		Domain:         &mockDomainInfoProvider{},
 		FS:             newConfigTestFS(),
 		ServiceManager: newConfigTestServiceManager(),
+		exitWait:       stubExitWait(),
 	}
 }
 
@@ -270,6 +271,55 @@ func TestRunConfig_ExistingService_StopFails(t *testing.T) {
 
 	if err == nil || !strings.Contains(err.Error(), "failed to stop service") {
 		t.Errorf("expected 'failed to stop service' error, got %v", err)
+	}
+}
+
+// A pre-existing agent whose process never exits must abort the install before
+// the registration is deleted or the executable replaced, and the service it
+// stopped must be brought back up.
+func TestRunConfig_ExistingService_ProcessNeverExits(t *testing.T) {
+	srv := newConfigServer(t, http.StatusOK, validConfigResponseBody("test-org"))
+	defer srv.Close()
+
+	clock := newFakeClock()
+	params := newBaseConfigParams(srv.URL)
+	params.exitWait = clock.options(2*time.Minute, 250*time.Millisecond)
+	var renames [][2]string
+	params.FS = &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc:   func(string) ([]byte, error) { return []byte("binary"), nil },
+		writeFileFunc:  func(string, []byte, os.FileMode) error { return nil },
+		mkdirAllFunc:   func(string) error { return nil },
+		removeAllFunc:  func(string) error { return nil },
+		renameFunc: func(oldPath string, newPath string) error {
+			renames = append(renames, [2]string{oldPath, newPath})
+			return nil
+		},
+		// The old process holds its image open for as long as it lives.
+		executableInUseFunc: func(string) (bool, error) { return true, nil },
+	}
+	existing := &mockService{isActive: true}
+	params.ServiceManager = &mockServiceManager{
+		openService:   existing,
+		createService: &mockService{},
+	}
+
+	err := runConfig(params)
+
+	if err == nil || !strings.Contains(err.Error(), "failed to wait for agent process to exit") {
+		t.Errorf("expected the install to abort on the exit wait, got %v", err)
+	}
+	if existing.deleteCalled {
+		t.Error("expected the existing service registration to be left alone")
+	}
+	if !existing.startCalled {
+		t.Error("expected the existing service to be restarted rather than left stopped")
+	}
+	agentExecutablePath := agent.GetAgentExecutablePath("test-org")
+	for _, rename := range renames {
+		if rename[1] == agentExecutablePath {
+			t.Error("expected the agent executable never to be replaced while the process is alive")
+		}
 	}
 }
 

--- a/cmd/agent_smith/main_test.go
+++ b/cmd/agent_smith/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"github.com/RewstApp/agent-smith-go/internal/service"
@@ -68,11 +69,14 @@ func (mock *mockDomainInfoProvider) EntraDomain(context.Context) (*string, error
 }
 
 type mockFileSystem struct {
-	executableFunc func() (string, error)
-	readFileFunc   func(name string) ([]byte, error)
-	writeFileFunc  func(name string, data []byte, perm os.FileMode) error
-	mkdirAllFunc   func(path string) error
-	removeAllFunc  func(path string) error
+	executableFunc      func() (string, error)
+	readFileFunc        func(name string) ([]byte, error)
+	writeFileFunc       func(name string, data []byte, perm os.FileMode) error
+	mkdirAllFunc        func(path string) error
+	removeAllFunc       func(path string) error
+	renameFunc          func(oldPath string, newPath string) error
+	removeFunc          func(name string) error
+	executableInUseFunc func(name string) (bool, error)
 }
 
 func (m *mockFileSystem) Executable() (string, error) {
@@ -95,21 +99,59 @@ func (m *mockFileSystem) RemoveAll(path string) error {
 	return m.removeAllFunc(path)
 }
 
+// Rename, Remove and ExecutableInUse default to the behaviour of a filesystem
+// where the write commits and no process holds the executable, so tests only
+// override them when the case under test is about those.
+func (m *mockFileSystem) Rename(oldPath string, newPath string) error {
+	if m.renameFunc == nil {
+		return nil
+	}
+	return m.renameFunc(oldPath, newPath)
+}
+
+func (m *mockFileSystem) Remove(name string) error {
+	if m.removeFunc == nil {
+		return nil
+	}
+	return m.removeFunc(name)
+}
+
+func (m *mockFileSystem) ExecutableInUse(name string) (bool, error) {
+	if m.executableInUseFunc == nil {
+		return false, nil
+	}
+	return m.executableInUseFunc(name)
+}
+
 type mockService struct {
 	isActive  bool
 	stopErr   error
 	deleteErr error
 	startErr  error
+	// isActiveFunc overrides isActive when a test needs the reported state to
+	// change from one observation to the next, as a service that is still
+	// shutting down does.
+	isActiveFunc func() bool
 
 	stopCalled   bool
 	deleteCalled bool
 	startCalled  bool
 }
 
-func (m *mockService) IsActive() bool { return m.isActive }
+func (m *mockService) IsActive() bool {
+	if m.isActiveFunc != nil {
+		return m.isActiveFunc()
+	}
+	return m.isActive
+}
 
+// Stop mirrors a real service manager: a stop that reports success means the
+// service reached Stopped, so it no longer reports itself active.
 func (m *mockService) Stop() error {
 	m.stopCalled = true
+	if m.stopErr == nil {
+		m.isActive = false
+	}
 	return m.stopErr
 }
 
@@ -131,10 +173,18 @@ type mockServiceManager struct {
 	createErr     error
 	createService service.Service
 
+	openCalls   int
 	createCalls []service.AgentParams
 }
 
 func (m *mockServiceManager) Open(name string) (service.Service, error) {
+	m.openCalls++
+	if svc, ok := m.openService.(*mockService); ok && svc.deleteCalled {
+		// A deleted registration is no longer visible to the manager. That is the
+		// signal the deregistration wait polls for, so the mock has to reproduce it
+		// or the wait would have nothing to observe.
+		return nil, errors.New("service does not exist")
+	}
 	return m.openService, m.openErr
 }
 

--- a/cmd/agent_smith/process_exit.go
+++ b/cmd/agent_smith/process_exit.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/service"
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+	"github.com/hashicorp/go-hclog"
+)
+
+const (
+	// agentProcessExitTimeout bounds how long install, update and uninstall wait
+	// for the old agent process to actually exit before replacing or deleting its
+	// files.
+	//
+	// The wait returns as soon as the process is gone, so a healthy endpoint pays
+	// only the time its shutdown genuinely takes — normally a fraction of a
+	// second. The deadline exists to catch a process that never exits, and is
+	// sized for a shutdown that is slow but legitimate: the agent drains the
+	// commands in flight, tears down the MQTT connection, and kills its plugin
+	// subprocesses one at a time, each waiting out go-plugin's graceful-exit
+	// grace period. Two minutes sits far above any healthy shutdown while still
+	// failing an unattended update the same run it started, with an actionable
+	// error.
+	agentProcessExitTimeout = 2 * time.Minute
+
+	// agentProcessExitPollInterval is how often the wait re-observes the exit
+	// signals. It only controls how quickly a completed exit is noticed; the wait
+	// never treats an elapsed interval as evidence of anything.
+	agentProcessExitPollInterval = 250 * time.Millisecond
+
+	// serviceDeregisterTimeout bounds how long the update path waits for a
+	// deleted service registration to disappear before re-registering the service
+	// under a new account. On Windows the Service Control Manager only reaps the
+	// registration once every handle to it is closed, so the name can stay
+	// visible briefly after Delete returns.
+	serviceDeregisterTimeout = 30 * time.Second
+)
+
+// exitTimeoutOverrideStr is overridable via -ldflags for integration testing and
+// QA. When set to a valid, positive Go duration it replaces
+// agentProcessExitTimeout, so a process that never exits can be observed being
+// given up on in seconds rather than the production two minutes. It is empty in
+// production builds.
+// Example: -ldflags "-X main.exitTimeoutOverrideStr=25s"
+var exitTimeoutOverrideStr = ""
+
+// resolveExitTimeout returns the deadline the exit wait uses: the
+// ldflags-injected override when a build sets a valid one, otherwise the
+// documented agentProcessExitTimeout.
+func resolveExitTimeout() time.Duration {
+	if exitTimeoutOverrideStr != "" {
+		if timeout, err := time.ParseDuration(exitTimeoutOverrideStr); err == nil && timeout > 0 {
+			return timeout
+		}
+	}
+	return agentProcessExitTimeout
+}
+
+// exitWaitOptions are the test seams for the bounded waits below. Zero values
+// select the documented package defaults, so production code never sets them.
+type exitWaitOptions struct {
+	timeout           time.Duration
+	deregisterTimeout time.Duration
+	pollInterval      time.Duration
+	now               func() time.Time
+	sleep             func(time.Duration)
+	// processRunning reports whether a process is still executing the agent
+	// binary. It defaults to a scan of the running processes.
+	processRunning func(path string) (bool, error)
+}
+
+// resolved returns a copy with every unset field replaced by its default.
+func (opts exitWaitOptions) resolved() exitWaitOptions {
+	if opts.timeout <= 0 {
+		opts.timeout = resolveExitTimeout()
+	}
+	if opts.deregisterTimeout <= 0 {
+		opts.deregisterTimeout = serviceDeregisterTimeout
+	}
+	if opts.pollInterval <= 0 {
+		opts.pollInterval = agentProcessExitPollInterval
+	}
+	if opts.now == nil {
+		opts.now = time.Now
+	}
+	if opts.sleep == nil {
+		opts.sleep = time.Sleep
+	}
+	if opts.processRunning == nil {
+		opts.processRunning = utils.ProcessRunningFromExecutable
+	}
+	return opts
+}
+
+// waitForAgentProcessExit blocks until the old agent process is really gone. It
+// waits on three direct observations of the process, all of which must clear:
+// the service manager no longer reports the service active, no process is still
+// executing the agent binary, and the executable is no longer held open as a
+// running image. The wait never concludes "exited" merely because a poll
+// interval or a fixed sleep elapsed, which is what made a five second sleep race
+// a slow shutdown and fail the update with a sharing violation.
+//
+// The three overlap deliberately: the file signal is what actually blocks the
+// write on Windows, but macOS lets a running image be opened for writing, and a
+// service manager can report a service stopped while its process is still
+// winding down.
+//
+// It returns as soon as every signal holds, so an endpoint that shuts down
+// promptly costs a single round of probes rather than an unconditional wait. If
+// any signal is still outstanding at the deadline it returns an error naming
+// what it was still waiting for and for how long, and the caller aborts without
+// touching the installation.
+func waitForAgentProcessExit(
+	logger hclog.Logger,
+	svc service.Service,
+	fsys utils.FileSystem,
+	executablePath string,
+	opts exitWaitOptions,
+) error {
+	opts = opts.resolved()
+
+	start := opts.now()
+	deadline := start.Add(opts.timeout)
+	fileProbeErrorLogged := false
+	processProbeErrorLogged := false
+
+	for {
+		var pending []string
+
+		if svc != nil && svc.IsActive() {
+			pending = append(pending, "the service manager still reports the service active")
+		}
+
+		running, err := opts.processRunning(executablePath)
+		switch {
+		case err != nil:
+			// Same reasoning as the file probe below: a scan that could not run is
+			// not evidence either way, so it must not pin the wait open.
+			if !processProbeErrorLogged {
+				logger.Warn(
+					"Cannot scan for the agent process; relying on the remaining signals",
+					"path", executablePath,
+					"error", err,
+				)
+				processProbeErrorLogged = true
+			}
+		case running:
+			pending = append(
+				pending,
+				fmt.Sprintf("a process is still running %s", executablePath),
+			)
+		}
+
+		inUse, err := fsys.ExecutableInUse(executablePath)
+		switch {
+		case err != nil:
+			// The probe itself could not run (a restrictive ACL, an unreadable
+			// parent directory). That is not evidence the process is alive, and the
+			// executable replacement is atomic either way, so fall back to the
+			// remaining signals rather than blocking every update on a probe that
+			// can never succeed on this endpoint.
+			if !fileProbeErrorLogged {
+				logger.Warn(
+					"Cannot probe whether the agent executable is still open; relying on the remaining signals",
+					"path",
+					executablePath,
+					"error",
+					err,
+				)
+				fileProbeErrorLogged = true
+			}
+		case inUse:
+			pending = append(
+				pending,
+				fmt.Sprintf("the agent executable %s is still held open", executablePath),
+			)
+		}
+
+		if len(pending) == 0 {
+			logger.Info(
+				"Agent process exited",
+				"waited",
+				opts.now().Sub(start).Round(time.Millisecond).String(),
+			)
+			return nil
+		}
+
+		if !opts.now().Before(deadline) {
+			return fmt.Errorf(
+				"agent process did not exit within %s: %s",
+				opts.timeout,
+				strings.Join(pending, "; "),
+			)
+		}
+
+		opts.sleep(opts.pollInterval)
+	}
+}
+
+// waitForServiceDeregistration blocks until the service manager no longer knows
+// about name, which is the real signal that a deleted registration has been
+// reaped and the name is free to register again. Each probe closes its handle
+// immediately, since on Windows an open handle is itself what keeps a deleted
+// registration alive.
+//
+// Overrunning the deadline is reported to the caller rather than being treated
+// as success; the caller decides whether re-registering anyway is better than
+// leaving the endpoint with no service at all.
+func waitForServiceDeregistration(
+	mgr service.ServiceManager,
+	name string,
+	opts exitWaitOptions,
+) error {
+	opts = opts.resolved()
+
+	deadline := opts.now().Add(opts.deregisterTimeout)
+	for {
+		svc, err := mgr.Open(name)
+		if err != nil {
+			// The manager no longer knows the service: the registration is gone.
+			return nil
+		}
+		if svc != nil {
+			_ = svc.Close()
+		}
+
+		if !opts.now().Before(deadline) {
+			return fmt.Errorf(
+				"service %s was still registered %s after it was deleted",
+				name,
+				opts.deregisterTimeout,
+			)
+		}
+
+		opts.sleep(opts.pollInterval)
+	}
+}
+
+// writeFileAtomic writes data to path without ever exposing a partially written
+// file: the bytes go to a temporary file alongside the destination and are then
+// renamed into place, which is a single atomic operation on every platform the
+// agent runs on. A failed or interrupted write therefore leaves the previous
+// file byte-identical instead of truncated — the same pattern the postback spool
+// uses for its entries.
+//
+// The temporary file lives in the destination directory so the rename never
+// crosses a filesystem boundary.
+func writeFileAtomic(fsys utils.FileSystem, path string, data []byte, perm os.FileMode) error {
+	tempPath := path + ".new"
+
+	if err := fsys.WriteFile(tempPath, data, perm); err != nil {
+		return err
+	}
+
+	if err := fsys.Rename(tempPath, path); err != nil {
+		// Leave the destination as it was and take the half-written temp file with
+		// us, so a retry does not inherit it.
+		if removeErr := fsys.Remove(tempPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("%w (temporary file %s left behind: %v)", err, tempPath, removeErr)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/cmd/agent_smith/process_exit_test.go
+++ b/cmd/agent_smith/process_exit_test.go
@@ -1,0 +1,475 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RewstApp/agent-smith-go/internal/utils"
+)
+
+// fakeClock drives the bounded waits without ever sleeping, so a test can burn a
+// two minute deadline instantly and still assert exactly how much waiting the
+// code asked for.
+type fakeClock struct {
+	current time.Time
+	slept   time.Duration
+	sleeps  int
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{current: time.Unix(0, 0)}
+}
+
+func (c *fakeClock) Now() time.Time { return c.current }
+
+func (c *fakeClock) Sleep(d time.Duration) {
+	c.slept += d
+	c.sleeps++
+	c.current = c.current.Add(d)
+}
+
+func (c *fakeClock) options(timeout time.Duration, poll time.Duration) exitWaitOptions {
+	return exitWaitOptions{
+		timeout:           timeout,
+		deregisterTimeout: timeout,
+		pollInterval:      poll,
+		now:               c.Now,
+		sleep:             c.Sleep,
+		processRunning:    noProcessRunning,
+	}
+}
+
+// noProcessRunning stands in for the process-table scan in tests that are about
+// the other signals, so they neither sweep the real process table nor depend on
+// what happens to be running on the machine.
+func noProcessRunning(string) (bool, error) { return false, nil }
+
+// stubExitWait keeps the documented defaults for everything except the process
+// scan, which unit tests must not perform against the real machine.
+func stubExitWait() exitWaitOptions {
+	return exitWaitOptions{processRunning: noProcessRunning}
+}
+
+// ── waitForAgentProcessExit ───────────────────────────────────────────────────
+
+// A process that is already gone must cost nothing: the whole point of replacing
+// the fixed five second sleep is that a healthy update gets faster, not slower.
+func TestWaitForAgentProcessExit_ExitsImmediately(t *testing.T) {
+	clock := newFakeClock()
+	probes := 0
+	fsys := &mockFileSystem{
+		executableInUseFunc: func(string) (bool, error) {
+			probes++
+			return false, nil
+		},
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: false},
+		fsys,
+		"/opt/rewst/agent",
+		clock.options(2*time.Minute, 250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to succeed, got %v", err)
+	}
+	if clock.sleeps != 0 {
+		t.Errorf(
+			"expected no waiting for a process that already exited, slept %d times",
+			clock.sleeps,
+		)
+	}
+	if probes != 1 {
+		t.Errorf("expected a single executable probe, got %d", probes)
+	}
+}
+
+// A process that takes a few polls to release the executable must be waited out
+// and then proceed — this is the slow-drain endpoint the fixed sleep raced.
+func TestWaitForAgentProcessExit_ExitsPartwayThrough(t *testing.T) {
+	clock := newFakeClock()
+	activeChecks := 0
+	probes := 0
+	svc := &mockService{isActive: true}
+	fsys := &mockFileSystem{
+		executableInUseFunc: func(string) (bool, error) {
+			probes++
+			// The image stays open for two polls after the service reports stopped.
+			return probes <= 4, nil
+		},
+	}
+
+	// The service reports active for the first two observations, then stopped.
+	svcActive := func() bool {
+		activeChecks++
+		return activeChecks <= 2
+	}
+	svc.isActiveFunc = svcActive
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		svc,
+		fsys,
+		"/opt/rewst/agent",
+		clock.options(2*time.Minute, 250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to succeed once the process exited, got %v", err)
+	}
+	if clock.sleeps != 4 {
+		t.Errorf("expected 4 polls before both signals cleared, got %d", clock.sleeps)
+	}
+	if clock.slept >= 2*time.Minute {
+		t.Errorf("expected the wait to return well inside the deadline, waited %s", clock.slept)
+	}
+}
+
+// A process that never exits must be given up on at the deadline with an error
+// naming what was still outstanding, so the caller can abort before writing.
+func TestWaitForAgentProcessExit_NeverExits(t *testing.T) {
+	clock := newFakeClock()
+	fsys := &mockFileSystem{
+		executableInUseFunc: func(string) (bool, error) { return true, nil },
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: true},
+		fsys,
+		"/opt/rewst/agent",
+		clock.options(2*time.Minute, 250*time.Millisecond),
+	)
+	if err == nil {
+		t.Fatal("expected an error when the process never exits")
+	}
+	if !strings.Contains(err.Error(), "2m0s") {
+		t.Errorf("expected the deadline in the error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "/opt/rewst/agent") {
+		t.Errorf("expected the executable path in the error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "still reports the service active") {
+		t.Errorf("expected the service state in the error, got %q", err)
+	}
+	if clock.slept < 2*time.Minute {
+		t.Errorf("expected the full deadline to be waited out, waited %s", clock.slept)
+	}
+	if clock.slept > 2*time.Minute+250*time.Millisecond {
+		t.Errorf("expected the wait to stay bounded by the deadline, waited %s", clock.slept)
+	}
+}
+
+// The wait must not conclude "still running" from a probe that could not run at
+// all: an unreadable path is not evidence of a live process, and the atomic
+// write covers the residual risk.
+func TestWaitForAgentProcessExit_ProbeErrorFallsBackToServiceState(t *testing.T) {
+	clock := newFakeClock()
+	fsys := &mockFileSystem{
+		executableInUseFunc: func(string) (bool, error) {
+			return false, errors.New("permission denied")
+		},
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: false},
+		fsys,
+		"/opt/rewst/agent",
+		clock.options(time.Minute, 250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to fall back to the service state, got %v", err)
+	}
+	if clock.sleeps != 0 {
+		t.Errorf(
+			"expected no waiting when the service is already stopped, slept %d times",
+			clock.sleeps,
+		)
+	}
+}
+
+// A process that is still executing the agent binary keeps the wait open even
+// when the service manager and the file lock both say otherwise — the case that
+// matters on macOS, where a running image can be opened for writing.
+func TestWaitForAgentProcessExit_WaitsForRunningProcess(t *testing.T) {
+	clock := newFakeClock()
+	scans := 0
+	opts := clock.options(2*time.Minute, 250*time.Millisecond)
+	opts.processRunning = func(string) (bool, error) {
+		scans++
+		return scans <= 3, nil
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: false},
+		&mockFileSystem{},
+		"/opt/rewst/agent",
+		opts,
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to succeed once the process was gone, got %v", err)
+	}
+	if clock.sleeps != 3 {
+		t.Errorf("expected 3 polls while the process was still running, got %d", clock.sleeps)
+	}
+}
+
+func TestWaitForAgentProcessExit_ProcessOutlivesDeadline(t *testing.T) {
+	clock := newFakeClock()
+	opts := clock.options(2*time.Minute, 250*time.Millisecond)
+	opts.processRunning = func(string) (bool, error) { return true, nil }
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: false},
+		&mockFileSystem{},
+		"/opt/rewst/agent",
+		opts,
+	)
+	if err == nil {
+		t.Fatal("expected an error when a process keeps running the agent binary")
+	}
+	if !strings.Contains(err.Error(), "a process is still running /opt/rewst/agent") {
+		t.Errorf("expected the live process named in the error, got %q", err)
+	}
+}
+
+// A process scan that cannot run is not evidence either way and must not pin the
+// wait open until the deadline.
+func TestWaitForAgentProcessExit_ProcessScanErrorFallsBack(t *testing.T) {
+	clock := newFakeClock()
+	opts := clock.options(time.Minute, 250*time.Millisecond)
+	opts.processRunning = func(string) (bool, error) {
+		return false, errors.New("cannot enumerate processes")
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		&mockService{isActive: false},
+		&mockFileSystem{},
+		"/opt/rewst/agent",
+		opts,
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to fall back to the remaining signals, got %v", err)
+	}
+	if clock.sleeps != 0 {
+		t.Errorf("expected no waiting, slept %d times", clock.sleeps)
+	}
+}
+
+// A missing service handle (the registration is already gone) leaves the
+// executable probe as the only signal, which must still be honoured.
+func TestWaitForAgentProcessExit_NilServiceUsesExecutableSignal(t *testing.T) {
+	clock := newFakeClock()
+	probes := 0
+	fsys := &mockFileSystem{
+		executableInUseFunc: func(string) (bool, error) {
+			probes++
+			return probes <= 2, nil
+		},
+	}
+
+	err := waitForAgentProcessExit(
+		utils.ConfigureLogger("test", os.Stdout, utils.Default),
+		nil,
+		fsys,
+		"/opt/rewst/agent",
+		clock.options(time.Minute, 250*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("expected the wait to succeed, got %v", err)
+	}
+	if clock.sleeps != 2 {
+		t.Errorf("expected 2 polls while the executable was held open, got %d", clock.sleeps)
+	}
+}
+
+func TestWaitForAgentProcessExit_DefaultsAreDocumentedValues(t *testing.T) {
+	opts := exitWaitOptions{}.resolved()
+	if opts.timeout != agentProcessExitTimeout {
+		t.Errorf("expected the default timeout %s, got %s", agentProcessExitTimeout, opts.timeout)
+	}
+	if opts.timeout <= 5*time.Second {
+		t.Errorf(
+			"expected a deadline substantially longer than the old 5s sleep, got %s",
+			opts.timeout,
+		)
+	}
+	if opts.pollInterval != agentProcessExitPollInterval {
+		t.Errorf(
+			"expected the default poll interval %s, got %s",
+			agentProcessExitPollInterval,
+			opts.pollInterval,
+		)
+	}
+}
+
+// ── waitForServiceDeregistration ──────────────────────────────────────────────
+
+func TestWaitForServiceDeregistration_AlreadyGone(t *testing.T) {
+	clock := newFakeClock()
+	mgr := &mockServiceManager{openErr: errors.New("service does not exist")}
+
+	if err := waitForServiceDeregistration(
+		mgr,
+		"svc",
+		clock.options(time.Minute, time.Second),
+	); err != nil {
+		t.Fatalf("expected success when the registration is already gone, got %v", err)
+	}
+	if clock.sleeps != 0 {
+		t.Errorf("expected no waiting, slept %d times", clock.sleeps)
+	}
+}
+
+func TestWaitForServiceDeregistration_NeverDisappears(t *testing.T) {
+	clock := newFakeClock()
+	mgr := &mockServiceManager{openService: &mockService{}}
+
+	err := waitForServiceDeregistration(mgr, "svc", clock.options(30*time.Second, time.Second))
+	if err == nil {
+		t.Fatal("expected an error when the registration outlives the deadline")
+	}
+	if !strings.Contains(err.Error(), "svc") {
+		t.Errorf("expected the service name in the error, got %q", err)
+	}
+	if clock.slept < 30*time.Second {
+		t.Errorf("expected the full deadline to be waited out, waited %s", clock.slept)
+	}
+}
+
+// ── writeFileAtomic ───────────────────────────────────────────────────────────
+
+func TestWriteFileAtomic_ReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	if err := os.WriteFile(path, []byte("old binary"), utils.DefaultExecutableFileMod); err != nil {
+		t.Fatalf("failed to seed the file: %v", err)
+	}
+
+	err := writeFileAtomic(
+		utils.NewFileSystem(),
+		path,
+		[]byte("new binary"),
+		utils.DefaultExecutableFileMod,
+	)
+	if err != nil {
+		t.Fatalf("expected the write to succeed, got %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read the file back: %v", err)
+	}
+	if string(got) != "new binary" {
+		t.Errorf("expected the new contents, got %q", got)
+	}
+	if _, err := os.Stat(path + ".new"); !os.IsNotExist(err) {
+		t.Errorf("expected the temporary file to be gone, stat returned %v", err)
+	}
+}
+
+// failingRenameFS commits nothing: it models the destination being unwritable at
+// the moment of the rename, which is exactly the sharing violation Windows
+// raises when the old process is still holding the image.
+type failingRenameFS struct {
+	utils.FileSystem
+}
+
+func (f *failingRenameFS) Rename(string, string) error {
+	return errors.New("sharing violation")
+}
+
+// A failed commit must leave the installed binary byte-identical rather than
+// truncated: the endpoint keeps running the old agent instead of nothing at all.
+func TestWriteFileAtomic_FailedCommitLeavesOriginalIntact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	original := []byte("old binary contents")
+	if err := os.WriteFile(path, original, utils.DefaultExecutableFileMod); err != nil {
+		t.Fatalf("failed to seed the file: %v", err)
+	}
+
+	fsys := &failingRenameFS{FileSystem: utils.NewFileSystem()}
+	err := writeFileAtomic(fsys, path, []byte("new"), utils.DefaultExecutableFileMod)
+	if err == nil {
+		t.Fatal("expected the write to fail")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read the file back: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("expected the original contents preserved, got %q", got)
+	}
+	if _, err := os.Stat(path + ".new"); !os.IsNotExist(err) {
+		t.Errorf("expected the temporary file to be cleaned up, stat returned %v", err)
+	}
+}
+
+func TestWriteFileAtomic_WriteFailureLeavesOriginalIntact(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent")
+	original := []byte("old binary contents")
+	if err := os.WriteFile(path, original, utils.DefaultExecutableFileMod); err != nil {
+		t.Fatalf("failed to seed the file: %v", err)
+	}
+
+	fsys := &mockFileSystem{
+		writeFileFunc: func(name string, _ []byte, _ os.FileMode) error {
+			if !strings.HasSuffix(name, ".new") {
+				t.Errorf("expected the write to target a temporary file, got %q", name)
+			}
+			return errors.New("no space left on device")
+		},
+	}
+
+	if err := writeFileAtomic(
+		fsys,
+		path,
+		[]byte("new"),
+		utils.DefaultExecutableFileMod,
+	); err == nil {
+		t.Fatal("expected the write to fail")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read the file back: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("expected the original contents preserved, got %q", got)
+	}
+}
+
+func TestResolveExitTimeout(t *testing.T) {
+	original := exitTimeoutOverrideStr
+	defer func() { exitTimeoutOverrideStr = original }()
+
+	// Production builds leave the override empty and get the documented deadline.
+	exitTimeoutOverrideStr = ""
+	if got := resolveExitTimeout(); got != agentProcessExitTimeout {
+		t.Errorf("expected the documented deadline %s, got %s", agentProcessExitTimeout, got)
+	}
+
+	exitTimeoutOverrideStr = "25s"
+	if got := resolveExitTimeout(); got != 25*time.Second {
+		t.Errorf("expected the injected deadline 25s, got %s", got)
+	}
+
+	// An unparseable or non-positive override must not disable the bound.
+	for _, invalid := range []string{"not-a-duration", "0s", "-5s"} {
+		exitTimeoutOverrideStr = invalid
+		if got := resolveExitTimeout(); got != agentProcessExitTimeout {
+			t.Errorf("expected %q to fall back to the documented deadline, got %s", invalid, got)
+		}
+	}
+}

--- a/cmd/agent_smith/uninstall.go
+++ b/cmd/agent_smith/uninstall.go
@@ -3,14 +3,11 @@ package main
 import (
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/RewstApp/agent-smith-go/internal/version"
 )
-
-const serviceExecutableTimeout = time.Second * 5
 
 func runUninstall(params *uninstallContext) {
 	logger := utils.ConfigureLogger("agent_smith", os.Stdout, utils.Default)
@@ -32,6 +29,8 @@ func runUninstall(params *uninstallContext) {
 		}
 	}()
 
+	agentExecutablePath := agent.GetAgentExecutablePath(params.OrgId)
+
 	if service.IsActive() {
 		logger.Info("Stopping service", "service", name)
 		err = service.Stop()
@@ -52,6 +51,37 @@ func runUninstall(params *uninstallContext) {
 		logger.Info("Service stopped", "service", name)
 	}
 
+	// Wait for the old process to actually exit before removing anything. Files
+	// deleted out from under a live process leave a partially removed install
+	// that neither runs nor reinstalls cleanly, so the deletion only starts once
+	// the process is observably gone.
+	logger.Info(
+		"Waiting for the agent process to exit",
+		"service", name,
+		"agent_executable", agentExecutablePath,
+	)
+	if err := waitForAgentProcessExit(
+		logger,
+		service,
+		params.FS,
+		agentExecutablePath,
+		params.exitWait,
+	); err != nil {
+		logger.Error(
+			"Agent process did not exit",
+			"service", name,
+			"agent_executable", agentExecutablePath,
+			"error", err,
+		)
+		logger.Error(
+			"Uninstall aborted; nothing was removed",
+			"service", name,
+			"service_registration", "intact",
+			"installed_files", "intact",
+		)
+		return
+	}
+
 	// Delete the service
 	err = service.Delete()
 	if err != nil {
@@ -59,10 +89,6 @@ func runUninstall(params *uninstallContext) {
 		return
 	}
 	logger.Info("Service deleted", "service", name)
-
-	// Wait for some time for the service executable to clean up
-	logger.Info("Waiting for service executable to stop")
-	time.Sleep(serviceExecutableTimeout)
 
 	// Delete data directory
 	dataDir := agent.GetDataDirectory(params.OrgId)

--- a/cmd/agent_smith/uninstall_context.go
+++ b/cmd/agent_smith/uninstall_context.go
@@ -15,6 +15,11 @@ type uninstallContext struct {
 
 	ServiceManager service.ServiceManager
 	FS             utils.FileSystem
+
+	// exitWait holds the test seams for the bounded wait for the old agent
+	// process to exit. Zero values select the documented defaults, so nothing
+	// outside tests ever sets it.
+	exitWait exitWaitOptions
 }
 
 // newUninstallFlagSet builds the flag set for uninstall mode, binding flags to

--- a/cmd/agent_smith/uninstall_test.go
+++ b/cmd/agent_smith/uninstall_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func newUninstallTestFS() *mockFileSystem {
@@ -15,7 +16,8 @@ func newUninstallTestFS() *mockFileSystem {
 
 func TestRunUninstall_OpenFails(t *testing.T) {
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openErr: errors.New("service not found"),
 		},
@@ -27,7 +29,8 @@ func TestRunUninstall_OpenFails(t *testing.T) {
 
 func TestRunUninstall_StopFails(t *testing.T) {
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: true, stopErr: errors.New("stop failed")},
 		},
@@ -51,6 +54,7 @@ func TestRunUninstall_StopFails_RemovesNothing(t *testing.T) {
 	}
 	params := &uninstallContext{
 		OrgId:          "test-org",
+		exitWait:       stubExitWait(),
 		ServiceManager: &mockServiceManager{openService: svc},
 		FS: &mockFileSystem{
 			removeAllFunc: func(path string) error {
@@ -75,7 +79,8 @@ func TestRunUninstall_StopFails_RemovesNothing(t *testing.T) {
 
 func TestRunUninstall_ActiveService_DeleteFails(t *testing.T) {
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: true, deleteErr: errors.New("delete failed")},
 		},
@@ -87,7 +92,8 @@ func TestRunUninstall_ActiveService_DeleteFails(t *testing.T) {
 
 func TestRunUninstall_InactiveService_DeleteFails(t *testing.T) {
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: false, deleteErr: errors.New("delete failed")},
 		},
@@ -97,13 +103,98 @@ func TestRunUninstall_InactiveService_DeleteFails(t *testing.T) {
 	runUninstall(params)
 }
 
-// ── post-delete tests (run in parallel to share the serviceExecutableTimeout delay) ──
+// A process that never exits must abort the uninstall before anything is
+// removed: deleting files out from under a live process is what leaves a
+// half-removed installation that neither runs nor reinstalls.
+func TestRunUninstall_ProcessNeverExits_RemovesNothing(t *testing.T) {
+	clock := newFakeClock()
+	var removed []string
+	svc := &mockService{isActive: true}
+	params := &uninstallContext{
+		OrgId:          "test-org",
+		ServiceManager: &mockServiceManager{openService: svc},
+		exitWait:       clock.options(2*time.Minute, 250*time.Millisecond),
+		FS: &mockFileSystem{
+			removeAllFunc: func(path string) error {
+				removed = append(removed, path)
+				return nil
+			},
+			// The old process holds its image open for as long as it lives.
+			executableInUseFunc: func(string) (bool, error) { return true, nil },
+		},
+	}
+
+	runUninstall(params)
+
+	if !svc.stopCalled {
+		t.Error("expected Stop to be attempted")
+	}
+	if svc.deleteCalled {
+		t.Error("expected the service registration to survive an aborted uninstall")
+	}
+	if len(removed) != 0 {
+		t.Errorf("expected no directories removed while the process is alive, got %v", removed)
+	}
+	if clock.slept < 2*time.Minute {
+		t.Errorf("expected the full deadline to be waited out, waited %s", clock.slept)
+	}
+}
+
+// A slow but healthy shutdown must be waited out and then removed completely —
+// nothing is deleted until the process is observably gone.
+func TestRunUninstall_WaitsForExitBeforeRemoving(t *testing.T) {
+	clock := newFakeClock()
+	probes := 0
+	var removed []string
+	probesWhenFirstRemoved := -1
+	svc := &mockService{isActive: true}
+	params := &uninstallContext{
+		OrgId:          "test-org",
+		ServiceManager: &mockServiceManager{openService: svc},
+		exitWait:       clock.options(2*time.Minute, 250*time.Millisecond),
+		FS: &mockFileSystem{
+			removeAllFunc: func(path string) error {
+				if probesWhenFirstRemoved == -1 {
+					probesWhenFirstRemoved = probes
+				}
+				removed = append(removed, path)
+				return nil
+			},
+			executableInUseFunc: func(string) (bool, error) {
+				probes++
+				// The image is released on the third observation.
+				return probes < 3, nil
+			},
+		},
+	}
+
+	runUninstall(params)
+
+	if probesWhenFirstRemoved != 3 {
+		t.Errorf(
+			"expected removal to start only once the process was gone, started after %d probes",
+			probesWhenFirstRemoved,
+		)
+	}
+	if !svc.deleteCalled {
+		t.Error("expected the service registration to be deleted")
+	}
+	if len(removed) != 3 {
+		t.Errorf("expected the three installation directories to be removed, got %v", removed)
+	}
+	if clock.sleeps != 2 {
+		t.Errorf("expected 2 polls while the process was shutting down, got %d", clock.sleeps)
+	}
+}
+
+// ── post-delete tests ─────────────────────────────────────────────────────────
 
 func TestRunUninstall_RemoveAllDataDirFails(t *testing.T) {
 	t.Parallel()
 
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: false},
 		},
@@ -120,7 +211,8 @@ func TestRunUninstall_RemoveAllProgramDirFails(t *testing.T) {
 
 	call := 0
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: false},
 		},
@@ -143,7 +235,8 @@ func TestRunUninstall_RemoveAllScriptsDirFails(t *testing.T) {
 
 	call := 0
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: false},
 		},
@@ -165,7 +258,8 @@ func TestRunUninstall_Success(t *testing.T) {
 	t.Parallel()
 
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: false},
 		},
@@ -179,7 +273,8 @@ func TestRunUninstall_ActiveService_Success(t *testing.T) {
 	t.Parallel()
 
 	params := &uninstallContext{
-		OrgId: "test-org",
+		OrgId:    "test-org",
+		exitWait: stubExitWait(),
 		ServiceManager: &mockServiceManager{
 			openService: &mockService{isActive: true},
 		},

--- a/cmd/agent_smith/update.go
+++ b/cmd/agent_smith/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"os"
 	"runtime"
-	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/service"
@@ -35,6 +34,53 @@ func runUpdate(params *updateContext) {
 		}
 	}()
 
+	// Track whether this run stopped the service and whether it got as far as
+	// starting it again. Registered after the handle cleanup so it runs first
+	// (deferred calls run last-in-first-out) and still has a usable handle.
+	stopped := false
+	completed := false
+	defer func() {
+		if completed || !stopped {
+			return
+		}
+		if svc == nil {
+			// The registration was removed on the way to re-registering the service
+			// and could not be recreated. There is nothing left to start, so say so
+			// plainly instead of leaving the endpoint quietly offline.
+			logger.Error(
+				"Update failed after the service registration was removed; the endpoint is offline until the agent is reinstalled",
+				"service",
+				name,
+			)
+			return
+		}
+		logger.Info("Restarting service after failed update", "service", name)
+		if err := svc.Start(); err != nil {
+			logger.Error(
+				"Failed to restart service after failed update; the endpoint is offline",
+				"service", name,
+				"error", err,
+			)
+			return
+		}
+		logger.Info("Service restarted after failed update", "service", name)
+	}()
+
+	// Get installation paths data. This is read before the service is stopped so
+	// the wait below knows which executable to watch.
+	pathsData, err := agent.NewPathsData(
+		context.Background(),
+		params.OrgId,
+		logger,
+		params.Sys,
+		params.Domain,
+	)
+	if err != nil {
+		logger.Error("Failed to read paths", "error", err)
+		return
+	}
+	agentExecutablePath := pathsData.AgentExecutablePath
+
 	// Stop the service if its running
 	if svc.IsActive() {
 		logger.Info("Stopping service", "service", name)
@@ -54,22 +100,39 @@ func runUpdate(params *updateContext) {
 			)
 			return
 		}
-
-		// Wait for some time for the service executable to clean up
-		logger.Info("Waiting for service executable to stop")
-		time.Sleep(serviceExecutableTimeout)
+		stopped = true
 	}
 
-	// Get installation paths data
-	pathsData, err := agent.NewPathsData(
-		context.Background(),
-		params.OrgId,
-		logger,
-		params.Sys,
-		params.Domain,
+	// Wait for the old process to actually exit. Replacing an executable that is
+	// still running fails outright on Windows and races the old process on Linux
+	// and macOS, so nothing is written until the process is observably gone. This
+	// runs even when the service was already stopped, since a process left over
+	// from a crashed or externally stopped service holds its image just as firmly.
+	// It costs a single round of probes when the process is already gone.
+	logger.Info(
+		"Waiting for the agent process to exit",
+		"service", name,
+		"agent_executable", agentExecutablePath,
 	)
-	if err != nil {
-		logger.Error("Failed to read paths", "error", err)
+	if err := waitForAgentProcessExit(
+		logger,
+		svc,
+		params.FS,
+		agentExecutablePath,
+		params.exitWait,
+	); err != nil {
+		logger.Error(
+			"Agent process did not exit",
+			"service", name,
+			"agent_executable", agentExecutablePath,
+			"error", err,
+		)
+		logger.Error(
+			"Update aborted; existing installation left untouched",
+			"service", name,
+			"agent_executable", "not modified",
+			"config_file", "not modified",
+		)
 		return
 	}
 
@@ -142,7 +205,9 @@ func runUpdate(params *updateContext) {
 		return
 	}
 
-	err = params.FS.WriteFile(configFilePath, configBytes, utils.DefaultFileMod)
+	// Written atomically: a config file truncated by a failed write would leave
+	// the service unable to start at all.
+	err = writeFileAtomic(params.FS, configFilePath, configBytes, utils.DefaultFileMod)
 	if err != nil {
 		logger.Error("Failed to save config", "error", err)
 		return
@@ -163,8 +228,15 @@ func runUpdate(params *updateContext) {
 		return
 	}
 
-	agentExecutablePath := pathsData.AgentExecutablePath
-	err = params.FS.WriteFile(agentExecutablePath, execFileBytes, utils.DefaultExecutableFileMod)
+	// Written atomically so a failure here leaves the installed binary exactly as
+	// it was: the endpoint keeps running the old agent rather than a truncated
+	// one that cannot start.
+	err = writeFileAtomic(
+		params.FS,
+		agentExecutablePath,
+		execFileBytes,
+		utils.DefaultExecutableFileMod,
+	)
 	if err != nil {
 		logger.Error("Failed to create agent executable", "error", err)
 		return
@@ -193,8 +265,22 @@ func runUpdate(params *updateContext) {
 		}
 		svc = nil
 
-		logger.Info("Waiting for service executable to stop")
-		time.Sleep(serviceExecutableTimeout)
+		// Wait for the deleted registration to disappear rather than assuming a
+		// fixed sleep covered it. If it somehow outlives the deadline, still try to
+		// create the service: failing here would leave the endpoint with no
+		// registration at all, and Create reports the real conflict if there is one.
+		logger.Info("Waiting for the service registration to be removed", "service", name)
+		if err := waitForServiceDeregistration(
+			params.ServiceManager,
+			name,
+			params.exitWait,
+		); err != nil {
+			logger.Error(
+				"Service registration outlived its deletion; re-registering anyway",
+				"service", name,
+				"error", err,
+			)
+		}
 
 		newSvc, err := params.ServiceManager.Create(service.AgentParams{
 			Name:                name,
@@ -213,11 +299,17 @@ func runUpdate(params *updateContext) {
 		logger.Info("Service re-registered", "service", name)
 	}
 
-	// Starting the service
+	// Starting the service. From here on the start attempt is itself the recovery,
+	// so a failure is reported once rather than retried by the deferred restart.
+	completed = true
 	logger.Info("Starting service", "service", name)
 	err = svc.Start()
 	if err != nil {
-		logger.Error("Failed to start service", "service", name, "error", err)
+		logger.Error(
+			"Failed to start service; the endpoint is offline",
+			"service", name,
+			"error", err,
+		)
 		return
 	}
 

--- a/cmd/agent_smith/update_context.go
+++ b/cmd/agent_smith/update_context.go
@@ -28,6 +28,11 @@ type updateContext struct {
 
 	ServiceManager service.ServiceManager
 	FS             utils.FileSystem
+
+	// exitWait holds the test seams for the bounded wait for the old agent
+	// process to exit. Zero values select the documented defaults, so nothing
+	// outside tests ever sets it.
+	exitWait exitWaitOptions
 }
 
 // newUpdateFlagSet builds the flag set for update mode, binding flags to the

--- a/cmd/agent_smith/update_test.go
+++ b/cmd/agent_smith/update_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -50,6 +52,7 @@ func newBaseUpdateParams() *updateContext {
 		Domain:         &mockDomainInfoProvider{},
 		FS:             newUpdateTestFS(),
 		ServiceManager: &mockServiceManager{openService: &mockService{isActive: false}},
+		exitWait:       stubExitWait(),
 	}
 }
 
@@ -255,6 +258,132 @@ func TestRunUpdate_StopFails_LeavesInstallationUntouched(t *testing.T) {
 	}
 	if svc.deleteCalled {
 		t.Error("expected the service registration to be left alone after a failed stop")
+	}
+}
+
+// A process that never releases the executable must abort the update before
+// anything is written, and the service must be brought back up rather than left
+// stopped with the endpoint silently offline.
+func TestRunUpdate_ProcessNeverExits_AbortsAndRestartsService(t *testing.T) {
+	clock := newFakeClock()
+	var writes []string
+	params := newBaseUpdateParams()
+	params.exitWait = clock.options(2*time.Minute, 250*time.Millisecond)
+	params.FS = &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc:   func(string) ([]byte, error) { return validDeviceJSON("test-org"), nil },
+		writeFileFunc: func(name string, _ []byte, _ os.FileMode) error {
+			writes = append(writes, name)
+			return nil
+		},
+		mkdirAllFunc:  func(string) error { return nil },
+		removeAllFunc: func(string) error { return nil },
+		// The old process holds its image open for as long as it lives.
+		executableInUseFunc: func(string) (bool, error) { return true, nil },
+	}
+	svc := &mockService{isActive: true}
+	params.ServiceManager = &mockServiceManager{openService: svc}
+
+	runUpdate(params)
+
+	if !svc.stopCalled {
+		t.Error("expected the service to be stopped")
+	}
+	if len(writes) != 0 {
+		t.Errorf("expected nothing written while the old process is alive, got %v", writes)
+	}
+	if svc.deleteCalled {
+		t.Error("expected the service registration to be left alone")
+	}
+	if !svc.startCalled {
+		t.Error("expected the service to be restarted so the endpoint does not stay offline")
+	}
+	if clock.slept < 2*time.Minute {
+		t.Errorf("expected the full deadline to be waited out, waited %s", clock.slept)
+	}
+}
+
+// The executable is replaced by writing a temporary file next to it and renaming
+// it into place, so an interrupted update can never leave a truncated binary.
+func TestRunUpdate_ReplacesExecutableAtomically(t *testing.T) {
+	var writes []string
+	var renames [][2]string
+	params := newBaseUpdateParams()
+	params.FS = &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc:   func(string) ([]byte, error) { return validDeviceJSON("test-org"), nil },
+		writeFileFunc: func(name string, _ []byte, _ os.FileMode) error {
+			writes = append(writes, name)
+			return nil
+		},
+		renameFunc: func(oldPath string, newPath string) error {
+			renames = append(renames, [2]string{oldPath, newPath})
+			return nil
+		},
+		mkdirAllFunc:  func(string) error { return nil },
+		removeAllFunc: func(string) error { return nil },
+	}
+
+	runUpdate(params)
+
+	agentExecutablePath := agent.GetAgentExecutablePath("test-org")
+	for _, name := range writes {
+		if !strings.HasSuffix(name, ".new") {
+			t.Errorf("expected every write to target a temporary file, got %q", name)
+		}
+		if name == agentExecutablePath {
+			t.Errorf("expected the installed executable never to be written in place")
+		}
+	}
+
+	committed := false
+	for _, rename := range renames {
+		if rename[1] == agentExecutablePath && rename[0] == agentExecutablePath+".new" {
+			committed = true
+		}
+	}
+	if !committed {
+		t.Errorf(
+			"expected the executable to be committed by renaming %s.new into place, got %v",
+			agentExecutablePath,
+			renames,
+		)
+	}
+}
+
+// A commit that fails — the sharing violation this ticket is about, or a full
+// disk — must leave the endpoint running the old agent rather than stopped.
+func TestRunUpdate_ExecutableCommitFails_RestartsService(t *testing.T) {
+	params := newBaseUpdateParams()
+	agentExecutablePath := agent.GetAgentExecutablePath("test-org")
+	removedTemps := []string{}
+	params.FS = &mockFileSystem{
+		executableFunc: func() (string, error) { return "/fake/agent", nil },
+		readFileFunc:   func(string) ([]byte, error) { return validDeviceJSON("test-org"), nil },
+		writeFileFunc:  func(string, []byte, os.FileMode) error { return nil },
+		renameFunc: func(oldPath string, _ string) error {
+			if oldPath == agentExecutablePath+".new" {
+				return errors.New("sharing violation")
+			}
+			return nil
+		},
+		removeFunc: func(name string) error {
+			removedTemps = append(removedTemps, name)
+			return nil
+		},
+		mkdirAllFunc:  func(string) error { return nil },
+		removeAllFunc: func(string) error { return nil },
+	}
+	svc := &mockService{isActive: true}
+	params.ServiceManager = &mockServiceManager{openService: svc}
+
+	runUpdate(params)
+
+	if !svc.startCalled {
+		t.Error("expected the service to be restarted after a failed executable write")
+	}
+	if len(removedTemps) != 1 || removedTemps[0] != agentExecutablePath+".new" {
+		t.Errorf("expected the uncommitted temporary file to be cleaned up, got %v", removedTemps)
 	}
 }
 

--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -16,6 +16,23 @@ type FileSystem interface {
 	WriteFile(name string, data []byte, perm os.FileMode) error
 	MkdirAll(path string) error
 	RemoveAll(path string) error
+	// Rename moves oldPath to newPath, replacing newPath if it exists. It is the
+	// commit step of an atomic write: the caller writes a temporary file in the
+	// destination directory and renames it into place, so a failed write never
+	// leaves a truncated file behind.
+	Rename(oldPath string, newPath string) error
+	// Remove deletes a single file. It is used to clean up the temporary file of
+	// an atomic write that could not be committed.
+	Remove(name string) error
+	// ExecutableInUse reports whether the file at name is currently held open as
+	// a running image by some process. It is a real observation, not a guess: the
+	// probe opens the file for writing, which a running executable refuses with a
+	// sharing violation on Windows and with ETXTBSY on Linux and macOS.
+	//
+	// A file that does not exist is not in use. Any other failure to probe (a
+	// restrictive ACL, an unreadable parent directory) is returned as an error so
+	// the caller can decide what to do rather than silently reading as "free".
+	ExecutableInUse(name string) (bool, error)
 }
 
 type defaultFileSystem struct{}
@@ -38,6 +55,18 @@ func (*defaultFileSystem) MkdirAll(path string) error {
 
 func (*defaultFileSystem) RemoveAll(path string) error {
 	return os.RemoveAll(path)
+}
+
+func (*defaultFileSystem) Rename(oldPath string, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}
+
+func (*defaultFileSystem) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (*defaultFileSystem) ExecutableInUse(name string) (bool, error) {
+	return executableInUse(name)
 }
 
 func NewFileSystem() FileSystem {

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -115,3 +115,102 @@ func TestDefaultFileSystem_ReadFile_NotFound(t *testing.T) {
 		t.Error("expected error reading nonexistent file, got nil")
 	}
 }
+
+func TestDefaultFileSystem_Rename(t *testing.T) {
+	fs := NewFileSystem()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "agent.new")
+	destination := filepath.Join(dir, "agent")
+
+	if err := os.WriteFile(source, []byte("new"), DefaultExecutableFileMod); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("old"), DefaultExecutableFileMod); err != nil {
+		t.Fatal(err)
+	}
+
+	// Renaming over an existing file must replace it: that is what makes the
+	// executable replacement a single atomic step.
+	if err := fs.Rename(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	contents, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(contents) != "new" {
+		t.Errorf("expected the destination replaced, got %q", contents)
+	}
+	if _, statErr := os.Stat(source); !os.IsNotExist(statErr) {
+		t.Errorf("expected the source to be gone, stat returned %v", statErr)
+	}
+}
+
+func TestDefaultFileSystem_Remove(t *testing.T) {
+	fs := NewFileSystem()
+	path := filepath.Join(t.TempDir(), "agent.new")
+
+	if err := os.WriteFile(path, []byte("temp"), DefaultFileMod); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fs.Remove(path); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("expected the file to be removed, stat returned %v", statErr)
+	}
+}
+
+func TestDefaultFileSystem_ExecutableInUse_MissingFile(t *testing.T) {
+	fs := NewFileSystem()
+
+	inUse, err := fs.ExecutableInUse(filepath.Join(t.TempDir(), "never-installed"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if inUse {
+		t.Error("expected a path with nothing installed at it not to be in use")
+	}
+}
+
+func TestDefaultFileSystem_ExecutableInUse_IdleFile(t *testing.T) {
+	fs := NewFileSystem()
+	path := filepath.Join(t.TempDir(), "agent")
+	contents := []byte("not running")
+
+	if err := os.WriteFile(path, contents, DefaultExecutableFileMod); err != nil {
+		t.Fatal(err)
+	}
+
+	inUse, err := fs.ExecutableInUse(path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if inUse {
+		t.Error("expected a file no process is running not to be in use")
+	}
+
+	// The probe opens the file for writing; it must not disturb the contents it
+	// is only inspecting.
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(contents) {
+		t.Errorf("expected the probe to leave the file untouched, got %q", after)
+	}
+}
+
+func TestDefaultFileSystem_ExecutableInUse_UnprobeablePath(t *testing.T) {
+	fs := NewFileSystem()
+
+	// A path that cannot be opened for writing at all is reported as an error
+	// rather than silently as "free": the caller decides what to do about a probe
+	// it could not run, and must not read it as evidence the process is gone.
+	_, err := fs.ExecutableInUse(t.TempDir())
+	if err == nil {
+		t.Error("expected an error probing a path that is not a regular file")
+	}
+}

--- a/internal/utils/filesystem_unix.go
+++ b/internal/utils/filesystem_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package utils
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// executableInUse probes whether name is currently running. Linux and macOS both
+// refuse to open a running image for writing with ETXTBSY ("text file busy"),
+// which is a direct statement from the kernel that the process is still alive —
+// unlike a timer, it cannot report "gone" early.
+//
+// The file is opened without O_TRUNC and closed immediately, so a successful
+// probe leaves its contents untouched.
+func executableInUse(name string) (bool, error) {
+	file, err := os.OpenFile(name, os.O_WRONLY, 0)
+	if err == nil {
+		return false, file.Close()
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		// Nothing installed at that path yet: no process can be holding it.
+		return false, nil
+	}
+
+	if errors.Is(err, syscall.ETXTBSY) {
+		return true, nil
+	}
+
+	return false, err
+}

--- a/internal/utils/filesystem_windows.go
+++ b/internal/utils/filesystem_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package utils
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// errSharingViolation is ERROR_SHARING_VIOLATION. Windows maps a running image
+// to it: the loader keeps the executable open denying write sharing, so opening
+// it for writing fails with this error for exactly as long as the process lives.
+// It is the same error that made an in-place update fail after the fixed five
+// second sleep, used here as the signal to wait on instead of the symptom.
+const errSharingViolation = syscall.Errno(32)
+
+// executableInUse probes whether name is currently running. A successful open
+// means no process holds the image and the file can be replaced; a sharing
+// violation means the old process is still alive.
+//
+// The file is opened without O_TRUNC and closed immediately, so a successful
+// probe leaves its contents untouched.
+func executableInUse(name string) (bool, error) {
+	file, err := os.OpenFile(name, os.O_WRONLY, 0)
+	if err == nil {
+		return false, file.Close()
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		// Nothing installed at that path yet: no process can be holding it.
+		return false, nil
+	}
+
+	if errors.Is(err, errSharingViolation) {
+		return true, nil
+	}
+
+	return false, err
+}

--- a/internal/utils/process.go
+++ b/internal/utils/process.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/process"
+)
+
+// ProcessRunningFromExecutable reports whether any process other than the caller
+// is currently executing the binary at path.
+//
+// This is the portable half of "has the old agent really exited". Windows and
+// Linux also refuse to open a running image for writing, but macOS does not, so
+// on macOS this is the only direct observation of the old process available —
+// and everywhere it catches a process that is still winding down after its
+// service manager has already stopped reporting the service as active.
+//
+// The caller's own process is excluded so an operator running the installed
+// binary in place is not mistaken for the service it is updating. Processes that
+// cannot be inspected (they exited mid-scan, or belong to another user) are
+// skipped rather than failing the scan: they are not the stopped agent, whose
+// executable path the caller already knows.
+func ProcessRunningFromExecutable(path string) (bool, error) {
+	processes, err := process.Processes()
+	if err != nil {
+		return false, err
+	}
+
+	self := int32(os.Getpid())
+	targets := executablePathAliases(path)
+
+	for _, proc := range processes {
+		if proc.Pid == self {
+			continue
+		}
+
+		executable, err := proc.Exe()
+		if err != nil {
+			continue
+		}
+
+		if targets[normalizeExecutablePath(executable)] {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// executablePathAliases returns every spelling of path a process might be
+// reported under. Operating systems report a process's executable as the fully
+// resolved path (macOS answers /private/var for a /var path, Linux resolves
+// /proc/<pid>/exe), so the caller's own spelling alone would miss the match.
+func executablePathAliases(path string) map[string]bool {
+	aliases := map[string]bool{normalizeExecutablePath(path): true}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		aliases[normalizeExecutablePath(resolved)] = true
+	}
+	return aliases
+}
+
+// normalizeExecutablePath puts two executable paths into a form that can be
+// compared: cleaned, and case-folded on Windows where paths are not case
+// sensitive.
+func normalizeExecutablePath(path string) string {
+	cleaned := filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(cleaned)
+	}
+	return cleaned
+}

--- a/internal/utils/process_test.go
+++ b/internal/utils/process_test.go
@@ -1,0 +1,113 @@
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// helperSleepEnv marks the re-executed test binary as the sleeping child rather
+// than a normal test run.
+const helperSleepEnv = "AGENT_SMITH_TEST_HELPER_SLEEP"
+
+// TestHelperProcessSleeps is not a test: it is the body of the child process
+// spawned by TestProcessRunningFromExecutable, kept alive long enough to be
+// observed and then killed.
+func TestHelperProcessSleeps(t *testing.T) {
+	if os.Getenv(helperSleepEnv) != "1" {
+		t.Skip("helper process; only runs when re-executed by the process scan test")
+	}
+	time.Sleep(30 * time.Second)
+}
+
+// The scan has to answer both halves of the question it is used for: it must see
+// a live process running the binary, and it must stop seeing it once that
+// process is gone. A check that only ever says "running" would wedge every
+// update; one that only ever says "gone" would be the fixed sleep again.
+func TestProcessRunningFromExecutable(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to resolve the test binary: %v", err)
+	}
+
+	child := exec.Command(self, "-test.run=TestHelperProcessSleeps")
+	child.Env = append(os.Environ(), helperSleepEnv+"=1")
+	if err := child.Start(); err != nil {
+		t.Fatalf("failed to start the helper process: %v", err)
+	}
+	killed := false
+	defer func() {
+		if !killed {
+			_ = child.Process.Kill()
+			_, _ = child.Process.Wait()
+		}
+	}()
+
+	waitFor(t, "the helper process to be detected", func() bool {
+		running, err := ProcessRunningFromExecutable(self)
+		if err != nil {
+			t.Fatalf("failed to scan processes: %v", err)
+		}
+		return running
+	})
+
+	if err := child.Process.Kill(); err != nil {
+		t.Fatalf("failed to kill the helper process: %v", err)
+	}
+	_, _ = child.Process.Wait()
+	killed = true
+
+	waitFor(t, "the helper process to disappear", func() bool {
+		running, err := ProcessRunningFromExecutable(self)
+		if err != nil {
+			t.Fatalf("failed to scan processes: %v", err)
+		}
+		return !running
+	})
+}
+
+// The caller's own process must never count as the old agent, so an operator who
+// runs the installed binary in place is not mistaken for the service.
+func TestProcessRunningFromExecutable_ExcludesSelf(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to resolve the test binary: %v", err)
+	}
+
+	running, err := ProcessRunningFromExecutable(self)
+	if err != nil {
+		t.Fatalf("failed to scan processes: %v", err)
+	}
+	if running {
+		t.Error("expected the calling process to be excluded from the scan")
+	}
+}
+
+func TestProcessRunningFromExecutable_UnknownPath(t *testing.T) {
+	running, err := ProcessRunningFromExecutable(filepath.Join(t.TempDir(), "never-installed"))
+	if err != nil {
+		t.Fatalf("failed to scan processes: %v", err)
+	}
+	if running {
+		t.Error("expected no process to be running a binary that does not exist")
+	}
+}
+
+// waitFor polls condition until it holds or the test gives up, so the assertions
+// do not depend on how quickly the operating system reflects a process change.
+func waitFor(t *testing.T, what string, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/scripts/build_integration_test.ps1
+++ b/scripts/build_integration_test.ps1
@@ -12,6 +12,10 @@
 #   abort in seconds instead of the production five minutes). The symbol only
 #   exists in the Windows build; -X against a missing symbol is ignored, so the
 #   same flag is harmless on Linux and macOS.
+# - exitTimeoutOverrideStr overridden to 25s (the bounded wait for the old agent
+#   process to actually exit before its files are replaced or deleted, so a
+#   process that never exits is given up on in seconds instead of the production
+#   two minutes)
 
 $env:GOARCH = "amd64"
 
@@ -21,7 +25,8 @@ $baseBackoffFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.baseBac
 $maxRetriesFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.maxRetriesStr=6"
 $sasTokenLifetimeFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.sasTokenLifetimeOverrideStr=90s"
 $stopTimeoutFlag = "-X github.com/RewstApp/agent-smith-go/internal/service.stopTimeoutOverrideStr=25s"
-$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag $stopTimeoutFlag"
+$exitTimeoutFlag = "-X main.exitTimeoutOverrideStr=25s"
+$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag $stopTimeoutFlag $exitTimeoutFlag"
 
 if ($IsWindows) {
     $buildOutput = "./dist/rewst_agent_config.win.it.exe"


### PR DESCRIPTION
## Problem

Install, update and uninstall all waited for the old agent process to exit by sleeping a fixed five seconds and then acting regardless:

```go
// Wait for some time for the service executable to clean up
logger.Info("Waiting for service executable to stop")
time.Sleep(serviceExecutableTimeout) // 5s
```

Nothing checked whether the process had exited. After the sleep, `runUpdate` overwrote the agent executable in place and `runUninstall` deleted the installation directory.

On a loaded endpoint the old process is frequently still alive at the five second mark — its shutdown legitimately drains the commands in flight, tears down MQTT, and kills its plugin subprocesses one at a time, each waiting out go-plugin's graceful-exit grace period. Windows will not replace a running image, so the write failed with a sharing violation **after the service was already stopped**, and the updater returned. The customer sees devices silently dropping offline after a release, disproportionately their busiest servers, with nothing retrying. Because it is timing- and host-dependent it looks intermittent and reads as a network problem. Uninstall had the mirror-image failure: files removed out from under a live process, leaving an installation that neither ran nor reinstalled.

This is a fixed-deadline race, not a rare one — the same slow hosts fail every time. Latent in all released versions through v1.5.0 and current `main`. Hard failure on Windows (mandatory file locking); a subtler race on Linux and macOS.

## Fix

The four sleeps (`update.go` ×2, `config.go`, `uninstall.go`) are replaced with a wait on signals that are actual observations of the process. **Three** of them, all of which must clear:

| signal | what it observes |
|---|---|
| service manager | no longer reports the service active |
| process table | no process is executing the agent binary |
| executable | no longer held open as a running image |

The ACs name the first and third. The process scan is there because the file probe **is a no-op on macOS** — I verified on darwin that opening a running executable for writing succeeds, where Linux returns `ETXTBSY` and Windows a sharing violation. Without the scan, macOS would fall back to the service-manager signal alone, and a service manager can report a service stopped while its process is still winding down. The three overlap deliberately: the file signal is what actually blocks the write on Windows, the scan is what covers macOS and the wind-down window everywhere.

An elapsed poll interval is **never** by itself treated as evidence of an exit.

- **Fast path costs nothing.** The wait probes before it ever sleeps, so a healthy endpoint pays one round of probes — the update gets faster than the unconditional five second sleep, not slower.
- **Bounded at 2 minutes**, and the constant's doc comment says why: it exists to catch a process that never exits, not to race a slow one. Sized for many workers, in-flight commands, and several plugin subprocesses. Overrun logs at `Error` what was still outstanding and for how long:

  ```
  agent process did not exit within 2m0s: the service manager still reports the
  service active; the agent executable C:\...\agent_smith.win.exe is still held open
  ```

- **A probe that cannot run is not evidence.** A restrictive ACL or an unenumerable process table is logged once at `Warn` and the remaining signals are used, rather than wedging every update on an endpoint where that probe can never succeed.

### Callers

- **`runUpdate`** aborts before writing anything and leaves the installation fully intact. It now also **restarts the service it stopped** — on *any* failure after the stop, via a deferred recovery, not just this one — so a failed update no longer leaves the endpoint silently offline. If the failure comes after the registration was deleted (the `--service-username` path) there is nothing to start, and it says so plainly instead of failing quietly.
- **`runUninstall`** waits before deleting the registration *or* any files, and on overrun logs `Uninstall aborted; nothing was removed`. The delete/wait order is swapped so the service handle still exists to be observed.
- **`runConfig`** waits before deleting the existing registration and replacing the executable, and restarts the service it stopped. Its abort log is honest that the config file was already refreshed at that point — the installed agent and its registration are what had to be left alone.

### Non-destructive writes

The agent executable and the config file are written to a temp file in the destination directory and atomically renamed into place, mirroring `postback_spool.go:109-119`. A failed or interrupted write leaves the previous file **byte-identical** rather than truncated: the endpoint keeps running the old agent instead of a binary that cannot start. `FileSystem` gains `Rename`, `Remove` and `ExecutableInUse` for this.

The re-registration path's second sleep is replaced by polling until the deleted registration is actually reaped. If it outlives its deadline the failure is logged and `Create` is attempted anyway — aborting there would leave the endpoint with no registration at all, and `Create` surfaces the real conflict if there is one.

## Testing

**Unit tests** use a fake clock that advances only when the code under test sleeps, so a two minute deadline is burned instantly and deterministically. Covering exactly the ACs' four cases and then some: a process already gone (asserts **zero** waiting and a single probe), one that exits partway through, one that never exits (bounded, descriptive error, no destructive write), a failed commit leaving the original byte-identical, plus each probe failing independently, the nil-service handle case, deregistration, and the timeout resolution order. Caller-level tests assert `runUpdate` writes nothing and restarts the service on overrun, that the executable is only ever committed by renaming `*.new` into place, and that `runUninstall` starts removing only after the process is observed gone.

`ProcessRunningFromExecutable` is tested for real against a re-executed child process — it has to be able to say both "running" and "gone", since a scan stuck on either answer would wedge every update or be the fixed sleep again.

`go test ./...` green, `golangci-lint run` 0 issues, `GOOS=windows|linux go vet` clean, coverage **88.6%** (threshold 80).

**Integration** — [run 31501216206](https://github.com/RewstApp/agent-smith-go/actions/runs/31501216206) on the head commit, `os=all`. Every job green across Windows, Linux and macOS: `build`, `build-integration-test`, `test`, and `test-service-user` — including the Windows wedged-service abort scenarios and the `--service-username` re-registration path that uses the new deregistration wait. (The `set-matrix` job's status is stuck `in_progress` in the API with all of its own steps completed successfully; every job downstream of it consumed its output and passed.)

I did **not** add a new integration scenario for the deadline case. Reproducing "service reports `Stopped` but the process lingers holding the image" needs a fixture distinct from `test/wedgedservice` (which never reports `Stopped`) plus a new composite action. The ACs call for unit tests; the QA steps call for running the existing workflows, which pass unchanged. Happy to build it out if you want it before merge.

`exitTimeoutOverrideStr` is overridable via `-ldflags` and set to 25s in the integration build, mirroring the existing `stopTimeoutOverrideStr`, so QA step 4/7 ("force the deadline case") costs seconds rather than two minutes. A garbage or non-positive override falls back to the constant rather than disabling the bound.

## Docs

README gains "Waiting for the Old Agent Process to Exit" — the failure mode, the three signals and why three, the deadline and its sizing, what each caller does on abort, and the atomic-write guarantee. `CLAUDE.md`'s `cmd/agent_smith` entry points at it.

## Reviewer notes

- **The macOS finding is the one worth checking.** I tested it directly rather than assuming `ETXTBSY` is portable: a running binary on darwin opens for writing without error. If that matches your experience, the process scan is load-bearing on that platform; if not, it is redundant defence and still cheap.
- **`gopsutil` is a new dependency for this path** but already a direct dependency of the module (`internal/agent` host info), so no `go.mod` change. The scan runs once per 250ms poll; on Windows enumerating processes costs ~100-300ms, which is fine for an operation that already stops a service.
- **The scan excludes the caller's own PID**, so an operator running the installed binary in place is not mistaken for the service it is updating. That case still cannot succeed on Windows (the file is held by *us*), but it now fails with a clear wait error rather than a raw sharing violation.
- **`agent.NewPathsData` moved above the stop** in `runUpdate` so the wait knows which executable to watch. It only reads paths and host tags; no behavioural coupling to the service.
- **`runUpdate` still exits 0 on an aborted update** — same as before this change, the abort is reported through the log. Called out again because the new restart makes the endpoint recover, so the exit status is now the *only* thing that still misreports.
- **The 2 minute default is not exercised on a runner**, for the same reason the 5 minute stop deadline is not: it is unit-tested, and the ldflags override exists for the lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
