### PR TITLE
fix: [sc-106110] Cap and jitter the auto-update retry backoff

### DIFF
--- a/.github/actions/set-release-url/action.yml
+++ b/.github/actions/set-release-url/action.yml
@@ -1,0 +1,66 @@
+name: Set agent release url
+description: >
+  Point the installed integration-test agent at a different release endpoint by
+  writing the override file its build honors (sc-106110), or remove that file to
+  put it back on the real GitHub releases API. Used to drive the auto-update
+  retry schedule against the local stub release endpoint.
+
+  Only the integration build looks for this file at all - released builds compile
+  the endpoint in - so this is inert against a release binary. The agent reads it
+  when a service cycle constructs its updater, so the change takes effect on the
+  next service start. See fixture.ps1 for details.
+
+inputs:
+  mode:
+    description: "set or clear"
+    required: true
+  config_dir:
+    description: "Directory containing the per-org agent data directory (without org id suffix)"
+    required: true
+  org_id:
+    description: "Organization id whose agent should be pointed at the endpoint"
+    required: true
+  url:
+    description: "Release endpoint URL to write (required when mode is set)"
+    required: false
+    default: ""
+  file_name:
+    description: "Override file name, matching releaseUrlOverrideFileStr in the integration build"
+    required: false
+    default: "release_url_override"
+
+runs:
+  using: composite
+  steps:
+    - name: Set release url (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        CONFIG_DIR: ${{ inputs.config_dir }}
+        ORG_ID: ${{ inputs.org_id }}
+        MODE: ${{ inputs.mode }}
+        URL: ${{ inputs.url }}
+        FILE_NAME: ${{ inputs.file_name }}
+      run: |
+        set -euo pipefail
+        # Resolve pwsh up front: sudo resets PATH via secure_path on some runners.
+        pwsh_path="$(command -v pwsh)"
+        sudo "$pwsh_path" -NoProfile -File "$GITHUB_ACTION_PATH/fixture.ps1" \
+          -OverrideFile "$CONFIG_DIR/$ORG_ID/$FILE_NAME" \
+          -Mode "$MODE" \
+          -Url "$URL"
+
+    - name: Set release url (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        CONFIG_DIR: ${{ inputs.config_dir }}
+        ORG_ID: ${{ inputs.org_id }}
+        MODE: ${{ inputs.mode }}
+        URL: ${{ inputs.url }}
+        FILE_NAME: ${{ inputs.file_name }}
+      run: |
+        & "$env:GITHUB_ACTION_PATH/fixture.ps1" `
+          -OverrideFile (Join-Path (Join-Path $env:CONFIG_DIR $env:ORG_ID) $env:FILE_NAME) `
+          -Mode $env:MODE `
+          -Url $env:URL

--- a/.github/actions/set-release-url/fixture.ps1
+++ b/.github/actions/set-release-url/fixture.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7
+
+# Writes (or removes) the release-url override file the integration build reads
+# to decide which endpoint the auto-updater queries (sc-106110; see
+# agent.ResolveLatestReleaseUrl).
+#
+# The override lives beside the agent's config in the org's data directory
+# because that directory is what the service account can already read on all
+# three platforms, whatever account the service runs as. The file is read when a
+# service cycle constructs its updater, so writing it takes effect on the next
+# service start rather than mid-run.
+#
+# The directory belongs to the service account (root / SYSTEM), so this runs
+# elevated; the wrapping action supplies the elevation per platform.
+
+param(
+    [Parameter(Mandatory = $true)][string]$OverrideFile,
+    [Parameter(Mandatory = $true)][ValidateSet('set', 'clear')][string]$Mode,
+    [string]$Url
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Mode -eq 'clear') {
+    # Tolerates a missing file so an always() cleanup can run even when the
+    # scenario failed before writing one.
+    Remove-Item -Path $OverrideFile -Force -ErrorAction SilentlyContinue
+    Write-Output "release url override cleared ($OverrideFile)"
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($Url)) {
+    Write-Error "a url is required when setting the release url override"
+    exit 1
+}
+
+$directory = Split-Path -Parent $OverrideFile
+if (-not (Test-Path $directory)) {
+    Write-Error "agent data directory not found at $directory"
+    exit 1
+}
+
+Set-Content -Path $OverrideFile -Value $Url -NoNewline
+# The service may run as an account other than the one that wrote this, so the
+# file has to stay readable by it; the data directory's own permissions decide
+# who can get this far.
+if ($IsLinux -or $IsMacOS) {
+    chmod 0644 $OverrideFile
+}
+Write-Output "release url override set to $Url ($OverrideFile)"

--- a/.github/actions/stub-release/action.yml
+++ b/.github/actions/stub-release/action.yml
@@ -1,0 +1,241 @@
+name: Stub release endpoint
+description: >
+  Run the test/stubrelease fixture on the loopback interface as a stand-in for
+  the GitHub releases API, so the agent's auto-update check can be made to fail
+  and recover on demand (sc-106110). A real GitHub outage or rate-limit response
+  is not something CI can arrange, and an unroutable address produces connection
+  errors rather than the HTTP failure the ticket describes.
+
+  The endpoint answers over plain HTTP on 127.0.0.1, so - unlike the stub broker -
+  nothing has to be installed into the host trust store. The agent is pointed at
+  it with the set-release-url action, which writes the override file the
+  integration build honors.
+
+  On Windows the fixture must be launched detached (via WMI), because a child
+  started with Start-Process -NoNewWindow shares the launching step's console and
+  job object and is reaped when that step ends - the lesson the stub broker
+  learned the hard way.
+
+  mode=start builds and launches the endpoint in failing mode and verifies it
+  answers before any agent is pointed at it, so a broken fixture fails here
+  rather than as a mystifying assertion failure a minute later. mode=ok /
+  mode=fail flip the behavior per request without restarting anything, so the
+  endpoint can recover in the middle of a retry sequence. mode=stop tears it down
+  and reports its request log (the arrival-time record for the scenario); it is
+  idempotent and tolerant of missing state, so an always() cleanup step can run
+  it even if start never completed.
+
+inputs:
+  mode:
+    description: "start, ok, fail, or stop"
+    required: true
+  host:
+    description: "Loopback address the endpoint answers on"
+    required: false
+    default: "127.0.0.1"
+  port:
+    description: "Port to listen on"
+    required: false
+    default: "8765"
+  tag:
+    description: >
+      tag_name served in the release payload. Defaults to the integration build's
+      own version so a successful check ends at "No updates available" and the
+      recovery is observed without the agent downloading and executing anything.
+    required: false
+    default: "v0.0.0-it"
+
+outputs:
+  url:
+    description: "Release endpoint URL to point the agent at"
+    value: http://${{ inputs.host }}:${{ inputs.port }}/releases/latest
+  log_file:
+    description: "Path the endpoint's request log is written to"
+    value: ${{ steps.paths.outputs.log_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve working paths
+      id: paths
+      shell: pwsh
+      env:
+        RUNNER_TEMP_DIR: ${{ runner.temp }}
+      run: |
+        $workdir = Join-Path $env:RUNNER_TEMP_DIR 'stub-release'
+        New-Item -ItemType Directory -Force -Path $workdir | Out-Null
+        "workdir=$workdir"                              >> $env:GITHUB_OUTPUT
+        "log_file=$(Join-Path $workdir 'release.log')"  >> $env:GITHUB_OUTPUT
+        "mode_file=$(Join-Path $workdir 'mode')"        >> $env:GITHUB_OUTPUT
+        "pid_file=$(Join-Path $workdir 'release.pid')"  >> $env:GITHUB_OUTPUT
+
+    - name: Setup go
+      if: inputs.mode == 'start'
+      uses: actions/setup-go@v6
+      with:
+        go-version: "1.25.0"
+        cache: true
+
+    # Started in failing mode so a harness that forgets to set a mode reproduces
+    # the failing endpoint the scenario is built around rather than passing.
+    - name: Launch endpoint (Unix)
+      if: inputs.mode == 'start' && runner.os != 'Windows'
+      shell: bash
+      env:
+        WORKDIR: ${{ steps.paths.outputs.workdir }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        printf 'fail' > "$MODE_FILE"
+        rm -f "$LOG_FILE"
+        # The fixture is behind the `integration` build tag; see its package doc.
+        go build -tags integration -o "$WORKDIR/stubrelease" ./test/stubrelease
+        # It binds a high loopback port and reads only files it owns, so it runs
+        # unprivileged; the agent reaches it over loopback whatever account the
+        # service runs as. It writes its own log (-log) rather than having the
+        # shell redirect it, so both platforms capture output the same way.
+        nohup "$WORKDIR/stubrelease" \
+          -listen "$HOST:$PORT" \
+          -mode-file "$MODE_FILE" \
+          -tag "$TAG" \
+          -log "$LOG_FILE" > /dev/null 2>&1 &
+        echo $! > "$PID_FILE"
+        echo "Stub release endpoint started (pid $(cat "$PID_FILE"))"
+
+    - name: Launch endpoint (Windows)
+      if: inputs.mode == 'start' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        WORKDIR: ${{ steps.paths.outputs.workdir }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        Set-Content -Path $env:MODE_FILE -Value 'fail' -NoNewline
+        Remove-Item -Path $env:LOG_FILE -ErrorAction SilentlyContinue
+
+        $exe = Join-Path $env:WORKDIR 'stubrelease.exe'
+        # The fixture is behind the `integration` build tag; see its package doc.
+        go build -tags integration -o $exe ./test/stubrelease
+        if ($LASTEXITCODE -ne 0) { throw "failed to build stub release endpoint" }
+
+        # Launched through WMI rather than Start-Process: a process started with
+        # Start-Process -NoNewWindow shares this step's console and job object,
+        # so the runner reaps it the moment the step ends - which surfaces later
+        # as "the target machine actively refused it". Win32_Process.Create
+        # parents it to WmiPrvSE instead, outside both. WMI offers no stream
+        # redirection, which is why the fixture takes -log and writes its own.
+        $arguments = @(
+          "`"$exe`"",
+          "-listen", "`"$($env:HOST):$($env:PORT)`"",
+          "-mode-file", "`"$($env:MODE_FILE)`"",
+          "-tag", $env:TAG,
+          "-log", "`"$($env:LOG_FILE)`""
+        ) -join ' '
+        $created = Invoke-CimMethod -ClassName Win32_Process -MethodName Create `
+          -Arguments @{ CommandLine = $arguments }
+        if ($created.ReturnValue -ne 0) {
+          throw "Win32_Process.Create failed with return value $($created.ReturnValue)"
+        }
+        Set-Content -Path $env:PID_FILE -Value $created.ProcessId
+        Write-Output "Stub release endpoint started (pid $($created.ProcessId))"
+
+    # Proves the endpoint is actually answering before an agent is pointed at it.
+    # Without this a reaped or unstarted fixture is indistinguishable from the
+    # agent failing to retry, which is what the scenario's assertions measure.
+    - name: Verify the endpoint is reachable
+      if: inputs.mode == 'start'
+      shell: pwsh
+      env:
+        HOST: ${{ inputs.host }}
+        PORT: ${{ inputs.port }}
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+      run: |
+        $url = "http://$($env:HOST):$($env:PORT)/releases/latest"
+        for ($i = 1; $i -le 15; $i++) {
+          try {
+            # In failing mode the endpoint answers 503, which Invoke-WebRequest
+            # raises on - a raised HTTP status still proves it is listening, so
+            # only a transport-level failure is treated as not-yet-up.
+            $response = Invoke-WebRequest -Uri $url -Method Get -SkipHttpErrorCheck -TimeoutSec 5
+            Write-Output "Stub release endpoint answered $($response.StatusCode) after $i attempt(s)"
+            exit 0
+          } catch {
+            $lastError = $_
+            Start-Sleep -Seconds 1
+          }
+        }
+
+        $alive = $false
+        if (Test-Path $env:PID_FILE) {
+          $stubPid = (Get-Content $env:PID_FILE).Trim()
+          $alive = $null -ne (Get-Process -Id $stubPid -ErrorAction SilentlyContinue)
+          Write-Output "Endpoint process $stubPid alive: $alive"
+        }
+        Write-Output "Endpoint log follows:"
+        if (Test-Path $env:LOG_FILE) { Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue }
+        Write-Error "Stub release endpoint not reachable (process alive: $alive): $lastError"
+        exit 1
+
+    - name: Set endpoint mode
+      if: inputs.mode == 'ok' || inputs.mode == 'fail'
+      shell: pwsh
+      env:
+        MODE: ${{ inputs.mode }}
+        MODE_FILE: ${{ steps.paths.outputs.mode_file }}
+      run: |
+        # Read per request, so the change applies to the very next retry without
+        # restarting the endpoint or the agent.
+        Set-Content -Path $env:MODE_FILE -Value $env:MODE -NoNewline
+        Write-Output "Stub release endpoint mode set to $($env:MODE)"
+
+    # The request log is the arrival-time record: it shows retries arriving
+    # spread out rather than in the same millisecond, which is the fleet-facing
+    # half of what sc-106110 fixed.
+    - name: Report endpoint request log
+      if: inputs.mode == 'stop'
+      shell: pwsh
+      env:
+        LOG_FILE: ${{ steps.paths.outputs.log_file }}
+      run: |
+        if (Test-Path $env:LOG_FILE) {
+          Write-Output "---- $($env:LOG_FILE) ----"
+          Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue
+        }
+
+    - name: Tear down endpoint (Unix)
+      if: inputs.mode == 'stop' && runner.os != 'Windows'
+      shell: bash
+      env:
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+      run: |
+        # Tolerates missing state so this can run from an always() cleanup even
+        # when start never got far.
+        if [ -f "$PID_FILE" ]; then
+          kill "$(cat "$PID_FILE")" 2>/dev/null || true
+          rm -f "$PID_FILE"
+        fi
+        echo "Stub release endpoint torn down"
+
+    - name: Tear down endpoint (Windows)
+      if: inputs.mode == 'stop' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        PID_FILE: ${{ steps.paths.outputs.pid_file }}
+      run: |
+        if (Test-Path $env:PID_FILE) {
+          $stubPid = Get-Content $env:PID_FILE
+          Stop-Process -Id $stubPid -Force -ErrorAction SilentlyContinue
+          Remove-Item $env:PID_FILE -ErrorAction SilentlyContinue
+        }
+        Write-Output "Stub release endpoint torn down"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1620,14 +1620,16 @@ jobs:
           BASELINE: ${{ steps.retry_baseline.outputs.retrying }}
         run: |
           # The first check fires 30s after the service starts, then the schedule
-          # is roughly 2s, 4s, 7.5s, 7.5s... Three new lines prove the loop is
-          # running and leave three more slots for the recovery flip below to land
-          # in, so the flip cannot race the end of the retry budget.
+          # is roughly 2s, 4s, 7.5s, 7.5s... Four new lines put two slots at the
+          # ceiling, which is what the jitter assertion below needs to tell a
+          # jittered schedule from one that is merely capped, and still leave two
+          # more slots (~15s) for the recovery flip to land in, so the flip cannot
+          # race the end of the retry budget.
           $baseline = [int]$env:BASELINE
           for ($i = 1; $i -le 150; $i++) {
             $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
             $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Retrying update"))).Count } else { 0 }
-            if (($count - $baseline) -ge 3) {
+            if (($count - $baseline) -ge 4) {
               Write-Output "Observed $($count - $baseline) update retries after ~${i}s"
               exit 0
             }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1555,6 +1555,408 @@ jobs:
           scripts_dir: ${{ steps.inflight_script.outputs.scripts_dir }}
           orphan_path: ${{ steps.inflight_script.outputs.path }}
 
+      # ---- Capped and jittered auto-update retry scenario (sc-106110) ----
+      # The auto-update retry delay was base * (1 << attempt) with no ceiling and
+      # no jitter. Unjittered, every agent that failed against the release
+      # endpoint at the same moment retried at the same instants, so an outage or
+      # rate limit was sustained by the fleet trying to recover from it; uncapped,
+      # a large retry count overflowed the shift into a negative duration, which
+      # made the wait return immediately and spun the loop against the endpoint.
+      #
+      # A GitHub outage is not something CI can arrange and an unroutable address
+      # produces connection errors rather than the HTTP failure the ticket
+      # describes, so the agent is pointed at the test/stubrelease fixture through
+      # the override file the integration build honors. The fixture fails every
+      # request until it is flipped, which puts the agent into retryWithBackoff
+      # with the shortened build knobs - base 2s, 6 retries, 30s check interval,
+      # so the cap is a quarter of that interval (7.5s) - and makes a full
+      # schedule observable in under a minute.
+      #
+      # Fleet-wide de-synchronization needs many agents and is covered by unit
+      # tests over the schedule itself. What one endpoint can show, and what these
+      # steps assert, is that every slot is strictly positive, bounded by the cap,
+      # varies rather than repeating, and is never served back to back.
+      - name: Start stub release endpoint (failing)
+        id: stub_release
+        uses: ./.github/actions/stub-release
+        with:
+          mode: start
+
+      - name: Capture auto-update retry baseline counts
+        id: retry_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $retrying  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Retrying update"))).Count } else { 0 }
+          $succeeded = if ($content) { ([regex]::Matches($content, [regex]::Escape("Update succeeded on retry"))).Count } else { 0 }
+          "retrying=$retrying"   >> $env:GITHUB_OUTPUT
+          "succeeded=$succeeded" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> retrying=$retrying succeeded=$succeeded"
+
+      # Written before the install, because the updater reads the override when a
+      # service cycle constructs it - a file written afterwards would not be seen
+      # until the next restart, and the agent would spend the scenario updating
+      # itself from the real releases API instead.
+      - name: Point the agent at the stub release endpoint
+        uses: ./.github/actions/set-release-url
+        with:
+          mode: set
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+          url: ${{ steps.stub_release.outputs.url }}
+
+      - name: Install integration test binary with auto-updates on
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.it_binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for the update retry schedule to run
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.retry_baseline.outputs.retrying }}
+        run: |
+          # The first check fires 30s after the service starts, then the schedule
+          # is roughly 2s, 4s, 7.5s, 7.5s... Three new lines prove the loop is
+          # running and leave three more slots for the recovery flip below to land
+          # in, so the flip cannot race the end of the retry budget.
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 150; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Retrying update"))).Count } else { 0 }
+            if (($count - $baseline) -ge 3) {
+              Write-Output "Observed $($count - $baseline) update retries after ~${i}s"
+              exit 0
+            }
+            Start-Sleep -Seconds 1
+          }
+          Write-Error "The agent never retried the update against the failing release endpoint"
+          exit 1
+
+      # Flipped mid-sequence - the fixture re-reads its mode per request - so the
+      # recovery is the agent's own next retry, not a restart.
+      - name: Serve a valid release payload mid-sequence
+        uses: ./.github/actions/stub-release
+        with:
+          mode: ok
+
+      - name: Assert the update succeeds on a retry
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.retry_baseline.outputs.succeeded }}
+        run: |
+          # The fixture serves the running agent's own version as tag_name, so a
+          # recovered check ends at "No updates available" and the retry is seen
+          # succeeding without downloading or executing anything - the recovery is
+          # what is under test here, not the installer.
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Update succeeded on retry"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Update succeeded on a retry after ~$($i * 2)s (count $count > baseline $baseline)"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+
+          # Separates a real regression from a flip that landed after the budget
+          # was already spent, which would leave the next check succeeding on its
+          # first try and logging no retry at all.
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          if ($content -and $content.Contains("All retries exhausted")) {
+            Write-Output "Note: the log records an exhausted retry budget; the recovery flip may have landed after the last slot"
+          }
+          Write-Output "---- last 40 log lines ----"
+          Get-Content $env:LOG_FILE -Tail 40 -ErrorAction SilentlyContinue
+          Write-Error "The agent never logged a successful update retry after the endpoint recovered"
+          exit 1
+
+      - name: Assert the retry schedule is capped, jittered and never immediate
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.retry_baseline.outputs.retrying }}
+        run: |
+          # The cap the integration build lands on: a quarter of its 30s check
+          # interval, which is below the absolute 1h ceiling a released build uses.
+          $cap = 7.5
+          $baseline = [int]$env:BASELINE
+          $failures = @()
+
+          function ConvertTo-Seconds([string]$value) {
+            # Go renders a duration as concatenated unit components ("4.1s",
+            # "1m4s"), and a negative one with a leading '-'. The sign is read
+            # separately because the overflow this scenario guards against
+            # produced exactly that negative value, and summing the components
+            # alone would report it as positive.
+            $sign = if ($value.StartsWith('-')) { -1.0 } else { 1.0 }
+            $total = 0.0
+            foreach ($m in [regex]::Matches($value, '(?<n>[0-9.]+)(?<u>ms|us|ns|h|m|s)')) {
+              $n = [double]$m.Groups['n'].Value
+              switch ($m.Groups['u'].Value) {
+                'ns' { $total += $n / 1e9 }
+                'us' { $total += $n / 1e6 }
+                'ms' { $total += $n / 1e3 }
+                's'  { $total += $n }
+                'm'  { $total += $n * 60 }
+                'h'  { $total += $n * 3600 }
+              }
+            }
+            return $sign * $total
+          }
+
+          $lines = @(Get-Content $env:LOG_FILE -ErrorAction SilentlyContinue |
+            Where-Object { $_ -match 'Retrying update' } |
+            Select-Object -Skip $baseline)
+
+          $slots = @()
+          foreach ($line in $lines) {
+            # hclog writes "<timestamp> [INFO]  agent_smith: Retrying update: attempt=N backoff=D".
+            # The timestamp is a fixed-width local time followed by its offset, so
+            # the first 23 characters parse without worrying about the offset form.
+            $m = [regex]::Match($line, '^(?<ts>\S{23}).*Retrying update: attempt=(?<attempt>\d+) backoff=(?<backoff>\S+)')
+            if (-not $m.Success) {
+              $failures += "could not parse a retry line: $line"
+              continue
+            }
+            $stamp = $null
+            try {
+              $stamp = [datetime]::ParseExact(
+                $m.Groups['ts'].Value,
+                'yyyy-MM-ddTHH:mm:ss.fff',
+                [Globalization.CultureInfo]::InvariantCulture)
+            } catch {
+              $failures += "could not parse the timestamp of: $line"
+            }
+            $slots += [pscustomobject]@{
+              Attempt = [int]$m.Groups['attempt'].Value
+              Backoff = ConvertTo-Seconds $m.Groups['backoff'].Value
+              Time    = $stamp
+            }
+          }
+
+          if ($slots.Count -lt 3) {
+            Write-Error "Expected at least three retry slots to inspect, got $($slots.Count)"
+            exit 1
+          }
+
+          # The timestamp table the ticket asks for: every slot, what it waited,
+          # and how long actually elapsed before the next one arrived.
+          Write-Output "---- observed update retry schedule ----"
+          for ($i = 0; $i -lt $slots.Count; $i++) {
+            $gap = ''
+            if ($i -lt $slots.Count - 1 -and $slots[$i].Time -and $slots[$i + 1].Time) {
+              $gap = [math]::Round(($slots[$i + 1].Time - $slots[$i].Time).TotalSeconds, 3)
+            }
+            Write-Output ("attempt={0} backoff={1}s elapsed_to_next={2}" -f $slots[$i].Attempt, [math]::Round($slots[$i].Backoff, 3), $gap)
+          }
+
+          foreach ($slot in $slots) {
+            # A zero or negative slot is the overflow busy-spin: time.After fires
+            # immediately and the loop issues requests as fast as it can.
+            if ($slot.Backoff -le 0) {
+              $failures += "attempt $($slot.Attempt): backoff $($slot.Backoff)s is not strictly positive"
+            }
+            # The tolerance covers the millisecond rendering, not the cap itself.
+            if ($slot.Backoff -gt ($cap + 0.05)) {
+              $failures += "attempt $($slot.Attempt): backoff $($slot.Backoff)s exceeds the ${cap}s cap"
+            }
+          }
+
+          # Jitter: a fixed schedule repeats the same values bit for bit.
+          $distinct = @($slots | ForEach-Object { [math]::Round($_.Backoff, 3) } | Select-Object -Unique)
+          if ($distinct.Count -lt 2) {
+            $failures += "every retry slot was $($distinct -join ', ')s - the schedule is not jittered"
+          }
+          # Distinct values alone are weak evidence, because the doubling produces
+          # distinct values on its own until it reaches the ceiling. The slots that
+          # do reach it are the discriminator: an unjittered schedule pins every
+          # one of them to exactly the cap, while jitter spreads them across the
+          # band below it. Skipped when the sequence was cut short by the recovery
+          # flip before two slots got that far.
+          $nearCap = @($slots | Where-Object { $_.Backoff -ge ($cap * 0.75) })
+          if ($nearCap.Count -ge 2) {
+            $distinctNearCap = @($nearCap | ForEach-Object { [math]::Round($_.Backoff, 3) } | Select-Object -Unique)
+            if ($distinctNearCap.Count -lt 2) {
+              $failures += "the capped slots all measured $($distinctNearCap -join ', ')s - the jitter is not being applied"
+            }
+          }
+
+          # Growth: the schedule still doubles up to the cap rather than being flat.
+          $maxBackoff = ($slots | Measure-Object -Property Backoff -Maximum).Maximum
+          if ($maxBackoff -le $slots[0].Backoff) {
+            $failures += "the schedule never grew (first $($slots[0].Backoff)s, largest ${maxBackoff}s)"
+          }
+
+          # Spacing: consecutive slots of one sequence must be separated by at
+          # least the wait that was logged. Pairs that are not consecutive attempts
+          # belong to different retry sequences and are skipped.
+          for ($i = 0; $i -lt $slots.Count - 1; $i++) {
+            if ($slots[$i + 1].Attempt -ne $slots[$i].Attempt + 1) { continue }
+            if (-not $slots[$i].Time -or -not $slots[$i + 1].Time) { continue }
+            $gap = ($slots[$i + 1].Time - $slots[$i].Time).TotalSeconds
+            if ($gap -lt 1) {
+              $failures += "attempts $($slots[$i].Attempt) and $($slots[$i + 1].Attempt) arrived ${gap}s apart - back to back"
+            }
+            if ($gap -lt ($slots[$i].Backoff * 0.8)) {
+              $failures += "attempt $($slots[$i].Attempt) logged a $($slots[$i].Backoff)s backoff but the next retry came after ${gap}s"
+            }
+          }
+
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Output "FAIL: $_" }
+            Write-Error "the update retry schedule is not capped, jittered and spaced as expected"
+            exit 1
+          }
+          Write-Output "Retry schedule bounded by ${cap}s, jittered across $($distinct.Count) distinct values, and never served back to back"
+          exit 0
+
+      - name: Fail the release endpoint again for the stop check
+        uses: ./.github/actions/stub-release
+        with:
+          mode: fail
+
+      - name: Capture stop-during-backoff baseline counts
+        id: retry_stop_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $retrying = if ($content) { ([regex]::Matches($content, [regex]::Escape("Retrying update"))).Count } else { 0 }
+          $stopped  = if ($content) { ([regex]::Matches($content, [regex]::Escape("Auto updater stopped"))).Count } else { 0 }
+          "retrying=$retrying" >> $env:GITHUB_OUTPUT
+          "stopped=$stopped"   >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> retrying=$retrying stopped=$stopped"
+
+      - name: Wait for a fresh backoff to be entered
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.retry_stop_baseline.outputs.retrying }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 90; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Retrying update"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent is in a retry backoff again after ~${i}s"
+              exit 0
+            }
+            Start-Sleep -Seconds 1
+          }
+          Write-Error "The agent never entered a retry backoff after the endpoint was failed again"
+          exit 1
+
+      - name: Assert a service stop during a backoff is prompt
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          SERVICE: ${{ matrix.service }}
+          BASELINE: ${{ steps.retry_stop_baseline.outputs.stopped }}
+        run: |
+          # The agent has just entered a backoff with most of its 6-slot budget
+          # left (~30s of waiting at the 7.5s cap). A stop that has to wait out
+          # the pending slot - or worse, the whole budget - delays every caller of
+          # Stop(): the installer, an upgrade, and an uninstall.
+          $baseline = [int]$env:BASELINE
+          $sw = [System.Diagnostics.Stopwatch]::StartNew()
+          if ($IsWindows) {
+            sc.exe stop $env:SERVICE | Out-Null
+          } elseif ($IsLinux) {
+            sudo systemctl stop $env:SERVICE
+          } else {
+            # Bare label, not "system/<label>": stop is a legacy launchctl
+            # subcommand that resolves a label in the current domain, and a
+            # service-target form is read as a literal label that matches nothing.
+            sudo launchctl stop $env:SERVICE
+          }
+          # The service managers disagree about exit status for a stop that was
+          # delivered; the verdict here comes from the agent's own log.
+          $global:LASTEXITCODE = 0
+
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Auto updater stopped"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              $sw.Stop()
+              $elapsed = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+              if ($sw.Elapsed.TotalSeconds -gt 20) {
+                Write-Error "The auto updater stopped only after ${elapsed}s, long enough to have waited out its retry schedule"
+                exit 1
+              }
+              Write-Output "Auto updater stopped ${elapsed}s after the stop was issued, mid-backoff"
+              exit 0
+            }
+            Start-Sleep -Milliseconds 500
+          }
+          $sw.Stop()
+          Write-Output "---- last 40 log lines ----"
+          Get-Content $env:LOG_FILE -Tail 40 -ErrorAction SilentlyContinue
+          Write-Error "The auto updater never logged a stop after the service was stopped mid-backoff"
+          exit 1
+
+      # The restore steps run under always() so a failed assertion above cannot
+      # leave the rest of the job running an agent that points at a stub release
+      # endpoint (or leave the service stopped for the scenarios that follow).
+      - name: Capture restore baseline counts
+        if: always()
+        id: retry_restore_baseline
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+        run: |
+          $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+          $subscribed = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+          "subscribed=$subscribed" >> $env:GITHUB_OUTPUT
+          Write-Output "Baseline counts -> subscribed=$subscribed"
+
+      - name: Clear the release url override
+        if: always()
+        uses: ./.github/actions/set-release-url
+        with:
+          mode: clear
+          config_dir: ${{ matrix.config_dir }}
+          org_id: ${{ vars.IT_ORG_ID }}
+
+      - name: Stop stub release endpoint
+        if: always()
+        uses: ./.github/actions/stub-release
+        with:
+          mode: stop
+
+      - name: Reinstall the release binary after the retry scenario
+        if: always()
+        uses: ./.github/actions/run-agent
+        with:
+          binary: ${{ matrix.binary }}
+          args: --update --org-id ${{ vars.IT_ORG_ID }} --no-auto-updates ${{ matrix.no_auto_updates_extra }} --github-token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for resubscription after the retry scenario
+        if: always()
+        shell: pwsh
+        env:
+          LOG_FILE: ${{ matrix.log_file }}
+          BASELINE: ${{ steps.retry_restore_baseline.outputs.subscribed }}
+        run: |
+          $baseline = [int]$env:BASELINE
+          for ($i = 1; $i -le 60; $i++) {
+            $content = Get-Content $env:LOG_FILE -Raw -ErrorAction SilentlyContinue
+            $count = if ($content) { ([regex]::Matches($content, [regex]::Escape("Subscribed to messages"))).Count } else { 0 }
+            if ($count -gt $baseline) {
+              Write-Output "Agent resubscribed after the retry scenario (count $count > baseline $baseline) after ~$($i * 2)s"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Agent never resubscribed after the retry scenario"
+          exit 1
+
       # ---- Wedged Windows service stop scenario (sc-106108) ----
       # windowsService.Stop() polled the service state every 250ms in an
       # unbounded loop, so a service that never reached Stopped hung its caller

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Required tools:
   previous file byte-identical. See the README's "Waiting for the Old Agent
   Process to Exit" section.
 
-- **internal/agent/**: Device configuration, installation paths, and OS-specific host information
+- **internal/agent/**: Device configuration, installation paths, and OS-specific host information. The auto-update retry schedule is capped (1 hour, or a quarter of the check interval when shorter) and jittered (±25%) via `utils.JitteredBackoff`, the same helper the postback retry schedule uses, so the doubling cannot overflow into a negative sleep that busy-spins and a fleet-wide release-endpoint outage cannot produce a synchronized retry storm. See the README's "Capped and Jittered Auto-Update Retries" section.
 - **internal/interpreter/**: Command execution engine supporting both PowerShell and Bash interpreters  
 - **internal/mqtt/**: Azure IoT Hub MQTT client implementation with auto-reconnection
 - **internal/service/**: Cross-platform service management utilities. On Windows, `Stop()` waits a bounded, documented deadline (5 minutes) for the service to reach `Stopped` and otherwise returns an error naming the service and last observed state, so a wedged service aborts an update/install/uninstall with an actionable message instead of hanging forever. See the README's "Bounded Windows Service Stop" section.

--- a/README.md
+++ b/README.md
@@ -515,8 +515,10 @@ next 48-hour check interval. Two bounds keep that schedule safe at fleet scale:
   same moment retry at the same instants, so a GitHub releases outage or rate
   limit turns the whole fleet into a synchronized retry storm that sustains the
   condition it is recovering from and keeps endpoints on older versions long
-  after the outage ends. Jitter is applied after clamping and re-clamped, so a
-  jittered slot never exceeds the cap or drops to zero.
+  after the outage ends. Jitter is applied after the cap, and a slot that would
+  exceed the cap is reflected back under it rather than clamped to it — clamping
+  would land half of every capped slot on exactly the ceiling, so a fleet held at
+  the cap by a long outage would re-synchronize there.
 
 The backoff wait stays interruptible by the service stop signal, so a stop is
 never delayed by a pending retry, and a retry that succeeds resets the schedule

--- a/README.md
+++ b/README.md
@@ -495,6 +495,33 @@ pattern the postback spool uses. An interrupted or failed write therefore leaves
 the previous file byte-identical rather than truncated: the endpoint keeps running
 the old agent instead of a binary that cannot start.
 
+### Capped and Jittered Auto-Update Retries
+
+When an update check or download fails, the agent retries on an exponential
+schedule (base 5 minutes, doubling per retry, 5 retries) before waiting out the
+next 48-hour check interval. Two bounds keep that schedule safe at fleet scale:
+
+- **A cap.** No single retry sleep exceeds **1 hour**, or a quarter of the check
+  interval when that is shorter (integration builds shorten the interval via
+  ldflags). Without a ceiling the doubling reaches a 42-hour sleep by retry 10 —
+  longer than the interval the retries are nested inside — and a large retry
+  count overflows the doubling into a negative duration, which makes the wait
+  return immediately and spin the retry loop against the release endpoint. The
+  schedule is computed by iterated doubling with an early exit at the cap, so no
+  intermediate value can overflow and every slot is strictly positive and
+  bounded.
+- **Jitter.** Each slot is spread by up to **±25%**, mirroring the reconnect and
+  postback backoffs. An unjittered schedule makes every agent that failed at the
+  same moment retry at the same instants, so a GitHub releases outage or rate
+  limit turns the whole fleet into a synchronized retry storm that sustains the
+  condition it is recovering from and keeps endpoints on older versions long
+  after the outage ends. Jitter is applied after clamping and re-clamped, so a
+  jittered slot never exceeds the cap or drops to zero.
+
+The backoff wait stays interruptible by the service stop signal, so a stop is
+never delayed by a pending retry, and a retry that succeeds resets the schedule
+for the next cycle.
+
 ### Notification Plugin Supervision
 
 Notification plugins run as separate subprocesses reached over RPC, and every

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -30,9 +30,15 @@ const (
 	// config does not override them via worker_count / message_queue_size. The
 	// effective values are resolved per cycle from the device config; see
 	// agent.Device.ResolvedWorkerCount / ResolvedMessageQueueSize.
-	workerCount              = agent.DefaultWorkerCount
-	messageQueueSize         = agent.DefaultMessageQueueSize
-	postbackHTTPTimeout      = 30 * time.Second
+	workerCount         = agent.DefaultWorkerCount
+	messageQueueSize    = agent.DefaultMessageQueueSize
+	postbackHTTPTimeout = 30 * time.Second
+
+	// defaultLatestReleaseUrl is the release endpoint the auto-updater queries.
+	// Released builds always use it; an integration-test build can be pointed at
+	// a stub endpoint instead (see agent.ResolveLatestReleaseUrl).
+	defaultLatestReleaseUrl = "https://api.github.com/repos/rewstapp/agent-smith-go/releases/latest"
+
 	postbackMaxAttempts      = agent.DefaultPostbackMaxAttempts
 	postbackBaseRetryBackoff = agent.DefaultPostbackBaseRetryBackoff
 	postbackMaxRetryBackoff  = agent.DefaultPostbackMaxRetryBackoff
@@ -161,7 +167,7 @@ func (svc *serviceContext) Execute(
 		updater := agent.NewUpdater(
 			logger,
 			&device,
-			"https://api.github.com/repos/rewstapp/agent-smith-go/releases/latest",
+			agent.ResolveLatestReleaseUrl(logger, svc.OrgId, defaultLatestReleaseUrl),
 			device.GithubToken,
 			func(path string, args []string) error {
 				return detachedCommand(path, args, logFile, logFile).Start()

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand/v2"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -683,19 +682,17 @@ func (svc *serviceContext) processMessage(
 // retry attempt. attempt is 1-based and counts the initial try, so the first
 // backoff is paid before attempt 2; the uncapped schedule is base * 2^(attempt-2).
 //
-// The doubling is performed by iterated multiplication with an early exit at
-// maxBackoff rather than the naive base * (1 << (attempt-2)) shift. That shift
-// grows without bound and, for a large operator-configured postback_max_attempts,
-// overflows int64 nanoseconds into a negative time.Duration — time.After then
-// fires immediately and the retry loop busy-spins. Clamping to maxBackoff before
-// any overflow can occur keeps every slot strictly positive and bounded, so
-// raising the attempt count widens the total retry window without ever producing
-// a negative, zero, or multi-day sleep.
-//
-// Up to ±25% jitter is applied — mirroring the reconnect backoff generator (see
-// internal/utils/time.go) — to avoid synchronized retry storms across many
-// agents, and the result is clamped again so it never exceeds maxBackoff and
-// always stays strictly positive.
+// The schedule is computed by utils.JitteredBackoff, which performs the doubling
+// by iterated multiplication with an early exit at maxBackoff rather than the
+// naive base * (1 << (attempt-2)) shift. That shift grows without bound and, for
+// a large operator-configured postback_max_attempts, overflows int64 nanoseconds
+// into a negative time.Duration — time.After then fires immediately and the retry
+// loop busy-spins. Clamping to maxBackoff before any overflow can occur keeps
+// every slot strictly positive and bounded, so raising the attempt count widens
+// the total retry window without ever producing a negative, zero, or multi-day
+// sleep. Up to ±25% jitter is applied to avoid synchronized retry storms across
+// many agents. The same helper backs the auto-update retry schedule (see
+// agent.DefaultUpdateMaxRetryBackoff).
 func postbackRetryBackoff(base, maxBackoff time.Duration, attempt int) time.Duration {
 	if base <= 0 {
 		base = postbackBaseRetryBackoff
@@ -703,34 +700,8 @@ func postbackRetryBackoff(base, maxBackoff time.Duration, attempt int) time.Dura
 	if maxBackoff <= 0 {
 		maxBackoff = postbackMaxRetryBackoff
 	}
-	if base > maxBackoff {
-		base = maxBackoff
-	}
 
-	backoff := base
-	for i := 0; i < attempt-2; i++ {
-		// Stop before doubling would reach or overflow the cap. Because backoff
-		// never exceeds maxBackoff (a small, sane duration), base * 2^n can never
-		// overflow int64 nanoseconds into a negative value.
-		if backoff >= maxBackoff/2 {
-			backoff = maxBackoff
-			break
-		}
-		backoff *= 2
-	}
-	if backoff > maxBackoff {
-		backoff = maxBackoff
-	}
-
-	jitter := time.Duration(float64(backoff) * 0.25 * (2*rand.Float64() - 1))
-	backoff += jitter
-	if backoff > maxBackoff {
-		backoff = maxBackoff
-	}
-	if backoff <= 0 {
-		backoff = base
-	}
-	return backoff
+	return utils.JitteredBackoff(base, maxBackoff, attempt-2)
 }
 
 // sendPostbackWithRetry posts the command result to the Rewst engine, retrying

--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -417,6 +417,13 @@ func (r *AutoUpdateRunner) Start() {
 				if err := r.runUpdate(); err != nil {
 					r.logger.Error("Update failed, starting retry backoff", "error", err)
 					if r.retryWithBackoff() {
+						// A stop observed inside the backoff wait exits here rather
+						// than through the select above, so it is logged here too:
+						// otherwise the one path where a stop has to interrupt a
+						// pending wait - the path the bounded, jittered schedule
+						// exists for - would be the only one that leaves no record
+						// of the updater shutting down.
+						r.logger.Info("Auto updater stopped")
 						return
 					}
 				}

--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -50,7 +50,44 @@ const (
 	defaultUpdateInterval = 48 * time.Hour
 	defaultBaseBackoff    = 5 * time.Minute
 	defaultMaxRetries     = 5
+
+	// DefaultUpdateMaxRetryBackoff caps the exponential-backoff delay between
+	// auto-update retries regardless of how high the retry count is raised. The
+	// schedule doubles the base delay on every retry (base * 2^n); without a
+	// ceiling, the production base of 5 minutes reaches a 42-hour sleep by
+	// attempt 10 — longer than the update check interval the retries are nested
+	// inside — and a large injected maxRetries overflows the doubling into a
+	// negative time.Duration that makes time.After fire immediately and the retry
+	// loop busy-spin against the release endpoint. This mirrors
+	// DefaultPostbackMaxRetryBackoff and maxTimeout in the reconnect backoff
+	// generator (see internal/utils/time.go): the per-slot wait is bounded so the
+	// total retry window still widens with more retries, but no single sleep can
+	// overflow, outlive the check interval, or collapse into a tight loop.
+	DefaultUpdateMaxRetryBackoff = 1 * time.Hour
+
+	// updateBackoffIntervalDivisor bounds a single retry slot to this fraction of
+	// the update check interval, so the retry schedule always stays meaningfully
+	// nested inside the interval it belongs to rather than outliving it. It
+	// matters most for short intervals (integration builds shorten the interval
+	// via ldflags); at the production 48-hour interval the absolute
+	// DefaultUpdateMaxRetryBackoff ceiling is far lower and wins.
+	updateBackoffIntervalDivisor = 4
 )
+
+// updateMaxRetryBackoff returns the ceiling applied to every auto-update retry
+// slot for the given check interval: the lower of DefaultUpdateMaxRetryBackoff
+// and one updateBackoffIntervalDivisor-th of the interval. A non-positive
+// interval (no meaningful schedule to nest inside) yields the absolute ceiling.
+func updateMaxRetryBackoff(interval time.Duration) time.Duration {
+	maxBackoff := DefaultUpdateMaxRetryBackoff
+	if interval > 0 && interval/updateBackoffIntervalDivisor < maxBackoff {
+		maxBackoff = interval / updateBackoffIntervalDivisor
+	}
+	if maxBackoff <= 0 {
+		maxBackoff = DefaultUpdateMaxRetryBackoff
+	}
+	return maxBackoff
+}
 
 // DefaultUpdateInterval returns the auto-update check interval.
 // Uses updateIntervalStr if set via ldflags, otherwise defaults to 48 hours.
@@ -283,10 +320,13 @@ type AutoUpdateRunner struct {
 	interval    time.Duration
 	maxRetries  int
 	baseBackoff time.Duration
-	ctx         context.Context
-	cancel      context.CancelFunc
-	stop        chan struct{}
-	done        chan struct{}
+	// maxBackoff caps every retry slot; derived from the check interval at
+	// construction (see updateMaxRetryBackoff).
+	maxBackoff time.Duration
+	ctx        context.Context
+	cancel     context.CancelFunc
+	stop       chan struct{}
+	done       chan struct{}
 }
 
 func NewAutoUpdateRunner(
@@ -303,6 +343,7 @@ func NewAutoUpdateRunner(
 		interval:    interval,
 		maxRetries:  maxRetries,
 		baseBackoff: baseBackoff,
+		maxBackoff:  updateMaxRetryBackoff(interval),
 		ctx:         ctx,
 		cancel:      cancel,
 		stop:        make(chan struct{}),
@@ -361,9 +402,38 @@ func (r *AutoUpdateRunner) Stop() {
 	<-r.done
 }
 
+// retryBackoff returns the delay to wait before the given zero-based retry
+// attempt: the exponential schedule base * 2^attempt, clamped to the runner's
+// cap (see DefaultUpdateMaxRetryBackoff) and spread with up to ±25% jitter. The
+// result is always strictly positive and never exceeds the cap, for any attempt
+// number, so the wait can never fire immediately or outlive the check interval.
+func (r *AutoUpdateRunner) retryBackoff(attempt int) time.Duration {
+	base := r.baseBackoff
+	if base <= 0 {
+		base = defaultBaseBackoff
+	}
+	maxBackoff := r.maxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = updateMaxRetryBackoff(r.interval)
+	}
+
+	return utils.JitteredBackoff(base, maxBackoff, attempt)
+}
+
+// retryWithBackoff re-runs a failed update on an exponential schedule, returning
+// true when the runner was stopped mid-backoff so the caller exits its loop.
+//
+// Each slot is computed by utils.JitteredBackoff and is therefore bounded by
+// r.maxBackoff (see DefaultUpdateMaxRetryBackoff) and spread with up to ±25%
+// jitter. The bound keeps the doubling from overflowing into a negative duration
+// that would make the wait return immediately and busy-spin against the release
+// endpoint; the jitter keeps a whole fleet that failed against the same
+// unavailable or rate-limiting endpoint from retrying in lockstep and sustaining
+// the outage it is recovering from. The wait remains interruptible by r.stop, so
+// a service stop is never delayed by a long backoff.
 func (r *AutoUpdateRunner) retryWithBackoff() bool {
 	for attempt := range r.maxRetries {
-		backoff := r.baseBackoff * (1 << attempt)
+		backoff := r.retryBackoff(attempt)
 		r.logger.Info("Retrying update", "attempt", attempt+1, "backoff", backoff)
 
 		select {

--- a/internal/agent/updater.go
+++ b/internal/agent/updater.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/utils"
@@ -45,6 +47,19 @@ var baseBackoffStr = ""
 // maxRetriesStr is overridable via -ldflags for integration testing.
 // Example: -ldflags "-X github.com/RewstApp/agent-smith-go/internal/agent.maxRetriesStr=3"
 var maxRetriesStr = ""
+
+// releaseUrlOverrideFileStr names a file inside the org's data directory whose
+// contents replace the compiled-in release endpoint. It is overridable via
+// -ldflags for integration testing, which points the auto-updater at a local
+// stub release endpoint so the retry schedule can be observed against an
+// endpoint that fails on demand (sc-106110); a real GitHub outage is not
+// something CI can arrange.
+// Example: -ldflags "-X github.com/RewstApp/agent-smith-go/internal/agent.releaseUrlOverrideFileStr=release_url_override"
+//
+// Released builds leave it empty and then never look for the file at all, so the
+// update source of a shipped agent is fixed at build time and cannot be
+// redirected by dropping a file on an endpoint.
+var releaseUrlOverrideFileStr = ""
 
 const (
 	defaultUpdateInterval = 48 * time.Hour
@@ -121,6 +136,39 @@ func DefaultMaxRetries() int {
 		}
 	}
 	return defaultMaxRetries
+}
+
+// ResolveLatestReleaseUrl returns the endpoint the auto-updater should query for
+// the latest release: defaultUrl for released builds, and for an
+// integration-test build the URL named by releaseUrlOverrideFileStr when that
+// file exists in the org's data directory. A missing, unreadable, or empty
+// override file falls back to defaultUrl, so a fixture that failed to write it
+// leaves the agent updating normally rather than silently not updating at all.
+func ResolveLatestReleaseUrl(logger hclog.Logger, orgId string, defaultUrl string) string {
+	return resolveLatestReleaseUrl(logger, GetDataDirectory(orgId), defaultUrl)
+}
+
+func resolveLatestReleaseUrl(logger hclog.Logger, dataDir string, defaultUrl string) string {
+	if releaseUrlOverrideFileStr == "" {
+		return defaultUrl
+	}
+
+	path := filepath.Join(dataDir, releaseUrlOverrideFileStr)
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Warn("Failed to read release url override", "path", path, "error", err)
+		}
+		return defaultUrl
+	}
+
+	url := strings.TrimSpace(string(contents))
+	if url == "" {
+		return defaultUrl
+	}
+
+	logger.Info("Using release url override", "path", path, "url", url)
+	return url
 }
 
 type RunCommandFunc = func(path string, args []string) error

--- a/internal/agent/updater_backoff_test.go
+++ b/internal/agent/updater_backoff_test.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+// newBackoffTestRunner builds a runner wired for schedule inspection only; the
+// updater is never run.
+func newBackoffTestRunner(
+	interval time.Duration,
+	maxRetries int,
+	base time.Duration,
+) *AutoUpdateRunner {
+	return NewAutoUpdateRunner(hclog.NewNullLogger(), &mockUpdater{}, interval, maxRetries, base)
+}
+
+// TestUpdateMaxRetryBackoff_CapSelection verifies the ceiling is the lower of the
+// absolute DefaultUpdateMaxRetryBackoff and a quarter of the check interval, so
+// the retry schedule stays nested inside the interval it belongs to.
+func TestUpdateMaxRetryBackoff_CapSelection(t *testing.T) {
+	cases := []struct {
+		name     string
+		interval time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "production interval uses absolute cap",
+			interval: defaultUpdateInterval,
+			expected: DefaultUpdateMaxRetryBackoff,
+		},
+		{
+			name:     "short integration interval uses interval fraction",
+			interval: 30 * time.Second,
+			expected: 7500 * time.Millisecond,
+		},
+		{
+			name:     "interval just above cap boundary uses absolute cap",
+			interval: 8 * time.Hour,
+			expected: DefaultUpdateMaxRetryBackoff,
+		},
+		{
+			name:     "non-positive interval uses absolute cap",
+			interval: 0,
+			expected: DefaultUpdateMaxRetryBackoff,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := updateMaxRetryBackoff(c.interval); got != c.expected {
+				t.Fatalf("expected cap %v for interval %v, got %v", c.expected, c.interval, got)
+			}
+		})
+	}
+}
+
+// TestUpdateRetryBackoff_ProductionScheduleGrowsAndCaps verifies the production
+// schedule (base 5m, 48h interval) still doubles as before for the early
+// attempts and flattens at the documented 1h ceiling instead of growing to the
+// 42-hour sleep the uncapped shift produced by attempt 10. Jitter is bounded to
+// ±25%, so each slot is asserted within that band rather than exactly.
+func TestUpdateRetryBackoff_ProductionScheduleGrowsAndCaps(t *testing.T) {
+	runner := newBackoffTestRunner(defaultUpdateInterval, defaultMaxRetries, defaultBaseBackoff)
+
+	cases := []struct {
+		attempt  int
+		expected time.Duration // exponential base before jitter
+	}{
+		{attempt: 0, expected: 5 * time.Minute},
+		{attempt: 1, expected: 10 * time.Minute},
+		{attempt: 2, expected: 20 * time.Minute},
+		{attempt: 3, expected: 40 * time.Minute},
+		{attempt: 4, expected: DefaultUpdateMaxRetryBackoff},
+		{attempt: 10, expected: DefaultUpdateMaxRetryBackoff},
+	}
+
+	for _, c := range cases {
+		// Sample repeatedly so jitter variance is exercised.
+		for range 500 {
+			got := runner.retryBackoff(c.attempt)
+			low := time.Duration(float64(c.expected) * 0.75)
+			high := time.Duration(float64(c.expected) * 1.25)
+			if high > DefaultUpdateMaxRetryBackoff {
+				high = DefaultUpdateMaxRetryBackoff
+			}
+			if got < low || got > high {
+				t.Fatalf("attempt %d: backoff %v outside expected jittered band [%v, %v]",
+					c.attempt, got, low, high)
+			}
+		}
+	}
+}
+
+// TestUpdateRetryBackoff_AbsurdMaxRetriesStayPositiveAndCapped is the core
+// regression for the uncapped/overflowing backoff: across the full attempt range
+// of a deliberately absurd maxRetries — well past the point where
+// baseBackoff * (1 << attempt) overflows int64 nanoseconds into a negative
+// duration — every slot must stay strictly positive and within the cap, so
+// time.After can never fire immediately and the retry loop can never busy-spin.
+func TestUpdateRetryBackoff_AbsurdMaxRetriesStayPositiveAndCapped(t *testing.T) {
+	for _, maxRetries := range []int{64, 128, 1000} {
+		runner := newBackoffTestRunner(defaultUpdateInterval, maxRetries, defaultBaseBackoff)
+
+		for attempt := range runner.maxRetries {
+			got := runner.retryBackoff(attempt)
+			if got <= 0 {
+				t.Fatalf("maxRetries %d, attempt %d: backoff must be strictly positive, got %v",
+					maxRetries, attempt, got)
+			}
+			if got > runner.maxBackoff {
+				t.Fatalf("maxRetries %d, attempt %d: backoff %v exceeds cap %v",
+					maxRetries, attempt, got, runner.maxBackoff)
+			}
+		}
+	}
+
+	// Spot-check attempt numbers far beyond any configurable retry count.
+	runner := newBackoffTestRunner(defaultUpdateInterval, defaultMaxRetries, defaultBaseBackoff)
+	for _, attempt := range []int{63, 64, 100, 10000, 1 << 20} {
+		got := runner.retryBackoff(attempt)
+		if got <= 0 || got > runner.maxBackoff {
+			t.Fatalf(
+				"attempt %d: expected 0 < backoff <= %v, got %v",
+				attempt,
+				runner.maxBackoff,
+				got,
+			)
+		}
+	}
+}
+
+// TestUpdateRetryBackoff_ShortIntervalStaysWithinInterval verifies that the
+// retry budget of an agent built with the shortened integration ldflags still
+// fits inside its own check interval rather than outliving it.
+func TestUpdateRetryBackoff_ShortIntervalStaysWithinInterval(t *testing.T) {
+	interval := 30 * time.Second
+	runner := newBackoffTestRunner(interval, 5, time.Second)
+
+	var total time.Duration
+	for attempt := range runner.maxRetries {
+		got := runner.retryBackoff(attempt)
+		if got <= 0 || got > runner.maxBackoff {
+			t.Fatalf(
+				"attempt %d: expected 0 < backoff <= %v, got %v",
+				attempt,
+				runner.maxBackoff,
+				got,
+			)
+		}
+		total += got
+	}
+
+	if total > interval {
+		t.Fatalf("full retry budget %v outlives the check interval %v", total, interval)
+	}
+}
+
+// TestUpdateRetryBackoff_Desynchronizes demonstrates the fleet-wide effect the
+// jitter exists for: many independent computations of the same retry slot
+// produce a distribution of delays rather than one repeated value, so agents
+// that fail against the same endpoint at the same moment do not retry in
+// lockstep.
+func TestUpdateRetryBackoff_Desynchronizes(t *testing.T) {
+	runner := newBackoffTestRunner(defaultUpdateInterval, defaultMaxRetries, defaultBaseBackoff)
+
+	const samples = 1000
+	distinct := make(map[time.Duration]struct{}, samples)
+	for range samples {
+		distinct[runner.retryBackoff(2)] = struct{}{}
+	}
+
+	// The jitter is continuous, so near-total uniqueness is expected; assert a
+	// conservative floor that a fixed (or coarsely quantized) schedule fails.
+	if len(distinct) < samples/2 {
+		t.Fatalf("expected a spread of retry delays, got only %d distinct values across %d samples",
+			len(distinct), samples)
+	}
+}
+
+// TestUpdateRetryBackoff_NonPositiveInputsFallBackToDefaults verifies the guards
+// that keep a misconfigured base or cap from producing a zero or negative slot.
+func TestUpdateRetryBackoff_NonPositiveInputsFallBackToDefaults(t *testing.T) {
+	runner := newBackoffTestRunner(0, defaultMaxRetries, 0)
+	runner.maxBackoff = 0
+
+	for _, attempt := range []int{0, 5, 100} {
+		got := runner.retryBackoff(attempt)
+		if got <= 0 {
+			t.Fatalf(
+				"attempt %d: expected positive backoff with defaulted inputs, got %v",
+				attempt,
+				got,
+			)
+		}
+		if got > DefaultUpdateMaxRetryBackoff {
+			t.Fatalf("attempt %d: expected backoff within defaulted cap %v, got %v",
+				attempt, DefaultUpdateMaxRetryBackoff, got)
+		}
+	}
+}
+
+// TestUpdateRetryBackoff_BaseAboveCapClamped verifies that a base delay larger
+// than the cap (an ldflags build with a long base and a short interval) still
+// produces a bounded, positive slot.
+func TestUpdateRetryBackoff_BaseAboveCapClamped(t *testing.T) {
+	runner := newBackoffTestRunner(10*time.Second, 5, time.Hour)
+
+	for attempt := range runner.maxRetries {
+		got := runner.retryBackoff(attempt)
+		if got <= 0 || got > runner.maxBackoff {
+			t.Fatalf(
+				"attempt %d: expected 0 < backoff <= %v, got %v",
+				attempt,
+				runner.maxBackoff,
+				got,
+			)
+		}
+	}
+}

--- a/internal/agent/updater_backoff_test.go
+++ b/internal/agent/updater_backoff_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -220,3 +222,71 @@ func TestUpdateRetryBackoff_BaseAboveCapClamped(t *testing.T) {
 		}
 	}
 }
+
+// TestResolveLatestReleaseUrl_ReleasedBuildIgnoresOverrideFile pins the gate on
+// the override seam: with no ldflags injection (the released build) the file is
+// never consulted, so the update source of a shipped agent cannot be redirected
+// by dropping a file on an endpoint.
+func TestResolveLatestReleaseUrl_ReleasedBuildIgnoresOverrideFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "release_url_override"),
+		[]byte("http://127.0.0.1:8765/releases/latest"),
+		0o644,
+	); err != nil {
+		t.Fatalf("failed to seed override file: %v", err)
+	}
+
+	const defaultUrl = "https://api.github.com/repos/rewstapp/agent-smith-go/releases/latest"
+	got := resolveLatestReleaseUrl(hclog.NewNullLogger(), dir, defaultUrl)
+	if got != defaultUrl {
+		t.Fatalf("expected released build to keep %q, got %q", defaultUrl, got)
+	}
+}
+
+// TestResolveLatestReleaseUrl_IntegrationBuildReadsOverrideFile covers the
+// integration-test build: the override is honored when present, and every
+// degenerate case (missing, empty, whitespace-only) falls back to the compiled-in
+// endpoint so a fixture that failed to write the file leaves the agent updating
+// normally rather than silently not updating at all.
+func TestResolveLatestReleaseUrl_IntegrationBuildReadsOverrideFile(t *testing.T) {
+	const (
+		defaultUrl = "https://api.github.com/repos/rewstapp/agent-smith-go/releases/latest"
+		stubUrl    = "http://127.0.0.1:8765/releases/latest"
+	)
+
+	previous := releaseUrlOverrideFileStr
+	releaseUrlOverrideFileStr = "release_url_override"
+	t.Cleanup(func() { releaseUrlOverrideFileStr = previous })
+
+	cases := []struct {
+		name     string
+		contents *string
+		expected string
+	}{
+		{name: "missing file", contents: nil, expected: defaultUrl},
+		{name: "empty file", contents: ptr(""), expected: defaultUrl},
+		{name: "whitespace only", contents: ptr("  \n"), expected: defaultUrl},
+		{name: "url", contents: ptr(stubUrl), expected: stubUrl},
+		{name: "url with trailing newline", contents: ptr(stubUrl + "\n"), expected: stubUrl},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if c.contents != nil {
+				path := filepath.Join(dir, releaseUrlOverrideFileStr)
+				if err := os.WriteFile(path, []byte(*c.contents), 0o644); err != nil {
+					t.Fatalf("failed to write override file: %v", err)
+				}
+			}
+
+			got := resolveLatestReleaseUrl(hclog.NewNullLogger(), dir, defaultUrl)
+			if got != c.expected {
+				t.Fatalf("expected %q, got %q", c.expected, got)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/agent/updater_backoff_test.go
+++ b/internal/agent/updater_backoff_test.go
@@ -1,11 +1,15 @@
 package agent
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/RewstApp/agent-smith-go/internal/utils"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -290,3 +294,68 @@ func TestResolveLatestReleaseUrl_IntegrationBuildReadsOverrideFile(t *testing.T)
 }
 
 func ptr(s string) *string { return &s }
+
+// TestAutoUpdateRunner_LogsStopDuringBackoff pins the record left behind when a
+// stop lands while the runner is waiting out a retry backoff. That wait is the
+// one place a stop has to interrupt a pending sleep, so an exit with no log line
+// leaves the path the bounded, jittered schedule exists for unobservable - and
+// the integration workflow reads exactly this line to prove the stop was prompt.
+func TestAutoUpdateRunner_LogsStopDuringBackoff(t *testing.T) {
+	var buf bytes.Buffer
+	logger := utils.ConfigureLogger("test", &buf, utils.Info)
+	mock := &mockUpdater{runErr: fmt.Errorf("release endpoint unavailable")}
+
+	// A tick almost immediately, then a backoff long enough that only the stop
+	// can end it. The cap is raised past the interval-derived default for the
+	// same reason.
+	runner := NewAutoUpdateRunner(logger, mock, time.Millisecond, 5, time.Hour)
+	runner.maxBackoff = time.Hour
+
+	runner.Start()
+
+	// Wait until the runner is actually inside the backoff wait, so the stop
+	// cannot be observed by the outer select instead.
+	deadline := time.Now().Add(5 * time.Second)
+	for !strings.Contains(buf.String(), "Retrying update") {
+		if time.Now().After(deadline) {
+			t.Fatal("runner never entered a retry backoff")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		runner.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return promptly during a backoff wait")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Auto updater stopped") {
+		t.Fatalf("expected a stop to be logged from the backoff wait, got %q", output)
+	}
+	if strings.Count(output, "Auto updater stopped") != 1 {
+		t.Fatalf("expected the stop to be logged exactly once, got %q", output)
+	}
+}
+
+// TestAutoUpdateRunner_LogsStopWhileIdle covers the other exit: a stop observed
+// by the run loop's own select, between checks.
+func TestAutoUpdateRunner_LogsStopWhileIdle(t *testing.T) {
+	var buf bytes.Buffer
+	logger := utils.ConfigureLogger("test", &buf, utils.Info)
+
+	runner := NewAutoUpdateRunner(logger, &mockUpdater{}, time.Hour, 3, time.Millisecond)
+	runner.Start()
+	runner.Stop()
+
+	output := buf.String()
+	if strings.Count(output, "Auto updater stopped") != 1 {
+		t.Fatalf("expected the stop to be logged exactly once, got %q", output)
+	}
+}

--- a/internal/agent/updater_test.go
+++ b/internal/agent/updater_test.go
@@ -543,8 +543,11 @@ func TestAutoUpdateRunner_StopDuringBackoff(t *testing.T) {
 		runErr: fmt.Errorf("fails"),
 	}
 
-	// Use a long backoff so we can stop during it
+	// Use a long backoff so we can stop during it. The cap is normally derived
+	// from the (short) check interval, so raise it here to keep the retry slot
+	// long enough that the stop, not the timer, is what ends the wait.
 	runner := NewAutoUpdateRunner(logger, mock, 10*time.Millisecond, 5, time.Hour)
+	runner.maxBackoff = time.Hour
 
 	done := make(chan struct{})
 	go func() {

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -188,12 +188,18 @@ const MinJitteredBackoff time.Duration = time.Second
 // count widens the total retry window without ever producing a negative, zero,
 // or multi-day sleep.
 //
-// The jitter mirrors ReconnectTimeoutGenerator.Next: without it every agent in a
-// fleet that fails against the same endpoint at the same time retries on an
-// identical, perfectly synchronized cadence, and the fleet sustains the outage
-// or rate limit it is trying to recover from. It is applied after clamping and
-// the result is clamped again, so a jittered slot never exceeds maxBackoff and
-// never collapses to zero or negative.
+// The jitter exists because without it every agent in a fleet that fails against
+// the same endpoint at the same time retries on an identical, perfectly
+// synchronized cadence, and the fleet sustains the outage or rate limit it is
+// trying to recover from. It is applied after clamping, and a jittered slot that
+// would exceed maxBackoff is reflected back under the ceiling rather than
+// clamped to it: clamping looks harmless but collapses half of every capped slot
+// onto exactly maxBackoff, so once a schedule reaches its ceiling — which is
+// where a sustained outage puts the whole fleet — around half of all agents fire
+// at the same instant again. Reflecting keeps the result strictly below the
+// ceiling and spread across the band beneath it, and it can never reach zero or
+// go negative because the jitter is at most a quarter of a value that is itself
+// at most maxBackoff.
 //
 // Degenerate inputs are tolerated rather than propagated: a non-positive base
 // falls back to MinJitteredBackoff, a non-positive maxBackoff disables the
@@ -228,7 +234,11 @@ func JitteredBackoff(base, maxBackoff time.Duration, step int) time.Duration {
 	jitter := time.Duration(float64(backoff) * 0.25 * (2*rand.Float64() - 1))
 	backoff += jitter
 	if backoff > maxBackoff {
-		backoff = maxBackoff
+		// Reflected, not clamped: see the doc comment. backoff was at most
+		// maxBackoff before the jitter and the jitter is at most a quarter of it,
+		// so the reflection lands in [0.75*maxBackoff, maxBackoff] and stays
+		// strictly positive.
+		backoff = 2*maxBackoff - backoff
 	}
 	if backoff <= 0 {
 		backoff = base

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -168,6 +168,74 @@ func SasTokenRenewMargin(lifetime time.Duration) time.Duration {
 	return margin
 }
 
+// MinJitteredBackoff is the floor substituted for a non-positive base delay in
+// JitteredBackoff. Callers are expected to normalize their own configuration
+// defaults before calling; this exists only so a mis-set knob can never make the
+// helper return a zero or negative delay that would turn a retry loop into a
+// busy-spin.
+const MinJitteredBackoff time.Duration = time.Second
+
+// JitteredBackoff returns the delay to wait before the retry at the given
+// zero-based step of an exponential schedule (base, 2*base, 4*base, ...),
+// clamped to maxBackoff and spread with up to ±25% jitter.
+//
+// The doubling is performed by iterated multiplication with an early exit at
+// maxBackoff rather than the naive base * (1 << step) shift. That shift grows
+// without bound and, for a large caller-configured retry count, overflows int64
+// nanoseconds into a negative time.Duration — time.After then fires immediately
+// and the retry loop busy-spins. Clamping to maxBackoff before any doubling can
+// overflow keeps every slot strictly positive and bounded, so raising the retry
+// count widens the total retry window without ever producing a negative, zero,
+// or multi-day sleep.
+//
+// The jitter mirrors ReconnectTimeoutGenerator.Next: without it every agent in a
+// fleet that fails against the same endpoint at the same time retries on an
+// identical, perfectly synchronized cadence, and the fleet sustains the outage
+// or rate limit it is trying to recover from. It is applied after clamping and
+// the result is clamped again, so a jittered slot never exceeds maxBackoff and
+// never collapses to zero or negative.
+//
+// Degenerate inputs are tolerated rather than propagated: a non-positive base
+// falls back to MinJitteredBackoff, a non-positive maxBackoff disables the
+// ceiling (it becomes the base), and a base above the ceiling is clamped down to
+// it so the cap always wins.
+func JitteredBackoff(base, maxBackoff time.Duration, step int) time.Duration {
+	if base <= 0 {
+		base = MinJitteredBackoff
+	}
+	if maxBackoff <= 0 {
+		maxBackoff = base
+	}
+	if base > maxBackoff {
+		base = maxBackoff
+	}
+
+	backoff := base
+	for range step {
+		// Stop before doubling would reach or overflow the cap. Because backoff
+		// never exceeds maxBackoff (a small, sane duration), base * 2^n can never
+		// overflow int64 nanoseconds into a negative value.
+		if backoff >= maxBackoff/2 {
+			backoff = maxBackoff
+			break
+		}
+		backoff *= 2
+	}
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+
+	jitter := time.Duration(float64(backoff) * 0.25 * (2*rand.Float64() - 1))
+	backoff += jitter
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	if backoff <= 0 {
+		backoff = base
+	}
+	return backoff
+}
+
 type ReconnectTimeoutGenerator struct {
 	base    time.Duration
 	timeout time.Duration

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -124,6 +124,134 @@ func TestSasTokenRenewMargin(t *testing.T) {
 	}
 }
 
+// TestJitteredBackoffSchedule verifies the exponential schedule doubles per step
+// and flattens at the cap. Jitter is bounded to ±25%, so each slot is asserted
+// within that band rather than exactly.
+func TestJitteredBackoffSchedule(t *testing.T) {
+	base := time.Second
+	maxBackoff := 8 * time.Second
+
+	cases := []struct {
+		step   int
+		expect time.Duration // exponential base before jitter
+	}{
+		{step: 0, expect: 1 * time.Second},
+		{step: 1, expect: 2 * time.Second},
+		{step: 2, expect: 4 * time.Second},
+		{step: 3, expect: 8 * time.Second},
+		{step: 4, expect: 8 * time.Second},
+	}
+
+	for _, c := range cases {
+		for range 500 {
+			got := JitteredBackoff(base, maxBackoff, c.step)
+			low := time.Duration(float64(c.expect) * 0.75)
+			high := time.Duration(float64(c.expect) * 1.25)
+			if high > maxBackoff {
+				high = maxBackoff
+			}
+			if got < low || got > high {
+				t.Fatalf("step %d: backoff %v outside expected jittered band [%v, %v]",
+					c.step, got, low, high)
+			}
+		}
+	}
+}
+
+// TestJitteredBackoffStaysPositiveAndCapped is the overflow regression: for step
+// numbers well past the point where base * (1 << step) wraps int64 nanoseconds
+// negative, the result must remain strictly positive and within the cap.
+func TestJitteredBackoffStaysPositiveAndCapped(t *testing.T) {
+	base := 5 * time.Minute
+	maxBackoff := time.Hour
+
+	for _, step := range []int{0, 10, 33, 63, 64, 128, 10000, 1 << 20} {
+		for range 100 {
+			got := JitteredBackoff(base, maxBackoff, step)
+			if got <= 0 {
+				t.Fatalf("step %d: backoff must be strictly positive, got %v", step, got)
+			}
+			if got > maxBackoff {
+				t.Fatalf("step %d: backoff %v exceeds cap %v", step, got, maxBackoff)
+			}
+		}
+	}
+}
+
+// TestJitteredBackoffDegenerateInputs verifies the guards for a non-positive
+// base, a non-positive cap, a base above the cap, and a negative step.
+func TestJitteredBackoffDegenerateInputs(t *testing.T) {
+	cases := []struct {
+		name       string
+		base       time.Duration
+		maxBackoff time.Duration
+		step       int
+		maxAllowed time.Duration
+	}{
+		{name: "zero base", base: 0, maxBackoff: time.Minute, step: 5, maxAllowed: time.Minute},
+		{
+			name:       "negative base",
+			base:       -time.Second,
+			maxBackoff: time.Minute,
+			step:       3,
+			maxAllowed: time.Minute,
+		},
+		{
+			name:       "zero cap",
+			base:       2 * time.Second,
+			maxBackoff: 0,
+			step:       4,
+			maxAllowed: 2 * time.Second,
+		},
+		{
+			name:       "base above cap",
+			base:       time.Hour,
+			maxBackoff: time.Second,
+			step:       6,
+			maxAllowed: time.Second,
+		},
+		// A negative step is treated as step 0, so the slot is the base plus at
+		// most the +25% jitter.
+		{
+			name:       "negative step",
+			base:       2 * time.Second,
+			maxBackoff: time.Minute,
+			step:       -3,
+			maxAllowed: 2500 * time.Millisecond,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for range 200 {
+				got := JitteredBackoff(c.base, c.maxBackoff, c.step)
+				if got <= 0 {
+					t.Fatalf("expected strictly positive backoff, got %v", got)
+				}
+				if got > c.maxAllowed {
+					t.Fatalf("expected backoff within %v, got %v", c.maxAllowed, got)
+				}
+			}
+		})
+	}
+}
+
+// TestJitteredBackoffDesynchronizes demonstrates why the jitter exists: repeated
+// computations of the same slot spread out instead of returning one repeated
+// value, so a fleet retrying against the same endpoint does not synchronize.
+func TestJitteredBackoffDesynchronizes(t *testing.T) {
+	const samples = 1000
+	distinct := make(map[time.Duration]struct{}, samples)
+	for range samples {
+		distinct[JitteredBackoff(time.Second, time.Minute, 3)] = struct{}{}
+	}
+
+	if len(distinct) < samples/2 {
+		t.Fatalf("expected a spread of delays, got only %d distinct values across %d samples",
+			len(distinct), samples)
+	}
+}
+
 func TestReconnectTimeoutGeneratorJitterDiffers(t *testing.T) {
 	// Two independent generators must produce different sequences
 	g1 := ReconnectTimeoutGenerator{}

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -270,3 +270,58 @@ func TestReconnectTimeoutGeneratorJitterDiffers(t *testing.T) {
 		t.Error("expected two independent generators to produce different jittered sequences")
 	}
 }
+
+// TestJitteredBackoffSpreadsAtTheCap is the regression for jitter that was
+// clamped to the ceiling instead of reflected under it. Clamping put roughly
+// half of every capped draw on exactly maxBackoff, so a fleet whose schedules
+// had all reached the ceiling - which is where a sustained outage puts it - fired
+// half its retries at the same instant, the very synchronization the jitter is
+// there to break up. It was caught by the integration scenario, whose two capped
+// slots landed on exactly the cap on two of three platforms.
+func TestJitteredBackoffSpreadsAtTheCap(t *testing.T) {
+	base := time.Second
+	maxBackoff := 8 * time.Second
+
+	const samples = 1000
+	atCap := 0
+	distinct := make(map[time.Duration]struct{}, samples)
+	minSeen := maxBackoff
+
+	for range samples {
+		// A step well past the point where the schedule reaches the ceiling.
+		got := JitteredBackoff(base, maxBackoff, 10)
+		if got <= 0 || got > maxBackoff {
+			t.Fatalf("expected 0 < backoff <= %v, got %v", maxBackoff, got)
+		}
+		if got == maxBackoff {
+			atCap++
+		}
+		if got < minSeen {
+			minSeen = got
+		}
+		distinct[got] = struct{}{}
+	}
+
+	// The clamped implementation this replaces scored ~500 here.
+	if atCap > samples/100 {
+		t.Fatalf(
+			"%d of %d capped slots landed on exactly %v; the jitter is clamped to the cap rather than spread under it",
+			atCap,
+			samples,
+			maxBackoff,
+		)
+	}
+	if len(distinct) < samples/2 {
+		t.Fatalf("expected capped slots to spread, got only %d distinct values across %d samples",
+			len(distinct), samples)
+	}
+	// The spread should reach into the band below the ceiling rather than
+	// hovering against it.
+	if minSeen > time.Duration(float64(maxBackoff)*0.9) {
+		t.Fatalf(
+			"capped slots never dropped meaningfully below the cap (smallest %v of %v)",
+			minSeen,
+			maxBackoff,
+		)
+	}
+}

--- a/scripts/build_integration_test.ps1
+++ b/scripts/build_integration_test.ps1
@@ -16,17 +16,28 @@
 #   process to actually exit before its files are replaced or deleted, so a
 #   process that never exits is given up on in seconds instead of the production
 #   two minutes)
+# - baseBackoffStr overridden to 2s and maxRetriesStr to 6, so a full update
+#   retry sequence runs in well under a minute. With the 30s check interval the
+#   retry cap is a quarter of it (7.5s), so the schedule doubles 2s, 4s, then
+#   flattens at the cap - both halves of the sc-106110 fix are observable in one
+#   sequence
+# - releaseUrlOverrideFileStr overridden to release_url_override, which lets the
+#   integration harness point the auto-updater at a local stub release endpoint
+#   (see .github/actions/set-release-url) so the retry schedule can be driven by
+#   an endpoint that fails on demand. Released builds leave this empty and never
+#   look for the file, so their update source stays fixed at build time
 
 $env:GOARCH = "amd64"
 
 $versionFlag = "-X github.com/RewstApp/agent-smith-go/internal/version.Version=v0.0.0-it"
 $intervalFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.updateIntervalStr=30s"
-$baseBackoffFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.baseBackoffStr=10s"
+$baseBackoffFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.baseBackoffStr=2s"
 $maxRetriesFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.maxRetriesStr=6"
 $sasTokenLifetimeFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.sasTokenLifetimeOverrideStr=90s"
 $stopTimeoutFlag = "-X github.com/RewstApp/agent-smith-go/internal/service.stopTimeoutOverrideStr=25s"
 $exitTimeoutFlag = "-X main.exitTimeoutOverrideStr=25s"
-$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag $stopTimeoutFlag $exitTimeoutFlag"
+$releaseUrlOverrideFlag = "-X github.com/RewstApp/agent-smith-go/internal/agent.releaseUrlOverrideFileStr=release_url_override"
+$ldflags = "-w -s $versionFlag $intervalFlag $baseBackoffFlag $maxRetriesFlag $sasTokenLifetimeFlag $stopTimeoutFlag $exitTimeoutFlag $releaseUrlOverrideFlag"
 
 if ($IsWindows) {
     $buildOutput = "./dist/rewst_agent_config.win.it.exe"

--- a/test/stubrelease/main.go
+++ b/test/stubrelease/main.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+// Command stubrelease is a deliberately minimal stand-in for the GitHub releases
+// API, used by the integration test suite to drive the auto-update retry path
+// that sc-106110 capped and jittered: a release endpoint that fails on demand,
+// so the agent enters retryWithBackoff and its schedule can be observed, and
+// then recovers on demand so a retry can be seen succeeding.
+//
+// A real GitHub outage or rate-limit response is not something CI can arrange,
+// and pointing the agent at an unroutable address produces connection errors
+// rather than the HTTP failure the ticket describes. The stub answers on
+// loopback over plain HTTP - no TLS, so unlike the stub broker it needs no CA in
+// the host trust store - and the agent is pointed at it through the
+// release-url override file the integration build honors (see
+// agent.ResolveLatestReleaseUrl).
+//
+// Whether a request is failed or served is read from -mode-file on every
+// request, so the harness can flip the endpoint mid-retry-sequence without
+// restarting it. The default (and the behavior with a missing mode file) is to
+// fail, so a harness that forgets to set a mode reproduces the failing endpoint
+// the scenario is built around rather than silently passing.
+//
+// Every request is logged with a millisecond timestamp and the mode it was
+// answered in, so the log doubles as the arrival-time record the scenario uses
+// to show that retries arrive spread out rather than back to back.
+//
+// The release payload it serves carries -tag as tag_name and no assets. The
+// scenario sets -tag to the running agent's own version, so a successful check
+// ends at "No updates available" and the retry is seen succeeding without the
+// agent downloading and executing anything - the recovery is what is under test,
+// not the installer.
+//
+// It sits behind the `integration` build tag so it stays out of
+// `go test ./...`: as an untested CI fixture its statements would otherwise
+// count against the repository coverage threshold. It is still linted, because
+// the tag is listed in .golangci.yml. Build it with
+// `go build -tags integration ./test/stubrelease`.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// modeOk is the -mode-file content that makes the endpoint serve a release
+// payload. Any other content (including a missing file) fails the request with
+// the status below.
+const modeOk = "ok"
+
+// failStatus is what a request is failed with. 503 is what an unavailable
+// releases API returns and is the status the ticket's reproduction uses; the
+// agent treats any non-200 identically, so this stands in for a rate-limit
+// response as well.
+const failStatus = http.StatusServiceUnavailable
+
+// readTimeout and writeTimeout bound a single request so a stuck client cannot
+// pin the fixture for the rest of the job.
+const (
+	readTimeout  = 10 * time.Second
+	writeTimeout = 10 * time.Second
+)
+
+func main() {
+	listen := flag.String("listen", "127.0.0.1:8765", "address to listen on")
+	modeFile := flag.String(
+		"mode-file",
+		"",
+		fmt.Sprintf("path to a file containing %q to serve a release payload; "+
+			"any other content (or a missing file) fails the request with %d",
+			modeOk, failStatus),
+	)
+	tag := flag.String(
+		"tag",
+		"v0.0.0-it",
+		"tag_name to report in the release payload; set to the running agent's "+
+			"own version so a successful check ends at \"No updates available\"",
+	)
+	logPath := flag.String("log", "", "path to write this endpoint's log to (defaults to stderr)")
+	flag.Parse()
+
+	// Redirected here rather than by the launching shell for the same reason the
+	// stub broker does it: on Windows the fixture has to be launched detached
+	// from the step that starts it, and a detached launch has nowhere to attach a
+	// redirect. Set up first so a startup failure - a port already in use, say -
+	// lands in the file the harness reports.
+	if *logPath != "" {
+		logFile, err := os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open log file %s: %v\n", *logPath, err)
+			os.Exit(1)
+		}
+		defer func() { _ = logFile.Close() }()
+		log.SetOutput(logFile)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		handle(w, r, *modeFile, *tag)
+	})
+
+	server := &http.Server{
+		Addr:         *listen,
+		Handler:      mux,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+	}
+
+	log.Printf(
+		"stub release endpoint listening on %s (mode file %q, tag %q)",
+		*listen,
+		*modeFile,
+		*tag,
+	)
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("failed to serve on %s: %v", *listen, err)
+	}
+}
+
+// handle answers a single request according to the current mode, logging the
+// arrival time either way. The mode is read per request so the harness can
+// recover the endpoint in the middle of a retry sequence.
+func handle(w http.ResponseWriter, r *http.Request, modeFile string, tag string) {
+	ok := currentModeIsOk(modeFile)
+	// Millisecond precision, because the point of the log is the spacing between
+	// arrivals: a busy-spinning retry loop would show requests in the same
+	// millisecond, and a jittered schedule shows unequal gaps.
+	arrived := time.Now().Format("2006-01-02T15:04:05.000Z07:00")
+
+	if !ok {
+		log.Printf("%s %s %s -> %d (mode=fail)", arrived, r.Method, r.URL.Path, failStatus)
+		w.WriteHeader(failStatus)
+		return
+	}
+
+	release := map[string]any{
+		"id":       1,
+		"tag_name": tag,
+		"assets":   []any{},
+	}
+	body, err := json.Marshal(release)
+	if err != nil {
+		// Unreachable for this fixed payload, but failing loudly beats serving a
+		// truncated body the agent would report as a parse error.
+		log.Printf("%s failed to marshal release payload: %v", arrived, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("%s %s %s -> 200 (mode=ok, tag=%s)", arrived, r.Method, r.URL.Path, tag)
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(body); err != nil {
+		log.Printf("%s failed to write release payload: %v", arrived, err)
+	}
+}
+
+// currentModeIsOk reports whether the mode file currently asks for a served
+// release. A missing or unreadable file means fail, so the fixture's default is
+// the failing endpoint the scenario needs.
+func currentModeIsOk(modeFile string) bool {
+	if modeFile == "" {
+		return false
+	}
+	contents, err := os.ReadFile(modeFile)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(string(contents)), modeOk)
+}


### PR DESCRIPTION
## Problem

The auto-update retry delay was `r.baseBackoff * (1 << attempt)` — no ceiling, no jitter.

Unjittered, every agent that fails against the release endpoint at the same moment retries at exactly `base`, `2*base`, `4*base`, so a GitHub API outage or rate-limit response is sustained by the fleet trying to recover from it, and endpoints stay on old versions — missing fixes we have already shipped — far longer than the outage lasted.

Uncapped, the production 5 minute base reaches a 42 hour sleep by attempt 10, longer than the 48 hour check interval the retries are nested inside, and because `maxRetries` is injectable a large value overflows the shift into a negative `time.Duration`: `time.After` fires immediately and the loop issues HTTP requests as fast as it can.

This is the defect class already fixed for postback retries in sc-103965; the update path never got the same treatment.

## Changes

**Cap and jitter (f580066).** Extracted the postback fix's schedule math into `utils.JitteredBackoff` rather than duplicating it, and pointed both retry paths at it. The doubling is iterated multiplication with an early exit at the cap, so no intermediate value can overflow; jitter of up to ±25% spreads each slot. The update cap is the lower of a documented `DefaultUpdateMaxRetryBackoff` (1 hour) and a quarter of the check interval, so the retry budget always stays nested inside the interval it belongs to. The production schedule is unchanged where it matters — 5m, 10m, 20m, 40m — and then flattens at an hour. `postbackRetryBackoff` keeps its own defaults and is otherwise unchanged.

**Integration coverage (9cd12bc).** A scenario on all three platforms drives the retry loop against `test/stubrelease`, a stub release endpoint that fails and recovers on demand. Reaching it needs a build-time-gated seam: `releaseUrlOverrideFileStr` is injected only into the integration binary; released builds leave it empty and never look for the override file, so a shipped agent's update source stays fixed at build time.

The scenario found two further defects, both fixed here:

**Silent stop (15a1db0).** The stop *was* prompt — honored 276ms into a 2.17s backoff on Linux — but nothing was logged. `Start()` logged `Auto updater stopped` only when its own select saw the stop; a stop observed inside the backoff wait returned through `retryWithBackoff` and exited silently, so the one path where a stop must interrupt a pending sleep was the only one leaving no record.

**Jitter collapsing at the cap (b62503d).** Jitter was applied and then *clamped* to `maxBackoff`, so roughly half of every capped slot landed on exactly the ceiling. That is this ticket's synchronization surviving where it matters most: a sustained outage walks the whole fleet up to the ceiling and holds it there, and from then on about half of it retries at the same instant. A jittered value above the ceiling is now reflected back under it (`2*max - value`), which lands in `[0.75*max, max]` and stays strictly positive. The postback schedule shares the helper and benefits too.

## Verification

Unit tests assert every slot is strictly positive and capped across the full attempt range for absurd `maxRetries` (64/128/1000, plus spot checks past `1<<20`), that repeated draws of one slot produce a distribution rather than a repeated value, that capped draws do not pile onto the ceiling (fails above 1% of 1000 samples; the clamped implementation scored ~500), that a short-interval build's whole budget fits inside its interval, and that both stop paths log exactly once.

Integration test run: https://github.com/RewstApp/agent-smith-go/actions/runs/31653559872 — all 13 jobs green. Observed schedules against a 503 endpoint, cap 7.5s (a quarter of the integration build's 30s interval):

| Platform | attempt 1 | 2 | 3 | 4 | recovery | stop mid-backoff |
|---|---|---|---|---|---|---|
| ubuntu-latest | 2.134s | 3.480s | 6.380s | 7.179s | succeeded on retry | 0.1s |
| windows-latest | 1.842s | 4.493s | 7.408s | 7.012s | succeeded on retry | 0.6s |
| macos-latest | 2.441s | 3.816s | 7.148s | 6.110s | succeeded on retry | 0.1s |

Every slot bounded by the cap, four distinct values per run, never served back to back, and the schedule recovered on a retry when the endpoint started serving a valid payload mid-sequence.

## Follow-up

`ReconnectTimeoutGenerator.Next` has its own copy of the clamp and the same pile-up at its ceiling. Left alone to keep this change scoped to the update and postback paths; worth its own ticket.