### PR TITLE
fix: [sc-108850] Bound notification plugin Notify RPC calls with a timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Required tools:
 
 Agent Smith uses a plugin architecture for extensible notifications. Plugins are separate executables that implement the `Notifier` interface via RPC. The system supports loading multiple plugins simultaneously and sends status notifications (AgentStarted, AgentStatus:Online, AgentStatus:Offline, etc.) to all loaded plugins.
 
-Loaded plugins are supervised: a subprocess that exits or crashes is detected (by a periodic health check and on the notification path) and relaunched with backoff, and delivery failures increment counters and are logged once per failure transition. See the README's "Notification Plugin Supervision" section.
+Loaded plugins are supervised: a subprocess that exits or crashes is detected (by a periodic health check and on the notification path) and relaunched with backoff, and delivery failures increment counters and are logged once per failure transition. See the README's "Notification Plugin Supervision" section. The crash-only health check cannot see a plugin that is still alive but has deadlocked internally, so every `Notify` RPC call (`shared.NotifierRPC.Notify`) is additionally bounded by `shared.NotifyTimeout` (10s): a call that never returns is abandoned rather than blocking the calling worker forever, counted separately from other notify failures (`NotifierStats.NotifyTimeouts`) so a hang is distinguishable from a crash, and the still-alive subprocess is killed and relaunched on the existing backoff schedule. See the README's "Bounded Notification Plugin RPC Calls" section.
 
 ### Message Processing Flow
 

--- a/README.md
+++ b/README.md
@@ -721,6 +721,37 @@ Loaded plugins are therefore supervised for the lifetime of the service:
 
 Deployments with no plugins configured are unaffected — no supervision runs.
 
+### Bounded Notification Plugin RPC Calls
+
+The health check above only detects a subprocess that has actually **exited** —
+it reads an in-process exit flag and performs no RPC. A plugin whose process is
+still alive but has deadlocked internally (blocked on a channel that's never
+signaled, stuck on a downstream call) is invisible to it, and the `Notify` RPC
+call itself used to have no deadline: `net/rpc`'s `Call` blocks until a response
+arrives, however long that takes. Since every message and status transition
+calls `Notify` on every loaded plugin, one plugin hanging without crashing could
+silently exhaust the whole worker pool over time — command execution stalling
+fleet-wide with MQTT connectivity still looking perfectly healthy, and no error
+anywhere pointing at the cause.
+
+Every `Notify` call is now bounded by a **10 second** timeout, matching the
+deadline pattern already used for MQTT operations:
+
+- A call that does not return within the timeout is abandoned and treated as a
+  plugin failure — counted and logged once per failure transition, exactly like
+  a crash — rather than blocking the calling worker any longer.
+- The failure is tracked in its own counter, separate from other notify
+  failures, so a hang is observable as distinct from a crash or a plugin-
+  returned error in both the logs and the `Plugin notification health summary`.
+- Because the subprocess is still alive at this point, dropping the handle also
+  **kills it** (the same teardown `Kill` uses), so the next `Notify` or health
+  check relaunches a fresh subprocess on the existing backoff schedule instead
+  of repeatedly timing out against a permanently wedged process.
+
+The timeout is a fixed constant rather than a device config knob: unlike the
+MQTT timeouts, it bounds RPC to a subprocess the host itself launched on the
+same machine, not a network endpoint an operator might need to tune.
+
 ## Build
 Required tools and packages:
 

--- a/cmd/agent_smith/service.go
+++ b/cmd/agent_smith/service.go
@@ -239,6 +239,7 @@ func (svc *serviceContext) Execute(
 			logger.Warn(
 				"Plugin notification health summary",
 				"notify_failures", stats.NotifyFailures,
+				"notify_timeouts", stats.NotifyTimeouts,
 				"plugin_restarts", stats.Restarts,
 				"restart_failures", stats.RestartFailures,
 			)

--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -54,9 +54,14 @@ var pluginMap = map[string]plugin.Plugin{
 // nothing has gone wrong.
 type NotifierStats struct {
 	// NotifyFailures counts notifications that could not be delivered to a
-	// plugin, whether because the RPC call failed or because no subprocess was
-	// running at the time.
+	// plugin, whether because the RPC call failed, because it timed out, or
+	// because no subprocess was running at the time.
 	NotifyFailures int64
+	// NotifyTimeouts counts, of NotifyFailures, how many were a plugin accepting
+	// a Notify call and never responding within shared.NotifyTimeout (hung, not
+	// crashed) rather than an error the plugin returned or a broken RPC channel.
+	// Tracked separately so a hang is observable as distinct from a crash.
+	NotifyTimeouts int64
 	// Restarts counts plugin subprocesses successfully relaunched after an exit.
 	Restarts int64
 	// RestartFailures counts relaunch attempts that themselves failed.
@@ -113,6 +118,7 @@ type optionalNotifierWrapper struct {
 	failing bool
 
 	notifyFailures  atomic.Int64
+	notifyTimeouts  atomic.Int64
 	restarts        atomic.Int64
 	restartFailures atomic.Int64
 }
@@ -196,12 +202,20 @@ func (p *optionalNotifierWrapper) Notify(message string) error {
 		return nil
 	}
 
-	// A broken RPC channel means the subprocess is gone or unusable, so drop the
-	// handle and let the next attempt relaunch it. An error the plugin itself
-	// returned is a plugin-side failure: it is counted and logged, but the
-	// subprocess is working and must be left alone.
-	if isTransportError(err) {
+	timedOut := errors.Is(err, shared.ErrNotifyTimeout)
+
+	// A broken RPC channel means the subprocess is gone; a call that never
+	// returned within shared.NotifyTimeout means it is alive but hung. Either way
+	// the handle is unusable, so drop it and let the next attempt relaunch —
+	// dropLocked kills a still-alive hung subprocess rather than leaving it to
+	// wedge every future call. An error the plugin itself returned is a
+	// plugin-side failure: it is counted and logged, but the subprocess is
+	// working and must be left alone.
+	if timedOut || isTransportError(err) {
 		p.mu.Lock()
+		if timedOut {
+			p.notifyTimeouts.Add(1)
+		}
 		// Only discard the handle this call actually used; a concurrent Notify or
 		// health check may already have relaunched the plugin.
 		if p.client == client {
@@ -227,6 +241,7 @@ func (p *optionalNotifierWrapper) CheckHealth() {
 func (p *optionalNotifierWrapper) Stats() NotifierStats {
 	return NotifierStats{
 		NotifyFailures:  p.notifyFailures.Load(),
+		NotifyTimeouts:  p.notifyTimeouts.Load(),
 		Restarts:        p.restarts.Load(),
 		RestartFailures: p.restartFailures.Load(),
 	}
@@ -244,8 +259,10 @@ func (p *optionalNotifierWrapper) restartable() bool {
 //
 // This detects a subprocess that exits or crashes, which is the failure mode
 // that silently killed notification delivery. A plugin whose process is alive
-// but wedged is not detectable this way; it surfaces instead as a failing Notify
-// (counted and logged), which then drops the handle for relaunch.
+// but wedged is not detectable this way; it surfaces instead as a Notify call
+// that times out (see shared.NotifyTimeout), which is counted, logged, and
+// drops the handle for relaunch exactly like a transport error — dropLocked
+// kills the still-alive process rather than leaving it running and unusable.
 func (p *optionalNotifierWrapper) deadLocked() bool {
 	if !p.restartable() {
 		return false
@@ -416,6 +433,7 @@ func (s *notifierSetWrapper) Stats() NotifierStats {
 	for _, notifier := range s.notifiers {
 		pluginStats := notifier.Stats()
 		stats.NotifyFailures += pluginStats.NotifyFailures
+		stats.NotifyTimeouts += pluginStats.NotifyTimeouts
 		stats.Restarts += pluginStats.Restarts
 		stats.RestartFailures += pluginStats.RestartFailures
 	}

--- a/plugins/loader_test.go
+++ b/plugins/loader_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/RewstApp/agent-smith-go/internal/agent"
+	"github.com/RewstApp/agent-smith-go/shared"
 	"github.com/hashicorp/go-hclog"
 )
 
@@ -590,6 +591,78 @@ func TestOptionalNotifierWrapper_Notify_PluginErrorKeepsHandle(t *testing.T) {
 	}
 }
 
+// TestOptionalNotifierWrapper_Notify_TimeoutDropsHandleAndCounts verifies a
+// Notify call that times out (the "hung, not exited" case the crash-only health
+// check cannot see) is treated like a broken transport: the handle is dropped so
+// the next attempt relaunches the subprocess, and the timeout is counted both as
+// a general failure and, distinctly, as a timeout.
+func TestOptionalNotifierWrapper_Notify_TimeoutDropsHandleAndCounts(t *testing.T) {
+	mock := &mockNotifier{notifyErr: shared.ErrNotifyTimeout}
+	wrapper := &optionalNotifierWrapper{plugin: mock, name: "test"}
+
+	if err := wrapper.Notify("hello"); !errors.Is(err, shared.ErrNotifyTimeout) {
+		t.Fatalf("expected ErrNotifyTimeout, got %v", err)
+	}
+
+	if wrapper.plugin != nil {
+		t.Error("expected the plugin handle to be dropped after a timeout")
+	}
+
+	stats := wrapper.Stats()
+	if stats.NotifyFailures != 1 {
+		t.Errorf("expected 1 notify failure, got %d", stats.NotifyFailures)
+	}
+	if stats.NotifyTimeouts != 1 {
+		t.Errorf("expected 1 notify timeout, got %d", stats.NotifyTimeouts)
+	}
+}
+
+// TestOptionalNotifierWrapper_Notify_TimeoutLoggedDistinctlyFromCrash verifies a
+// timeout and a crash produce distinguishable failure log lines and counters, so
+// QA and on-call can tell the two failure modes apart.
+func TestOptionalNotifierWrapper_Notify_TimeoutLoggedDistinctlyFromCrash(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	mock := &mockNotifier{notifyErr: shared.ErrNotifyTimeout}
+	wrapper := &optionalNotifierWrapper{
+		plugin: mock,
+		name:   "test",
+		logger: newBufferedLogger(logBuf),
+	}
+
+	if err := wrapper.Notify("hello"); err == nil {
+		t.Fatal("expected the timeout to be returned")
+	}
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "RPC call timed out") {
+		t.Errorf("expected the timeout error text in the failure log, got %q", logged)
+	}
+
+	stats := wrapper.Stats()
+	if stats.NotifyFailures != 1 || stats.NotifyTimeouts != 1 {
+		t.Errorf(
+			"expected NotifyFailures=1 and NotifyTimeouts=1 for a timeout, got %+v",
+			stats,
+		)
+	}
+
+	// A crash (transport error) is counted as a general failure but must not move
+	// the timeout-specific counter.
+	mock.notifyErr = rpc.ErrShutdown
+	wrapper.plugin = mock
+	if err := wrapper.Notify("hello"); err == nil {
+		t.Fatal("expected the crash to be returned")
+	}
+
+	stats = wrapper.Stats()
+	if stats.NotifyFailures != 2 {
+		t.Errorf("expected NotifyFailures=2 after a second failure, got %d", stats.NotifyFailures)
+	}
+	if stats.NotifyTimeouts != 1 {
+		t.Errorf("expected NotifyTimeouts to stay at 1 after a non-timeout failure, got %d", stats.NotifyTimeouts)
+	}
+}
+
 // TestOptionalNotifierWrapper_Notify_LogsOncePerFailureTransition verifies the
 // counter increments on every failure while the log stays quiet until the plugin
 // recovers, so a persistently broken plugin cannot flood the agent log.
@@ -976,6 +1049,61 @@ func TestLoadNotifer_NotifyRestartsCrashedPlugin(t *testing.T) {
 			"expected the notification to be delivered by the relaunched plugin, got %v",
 			deliveredNotifications(t, notifyLog),
 		)
+	}
+}
+
+// TestLoadNotifer_NotifyRecoversFromHungPlugin is the end-to-end regression test
+// for the "hung, not exited" failure mode: a real plugin subprocess that accepts
+// the Notify call and then blocks forever without exiting must not block the
+// calling worker past shared.NotifyTimeout, and the still-alive subprocess must
+// be killed and relaunched rather than left running and permanently wedged —
+// which is exactly what the existing crash-only health check could not detect.
+func TestLoadNotifer_NotifyRecoversFromHungPlugin(t *testing.T) {
+	original := shared.NotifyTimeout
+	shared.NotifyTimeout = 200 * time.Millisecond
+	defer func() { shared.NotifyTimeout = original }()
+
+	wrapper, _, notifyLog := loadTestNotifier(t)
+
+	start := time.Now()
+	err := wrapper.Notify("HANG_FOREVER")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, shared.ErrNotifyTimeout) {
+		t.Fatalf("expected ErrNotifyTimeout from a hung plugin, got %v", err)
+	}
+	// Bounded by NotifyTimeout plus go-plugin's own 2s graceful-kill grace period;
+	// 5x that margin comfortably rules out "actually blocked forever".
+	if elapsed > 5*time.Second {
+		t.Errorf("Notify was not bounded by the timeout: took %v", elapsed)
+	}
+
+	if got := wrapper.Stats().NotifyTimeouts; got != 1 {
+		t.Errorf("expected 1 notify timeout counted, got %d", got)
+	}
+
+	// The hung subprocess was killed as part of dropping the handle; the next
+	// Notify must relaunch it and resume delivery rather than calling a dead
+	// client forever.
+	if err := wrapper.Notify("AgentStatus:Online"); err != nil {
+		t.Fatalf("expected the relaunched plugin to deliver, got %v", err)
+	}
+
+	if got := wrapper.Stats().Restarts; got != 1 {
+		t.Errorf("expected the hung plugin to be restarted once, got %d", got)
+	}
+
+	delivered := waitFor(t, 5*time.Second, func() bool {
+		return len(deliveredNotifications(t, notifyLog)) == 1
+	})
+	if !delivered {
+		t.Fatalf(
+			"expected the notification to be delivered by the relaunched plugin, got %v",
+			deliveredNotifications(t, notifyLog),
+		)
+	}
+	if got := deliveredNotifications(t, notifyLog); len(got) != 1 || got[0] != "AgentStatus:Online" {
+		t.Errorf("expected [AgentStatus:Online] delivered, got %v", got)
 	}
 }
 

--- a/plugins/loader_test.go
+++ b/plugins/loader_test.go
@@ -659,7 +659,10 @@ func TestOptionalNotifierWrapper_Notify_TimeoutLoggedDistinctlyFromCrash(t *test
 		t.Errorf("expected NotifyFailures=2 after a second failure, got %d", stats.NotifyFailures)
 	}
 	if stats.NotifyTimeouts != 1 {
-		t.Errorf("expected NotifyTimeouts to stay at 1 after a non-timeout failure, got %d", stats.NotifyTimeouts)
+		t.Errorf(
+			"expected NotifyTimeouts to stay at 1 after a non-timeout failure, got %d",
+			stats.NotifyTimeouts,
+		)
 	}
 }
 
@@ -1102,7 +1105,11 @@ func TestLoadNotifer_NotifyRecoversFromHungPlugin(t *testing.T) {
 			deliveredNotifications(t, notifyLog),
 		)
 	}
-	if got := deliveredNotifications(t, notifyLog); len(got) != 1 || got[0] != "AgentStatus:Online" {
+	if got := deliveredNotifications(
+		t,
+		notifyLog,
+	); len(got) != 1 ||
+		got[0] != "AgentStatus:Online" {
 		t.Errorf("expected [AgentStatus:Online] delivered, got %v", got)
 	}
 }

--- a/plugins/testdata/notifier_plugin/main.go
+++ b/plugins/testdata/notifier_plugin/main.go
@@ -2,7 +2,9 @@
 // to exercise real subprocess crash and restart handling. Every notification it
 // receives is appended to the file named by the AGENT_SMITH_TEST_NOTIFY_LOG
 // environment variable, so a test can assert that delivery survives the plugin
-// process being killed and relaunched.
+// process being killed and relaunched. A message equal to hangMessage instead
+// blocks forever without exiting, modeling a plugin that deadlocks internally,
+// so a test can exercise the RPC timeout / "hung, not exited" recovery path.
 //
 // It lives under testdata so it is skipped by ./... build and vet patterns; the
 // test builds it explicitly by path.
@@ -20,11 +22,20 @@ import (
 // the environment because the host launches plugins with a fixed argument list.
 const notifyLogEnvVar = "AGENT_SMITH_TEST_NOTIFY_LOG"
 
+// hangMessage is the sentinel message that makes Notify block forever instead of
+// returning. Tests exercising the hang path must send exactly this string; it is
+// duplicated (not imported) in the test file since it lives in package main.
+const hangMessage = "HANG_FOREVER"
+
 type fileNotifier struct {
 	path string
 }
 
 func (n *fileNotifier) Notify(message string) error {
+	if message == hangMessage {
+		select {} // block forever without exiting, never reaching the file write
+	}
+
 	file, err := os.OpenFile(n.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err

--- a/shared/notifier.go
+++ b/shared/notifier.go
@@ -104,10 +104,17 @@ func (c *NotifierRPC) Notify(message string) error {
 
 	call := c.client.Go("Plugin.Notify", args, &reply, make(chan *rpc.Call, 1))
 
+	// Notify fires on every message and status transition, so on the common fast
+	// path (call.Done wins) the timer must be stopped rather than left to fire
+	// (and be garbage collected) up to timeout later; time.After would leak a
+	// live runtime timer per call until then.
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case <-call.Done:
 		return call.Error
-	case <-time.After(timeout):
+	case <-timer.C:
 		return ErrNotifyTimeout
 	}
 }

--- a/shared/notifier.go
+++ b/shared/notifier.go
@@ -1,10 +1,46 @@
 package shared
 
 import (
+	"errors"
 	"net/rpc"
+	"time"
 
 	"github.com/hashicorp/go-plugin"
 )
+
+// NotifyTimeout bounds how long the host waits for a single Notify RPC call to
+// a plugin subprocess to return.
+//
+// net/rpc's Call blocks until a response arrives, with no deadline of its own.
+// A plugin that accepts the call and then hangs internally — deadlocks on a
+// channel, blocks forever on a downstream call — without exiting the process
+// previously blocked the calling worker forever. That failure mode is invisible
+// to the health check, which only detects a subprocess that has actually
+// exited: the process is still alive, so nothing notices it. Because Notify
+// fires on every message and status transition, this could silently exhaust
+// the whole worker pool over time.
+//
+// Notify is a purely local subprocess round trip carrying a short string — no
+// network I/O — so it normally completes in microseconds. 10s is generous
+// slack for a plugin doing brief synchronous work in its Notify handler
+// (writing to disk, a quick local API call) while still recovering a truly
+// hung plugin in bounded time.
+//
+// It is a var rather than a const solely so tests can shrink it to exercise
+// the timeout path without a real multi-second wait; production code never
+// modifies it, and it is deliberately not exposed as a device config knob —
+// unlike the MQTT timeouts, it bounds host-internal RPC to a subprocess the
+// host itself launched, not a network endpoint an operator might need to tune.
+var NotifyTimeout = 10 * time.Second
+
+// ErrNotifyTimeout is returned by NotifierRPC.Notify when a plugin subprocess
+// does not respond to a Notify call within NotifyTimeout. It is distinct from
+// an error the plugin itself returned (net/rpc wraps those in rpc.ServerError)
+// and from a broken transport (rpc.ErrShutdown, io.EOF): the process is still
+// alive, it simply never answered. Callers that relaunch on a broken transport
+// should treat this the same way, since a plugin that hangs once is liable to
+// hang again.
+var ErrNotifyTimeout = errors.New("notification plugin: RPC call timed out waiting for response")
 
 // Notifier is the interface exposed to the host.
 type Notifier interface {
@@ -29,7 +65,7 @@ func (p *NotifierPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
 }
 
 func (p *NotifierPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
-	return &NotifierRPC{client: c}, nil
+	return &NotifierRPC{client: c, timeout: NotifyTimeout}, nil
 }
 
 // Server-side implementation of the RPC
@@ -44,10 +80,34 @@ func (s *NotifierRPCServer) Notify(args NotifyArgs, reply *EmptyReply) error {
 // Client-side proxy
 type NotifierRPC struct {
 	client *rpc.Client
+
+	// timeout bounds a single Notify call; zero falls back to NotifyTimeout. It
+	// exists as a per-instance field (rather than always reading the package var
+	// directly) so a value captured at dispense time cannot change mid-call.
+	timeout time.Duration
 }
 
+// Notify makes the RPC call asynchronously via client.Go rather than the
+// blocking client.Call so it can race the response against NotifyTimeout: a
+// plugin that accepts the call and never replies must not block the caller
+// forever. The done channel is buffered (required by client.Go) so an
+// abandoned call's late reply, if the plugin ever answers, does not block or
+// leak the goroutine that eventually delivers it.
 func (c *NotifierRPC) Notify(message string) error {
 	args := NotifyArgs{Message: message}
 	var reply EmptyReply // not used
-	return c.client.Call("Plugin.Notify", args, &reply)
+
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = NotifyTimeout
+	}
+
+	call := c.client.Go("Plugin.Notify", args, &reply, make(chan *rpc.Call, 1))
+
+	select {
+	case <-call.Done:
+		return call.Error
+	case <-time.After(timeout):
+		return ErrNotifyTimeout
+	}
 }

--- a/shared/notifier_test.go
+++ b/shared/notifier_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/rpc"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-plugin"
 )
@@ -259,6 +260,105 @@ func TestNotifierRPC_Notify_Integration_Error(t *testing.T) {
 
 	if err.Error() != expectedErr.Error() {
 		t.Errorf("expected error %q, got %q", expectedErr.Error(), err.Error())
+	}
+}
+
+// hangingNotifier accepts a Notify call and blocks until unblock is closed,
+// modeling a plugin that deadlocks internally without exiting the process.
+type hangingNotifier struct {
+	called  chan struct{}
+	unblock chan struct{}
+}
+
+func newHangingNotifier() *hangingNotifier {
+	return &hangingNotifier{called: make(chan struct{}), unblock: make(chan struct{})}
+}
+
+func (n *hangingNotifier) Notify(message string) error {
+	close(n.called)
+	<-n.unblock
+	return nil
+}
+
+// rpcPipe wires an RPC server for impl to a client over an in-memory pipe, for
+// tests that need a real net/rpc round trip rather than calling Go methods
+// directly.
+func rpcPipe(t *testing.T, impl Notifier) *rpc.Client {
+	t.Helper()
+
+	server := rpc.NewServer()
+	if err := server.RegisterName("Plugin", &NotifierRPCServer{Impl: impl}); err != nil {
+		t.Fatalf("failed to register RPC server: %v", err)
+	}
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = serverConn.Close() })
+	go server.ServeConn(serverConn)
+
+	client := rpc.NewClient(clientConn)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+// TestNotifierRPC_Notify_TimesOutOnHungPlugin verifies a plugin that accepts the
+// call and then hangs (without exiting) does not block the caller past the
+// configured timeout, and that the caller gets back ErrNotifyTimeout rather than
+// hanging forever. This is the regression test for the "hung, not crashed"
+// failure mode the health check cannot see.
+func TestNotifierRPC_Notify_TimesOutOnHungPlugin(t *testing.T) {
+	impl := newHangingNotifier()
+	defer close(impl.unblock) // release the still-blocked server goroutine on test exit
+
+	notifier := &NotifierRPC{client: rpcPipe(t, impl), timeout: 50 * time.Millisecond}
+
+	start := time.Now()
+	err := notifier.Notify("hello")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrNotifyTimeout) {
+		t.Fatalf("expected ErrNotifyTimeout, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Notify was not bounded by the timeout: took %v", elapsed)
+	}
+
+	select {
+	case <-impl.called:
+	default:
+		t.Fatal("expected the plugin's Notify to have actually been invoked")
+	}
+}
+
+// TestNotifierRPC_Notify_FastCallUnaffectedByTimeout verifies a well-behaved
+// plugin under typical latency is not disturbed by the new bounded wait.
+func TestNotifierRPC_Notify_FastCallUnaffectedByTimeout(t *testing.T) {
+	mockImpl := &mockNotifier{}
+	notifier := &NotifierRPC{client: rpcPipe(t, mockImpl), timeout: time.Second}
+
+	if err := notifier.Notify("hello"); err != nil {
+		t.Fatalf("expected no error for a fast-responding plugin, got %v", err)
+	}
+	if !mockImpl.notifyCalled {
+		t.Error("expected Notify to reach the plugin implementation")
+	}
+}
+
+// TestNotifierRPC_Notify_ZeroTimeoutFallsBackToDefault confirms an unset timeout
+// field (the zero value, as produced by NotifierPlugin.Client before this test
+// package overrides it) still bounds the call rather than blocking forever.
+func TestNotifierRPC_Notify_ZeroTimeoutFallsBackToDefault(t *testing.T) {
+	original := NotifyTimeout
+	NotifyTimeout = 50 * time.Millisecond
+	defer func() { NotifyTimeout = original }()
+
+	impl := newHangingNotifier()
+	defer close(impl.unblock)
+
+	notifier := &NotifierRPC{client: rpcPipe(t, impl)}
+
+	if err := notifier.Notify("hello"); !errors.Is(err, ErrNotifyTimeout) {
+		t.Fatalf("expected ErrNotifyTimeout, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Notify` RPC calls to notification plugins now race against a 10s timeout (`shared.NotifyTimeout`) instead of blocking on `net/rpc`'s undeadlined `Call`, so a plugin that hangs internally (without exiting) can no longer stall a worker forever — a failure mode invisible to the existing exit-only health check.
- A timed-out call is treated as a plugin failure: counted (`NotifierStats.NotifyTimeouts`, distinct from other `NotifyFailures`), logged once per failure transition consistent with crash handling, and drops the handle so the still-alive hung subprocess is killed and relaunched on the existing supervised-restart/backoff schedule.
- Documented in the README ("Bounded Notification Plugin RPC Calls") and CLAUDE.md.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] New real-RPC test (`shared`) proves a hung plugin's `Notify` returns `ErrNotifyTimeout` within the timeout rather than blocking
- [x] New real-subprocess test (`plugins`) launches an actual plugin binary that blocks forever on `Notify`, confirms the caller is unblocked, the counter is incremented, the subprocess is killed, and it is relaunched with delivery resuming
- [x] New unit tests confirm a timeout drops the handle/counts distinctly from a crash, and a well-behaved plugin under typical latency is unaffected
- [ ] Manual QA per the ticket: load a deliberately-hanging test plugin against a running agent and verify workers recover; verify well-behaved plugins are unaffected; verify failure logging/counters distinguish timeout from crash

Integration test workflow (`.github/workflows/integration-test.yml`) was checked but left unchanged — it has no existing notification-plugin infrastructure (no plugin build/deploy step or device config wiring) to extend; adding one would be new infra out of scope for this fix.